### PR TITLE
`execute_static` flag added in Cfg

### DIFF
--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -301,6 +301,9 @@ pub struct CfgEnv {
     /// If some it will effects EIP-170: Contract code size limit. Useful to increase this because of tests.
     /// By default it is 0x6000 (~25kb).
     pub limit_contract_code_size: Option<usize>,
+    /// Whether `interpreter.is_static` should be set to true before execution begins.
+    /// This is useful for enforcing static-only calls to Seismic endpoints like `call`.
+    pub execute_static: bool,
     /// A hard memory limit in bytes beyond which [crate::result::OutOfGasError::Memory] cannot be resized.
     ///
     /// In cases where the gas limit may be extraordinarily high, it is recommended to set this to
@@ -418,6 +421,7 @@ impl Default for CfgEnv {
             limit_contract_code_size: None,
             #[cfg(any(feature = "c-kzg", feature = "kzg-rs"))]
             kzg_settings: crate::kzg::EnvKzgSettings::Default,
+            execute_static: false,
             #[cfg(feature = "memory_limit")]
             memory_limit: (1 << 32) - 1,
             #[cfg(feature = "optional_balance_check")]

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -89,6 +89,9 @@ impl<'a, EXT, DB: Database> Evm<'a, EXT, DB> {
         // Peek the last stack frame.
         let mut stack_frame = call_stack.last_mut().unwrap();
 
+        // Set interpreter to enforce static-only.
+        stack_frame.interpreter_mut().is_static = self.cfg().execute_static;
+
         loop {
             // Execute the frame.
             let next_action =


### PR DESCRIPTION
Used for enforcing static-only calls to Seismic endpoints like `call`.