### PR TITLE
Rng integration

### DIFF
--- a/crates/optimism/src/precompiles.rs
+++ b/crates/optimism/src/precompiles.rs
@@ -7,9 +7,9 @@ use revm::{
     interpreter::InterpreterResult,
     precompile::{
         self, bn128, secp256r1, PrecompileError, Precompiles,
-        {PrecompileResult, PrecompileWithAddress},
+        PrecompileResult,
     },
-    primitives::{Address, Bytes},
+    primitives::Bytes,
 };
 use std::boxed::Box;
 use std::string::String;

--- a/crates/seismic/src/api/builder.rs
+++ b/crates/seismic/src/api/builder.rs
@@ -1,16 +1,18 @@
-use crate::{RngContainer, SeismicEvm, SeismicSpecId};
+use crate::{transaction::abstraction::SeismicTxTr, RngContainer, SeismicEvm, SeismicSpecId};
 use revm::{
-    context::{Cfg, ContextTr, JournalOutput},
-    context_interface::{Block, JournalTr, Transaction},
+    context::{Cfg, JournalOutput},
+    context_interface::{Block, JournalTr},
     handler::instructions::EthInstructions,
     interpreter::interpreter::EthInterpreter,
     Context, Database,
 };
 
+use super::exec::SeismicContextTr;
+
 /// Trait that allows for SeismicEvm to be built.
 pub trait SeismicBuilder: Sized {
     /// Type of the context.
-    type Context: ContextTr;
+    type Context: SeismicContextTr;
 
     /// Build the op.
     fn build_seismic(self) -> SeismicEvm<Self::Context, (), EthInstructions<EthInterpreter, Self::Context>>;
@@ -25,7 +27,7 @@ pub trait SeismicBuilder: Sized {
 impl<BLOCK, TX, CFG, DB, JOURNAL> SeismicBuilder for Context<BLOCK, TX, CFG, DB, JOURNAL, RngContainer>
 where
     BLOCK: Block,
-    TX: Transaction,
+    TX: SeismicTxTr,
     CFG: Cfg<Spec = SeismicSpecId>,
     DB: Database,
     JOURNAL: JournalTr<Database = DB, FinalOutput = JournalOutput>,

--- a/crates/seismic/src/api/builder.rs
+++ b/crates/seismic/src/api/builder.rs
@@ -1,4 +1,4 @@
-use crate::{SeismicEvm, SeismicSpecId};
+use crate::{RngContainer, SeismicEvm, SeismicSpecId};
 use revm::{
     context::{Cfg, ContextTr, JournalOutput},
     context_interface::{Block, JournalTr, Transaction},
@@ -22,7 +22,7 @@ pub trait SeismicBuilder: Sized {
     ) -> SeismicEvm<Self::Context, INSP, EthInstructions<EthInterpreter, Self::Context>>;
 }
 
-impl<BLOCK, TX, CFG, DB, JOURNAL> SeismicBuilder for Context<BLOCK, TX, CFG, DB, JOURNAL>
+impl<BLOCK, TX, CFG, DB, JOURNAL> SeismicBuilder for Context<BLOCK, TX, CFG, DB, JOURNAL, RngContainer>
 where
     BLOCK: Block,
     TX: Transaction,

--- a/crates/seismic/src/api/default_ctx.rs
+++ b/crates/seismic/src/api/default_ctx.rs
@@ -1,13 +1,13 @@
-use crate::{transaction::abstraction::SeismicTransaction, SeismicSpecId};
+use crate::{transaction::abstraction::SeismicTransaction, RngContainer, SeismicSpecId};
 use revm::{
     context::{BlockEnv, CfgEnv, TxEnv},
     database_interface::EmptyDB,
     Context, Journal, MainContext 
 };
 
-/// Type alias for the default context type of the OpEvm.
+/// Type alias for the default context type of the SeismicEvm.
 pub type SeismicContext<DB> =
-    Context<BlockEnv, SeismicTransaction<TxEnv>, CfgEnv<SeismicSpecId>, DB, Journal<DB>>;
+    Context<BlockEnv, SeismicTransaction<TxEnv>, CfgEnv<SeismicSpecId>, DB, Journal<DB>, RngContainer>;
 
 /// Trait that allows for a default context to be created.
 pub trait DefaultSeismic {
@@ -20,6 +20,7 @@ impl DefaultSeismic for SeismicContext<EmptyDB> {
         Context::mainnet()
             .with_tx(SeismicTransaction::default())
             .with_cfg(CfgEnv::new_with_spec(SeismicSpecId::MERCURY))
+            .with_chain(RngContainer::default())
     }
 }
 

--- a/crates/seismic/src/api/exec.rs
+++ b/crates/seismic/src/api/exec.rs
@@ -19,6 +19,7 @@ pub trait SeismicContextTr:
     Journal: JournalTr<FinalOutput = JournalOutput>,
     Tx: SeismicTxTr,
     Cfg: Cfg<Spec = SeismicSpecId>,
+    //Could do with higher level of abstraction, but until it's warranted, this will work.
     Chain= RngContainer
     >
 {

--- a/crates/seismic/src/api/exec.rs
+++ b/crates/seismic/src/api/exec.rs
@@ -2,7 +2,7 @@ use crate::{
     evm::SeismicEvm, handler::SeismicHandler, transaction::abstraction::SeismicTxTr, RngContainer, SeismicSpecId
 };
 use revm::{
-    context::{result::{HaltReason, InvalidTransaction}, ContextSetters, JournalOutput, Transaction},
+    context::{result::{HaltReason, InvalidTransaction}, ContextSetters, JournalOutput},
     context_interface::{
         result::{EVMError, ExecutionResult, ResultAndState},
         Cfg, ContextTr, Database, JournalTr,

--- a/crates/seismic/src/api/exec.rs
+++ b/crates/seismic/src/api/exec.rs
@@ -1,5 +1,5 @@
 use crate::{
-    evm::SeismicEvm, handler::SeismicHandler, SeismicSpecId
+    evm::SeismicEvm, handler::SeismicHandler, transaction::abstraction::SeismicTxTr, RngContainer, SeismicSpecId
 };
 use revm::{
     context::{result::{HaltReason, InvalidTransaction}, ContextSetters, JournalOutput, Transaction},
@@ -17,16 +17,19 @@ use revm::{
 pub trait SeismicContextTr:
     ContextTr<
     Journal: JournalTr<FinalOutput = JournalOutput>,
-    Tx: Transaction,
-    Cfg: Cfg<Spec = SeismicSpecId>>
+    Tx: SeismicTxTr,
+    Cfg: Cfg<Spec = SeismicSpecId>,
+    Chain= RngContainer
+    >
 {
 }
 
 impl<T> SeismicContextTr for T where
     T: ContextTr<
         Journal: JournalTr<FinalOutput = JournalOutput>,
-        Tx: Transaction,
-        Cfg: Cfg<Spec = SeismicSpecId>
+        Tx: SeismicTxTr,
+        Cfg: Cfg<Spec = SeismicSpecId>,
+        Chain= RngContainer
     >
 {
 }

--- a/crates/seismic/src/evm.rs
+++ b/crates/seismic/src/evm.rs
@@ -1,7 +1,6 @@
-use crate::precompiles::SeismicPrecompiles;
+use crate::{api::exec::SeismicContextTr, precompiles::SeismicPrecompiles};
 use revm::{
     context::{ContextSetters, Evm, EvmData},
-    context_interface::ContextTr,
     handler::{
         instructions::{EthInstructions, InstructionProvider},
         EvmTr,
@@ -15,7 +14,7 @@ pub struct SeismicEvm<CTX, INSP, I = EthInstructions<EthInterpreter, CTX>, P = S
     pub Evm<CTX, INSP, I, P>,
 );
 
-impl<CTX: ContextTr, INSP> SeismicEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, SeismicPrecompiles<CTX>> {
+impl<CTX: SeismicContextTr, INSP> SeismicEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, SeismicPrecompiles<CTX>> {
     pub fn new(ctx: CTX, inspector: INSP) -> Self {
         Self(Evm {
             data: EvmData { ctx, inspector },
@@ -27,7 +26,7 @@ impl<CTX: ContextTr, INSP> SeismicEvm<CTX, INSP, EthInstructions<EthInterpreter,
 
 impl<CTX, INSP, I, P> InspectorEvmTr for SeismicEvm<CTX, INSP, I, P>
 where
-    CTX: ContextTr<Journal: JournalExt> + ContextSetters,
+    CTX: SeismicContextTr<Journal: JournalExt> + ContextSetters,
     I: InstructionProvider<
         Context = CTX,
         InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,
@@ -57,7 +56,7 @@ where
 
 impl<CTX, INSP, I, P> EvmTr for SeismicEvm<CTX, INSP, I, P>
 where
-    CTX: ContextTr,
+    CTX: SeismicContextTr,
     I: InstructionProvider<
         Context = CTX,
         InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,

--- a/crates/seismic/src/handler.rs
+++ b/crates/seismic/src/handler.rs
@@ -1,9 +1,9 @@
 //!Handler related to Seismic chain
 use crate::api::exec::SeismicContextTr;
 use revm::{
-    context::result::{HaltReason, InvalidTransaction}, context_interface::{
-        result::{EVMError, FromStringError, ResultAndState}, JournalTr,
-    }, handler::{
+    context::result::{HaltReason, InvalidTransaction}, context_interface::
+        result::{EVMError, FromStringError, ResultAndState},
+    handler::{
         handler::EvmTrError, EvmTr, Frame, FrameResult,
         Handler, MainnetHandler,
     }, inspector::{Inspector, InspectorEvmTr, InspectorFrame, InspectorHandler}, interpreter::{interpreter::EthInterpreter, FrameInput}

--- a/crates/seismic/src/lib.rs
+++ b/crates/seismic/src/lib.rs
@@ -6,16 +6,18 @@
 extern crate alloc as std;
 
 pub mod api;
+pub mod evm;
 pub mod handler;
 pub mod precompiles;
+pub mod rng_container;
 pub mod transaction;
 pub mod spec;
-pub mod evm;
 
-pub use spec::*;
 pub use api::{
     builder::SeismicBuilder,
     default_ctx::{DefaultSeismic, SeismicContext},
 };
-
 pub use evm::SeismicEvm;
+pub use rng_container::RngContainer;
+pub use spec::*;
+

--- a/crates/seismic/src/precompiles.rs
+++ b/crates/seismic/src/precompiles.rs
@@ -20,17 +20,15 @@
 pub mod aes;
 pub mod ecdh_derive_sym_key;
 pub mod hkdf_derive_sym_key;
-//pub mod rng;
 pub mod secp256k1_sign;
 pub mod rng;
 pub mod stateful_precompile;
 pub use stateful_precompile::StatefulPrecompiles;
 
-use crate::SeismicSpecId;
+use crate::{api::exec::SeismicContextTr, SeismicSpecId};
 use once_cell::race::OnceBox;
 use revm::{
     context::Cfg,
-    context_interface::ContextTr,
     handler::{EthPrecompiles, PrecompileProvider},
     interpreter::{Gas, InstructionResult, InterpreterResult},
     precompile::{
@@ -42,12 +40,12 @@ use std::boxed::Box;
 use std::string::String;
 
 #[derive(Debug, Clone)]
-pub struct SeismicPrecompiles<CTX: ContextTr> {
+pub struct SeismicPrecompiles<CTX: SeismicContextTr> {
     inner: EthPrecompiles,
     stateful_precompiles: StatefulPrecompiles<CTX>,
 }
 
-impl <CTX: ContextTr> SeismicPrecompiles<CTX> {
+impl <CTX: SeismicContextTr> SeismicPrecompiles<CTX> {
     /// Create a new [`SeismicPrecompiles`] with the given precompiles.
     pub fn new(precompiles: (&'static Precompiles, StatefulPrecompiles<CTX>)) -> Self {
         Self {
@@ -66,7 +64,7 @@ impl <CTX: ContextTr> SeismicPrecompiles<CTX> {
 }
 
 /// Returns precompiles for MERCURY spec.
-pub fn mercury<CTX: ContextTr>() -> (&'static Precompiles, StatefulPrecompiles<CTX>) {
+pub fn mercury<CTX: SeismicContextTr>() -> (&'static Precompiles, StatefulPrecompiles<CTX>) {
     // Store only the stateless precompiles in the static OnceBox
     static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
     
@@ -84,14 +82,14 @@ pub fn mercury<CTX: ContextTr>() -> (&'static Precompiles, StatefulPrecompiles<C
     });
     
     //TODO: check how expensive is the below instead of a single init! issue with generics
-    let stateful_precompiles = StatefulPrecompiles::new();
-    //stateful_precompiles.extend(rng::precompiles::<CTX>().map(|p| (p.0, p.1)));
+    let mut stateful_precompiles = StatefulPrecompiles::new();
+    stateful_precompiles.extend(rng::precompile::rng_precompile_iter::<CTX>().map(|p| (p.0, p.1)));
     (regular_precompiles, stateful_precompiles)
 }
 
 impl<CTX> PrecompileProvider<CTX> for SeismicPrecompiles<CTX>
 where
-    CTX: ContextTr,
+    CTX: SeismicContextTr,
     CTX::Cfg: Cfg<Spec = SeismicSpecId>,
 {
     type Output = InterpreterResult;
@@ -155,7 +153,7 @@ where
     }
 }
 
-impl<CTX: ContextTr> Default for SeismicPrecompiles<CTX>
+impl<CTX: SeismicContextTr> Default for SeismicPrecompiles<CTX>
 where
     CTX::Cfg: Cfg, 
 {
@@ -167,9 +165,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use revm::database::EmptyDB;
+    use revm::{database::EmptyDB, primitives::hex};
     
-    use crate::SeismicContext;
+    use crate::{transaction::abstraction::SeismicTransaction, SeismicContext, DefaultSeismic};
 
     #[test]
     fn test_cancun_precompiles_in_mercury() {
@@ -186,6 +184,75 @@ mod tests {
 
         let intersection = default.intersection(latest);
         assert_eq!(intersection.len(), latest.len())
+    }
+
+    #[test]
+    fn test_seismic_precompiles_rng() {
+        let mut precompiles = SeismicPrecompiles::<SeismicContext<EmptyDB>>::new_with_spec(SeismicSpecId::MERCURY);
+        let mut context = SeismicContext::<EmptyDB>::seismic();
+        let rng_address = *precompiles.stateful_precompiles.addresses().next().expect("RNG precompile address should exist");
+        
+        let bytes_requested: u32 = 32;
+        let personalization = vec![0xAA, 0xBB, 0xCC, 0xDD];
+        let mut input_data = bytes_requested.to_be_bytes().to_vec();
+        input_data.extend(personalization);
+        let input = Bytes::from(input_data);
+        
+        let gas_limit = 10000;
+        
+        let result = precompiles.run(&mut context, &rng_address, &input, gas_limit);
+        
+        assert!(result.is_ok(), "SeismicPrecompiles should successfully route RNG call");
+        
+        let interpreter_result = result.unwrap().expect("Should return Some(InterpreterResult)");
+        let output_bytes = interpreter_result.output;
+        
+        assert_eq!(output_bytes.len(), 32, "RNG output should be 32 bytes");
+        assert_eq!(output_bytes, Bytes::from(hex!("6205fa1fc78e42116f1b370e200a867805679032f64ab68256ae59d678dc441d")), 
+                  "RNG precompile should return successfully");
+        
+        let gas_used = gas_limit - interpreter_result.gas.remaining();
+        assert!(gas_used >= 3500 && gas_used <= 3600, 
+                "Gas used should be in expected range, got {}", gas_used);
+        
+        let result2 = precompiles.run(&mut context, &rng_address, &input, gas_limit);
+        assert!(result2.is_ok(), "Second RNG call should succeed");
+        
+        let interpreter_result2 = result2.unwrap().expect("Should return Some(InterpreterResult)");
+        let output_bytes2 = interpreter_result2.output;
+        
+        assert_eq!(output_bytes2.len(), 32, "Second RNG output should be 32 bytes");
+        
+        let gas_used2 = gas_limit - interpreter_result2.gas.remaining();
+        assert!(gas_used2 < gas_used, 
+                "Second call should use less gas, used {} vs first call {}", gas_used2, gas_used);
+        
+        assert_ne!(output_bytes, output_bytes2, 
+                  "Subsequent RNG calls should return different outputs");
+    }
+    
+    #[test]
+    fn test_seismic_precompiles_warm_addresses() {
+        // Setup the SeismicPrecompiles
+        let precompiles = SeismicPrecompiles::<SeismicContext<EmptyDB>>::new_with_spec(SeismicSpecId::MERCURY);
+        
+        // Get all warm addresses
+        let warm_addresses: Vec<Address> = precompiles.warm_addresses().collect();
+        
+        // Verify RNG address is included
+        let rng_address = *precompiles.stateful_precompiles.addresses().next().expect("RNG precompile address should exist");
+        assert!(warm_addresses.contains(&rng_address), 
+                "warm_addresses() should include RNG precompile address");
+        
+        // Verify standard precompile addresses are included
+        let ecrecover_address = Address::from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        assert!(warm_addresses.contains(&ecrecover_address), 
+                "warm_addresses() should include standard precompile addresses");
+        
+        // Verify we have the expected number of warm addresses
+        // This should be the number of standard precompiles + number of stateful precompiles
+        assert!(warm_addresses.len() > 10, 
+                "warm_addresses() should return multiple addresses, got {}", warm_addresses.len());
     }
 }
 

--- a/crates/seismic/src/precompiles.rs
+++ b/crates/seismic/src/precompiles.rs
@@ -167,7 +167,7 @@ mod tests {
     use super::*;
     use revm::{database::EmptyDB, primitives::hex};
     
-    use crate::{transaction::abstraction::SeismicTransaction, SeismicContext, DefaultSeismic};
+    use crate::{SeismicContext, DefaultSeismic};
 
     #[test]
     fn test_cancun_precompiles_in_mercury() {

--- a/crates/seismic/src/precompiles/mod.rs
+++ b/crates/seismic/src/precompiles/mod.rs
@@ -85,7 +85,7 @@ pub fn mercury<CTX: ContextTr>() -> (&'static Precompiles, StatefulPrecompiles<C
     
     //TODO: check how expensive is the below instead of a single init! issue with generics
     let stateful_precompiles = StatefulPrecompiles::new();
-    stateful_precompiles.extend(rng::precompiles::<CTX>().map(|p| (p.0, p.1)));
+    //stateful_precompiles.extend(rng::precompiles::<CTX>().map(|p| (p.0, p.1)));
     (regular_precompiles, stateful_precompiles)
 }
 

--- a/crates/seismic/src/precompiles/mod.rs
+++ b/crates/seismic/src/precompiles/mod.rs
@@ -169,17 +169,15 @@ mod tests {
     use super::*;
     use revm::database::EmptyDB;
     
-    use crate::{DefaultSeismic,SeismicContext};
+    use crate::SeismicContext;
 
     #[test]
     fn test_cancun_precompiles_in_mercury() {
-        let context = SeismicContext::<EmptyDB>::seismic();
         assert_eq!(mercury::<SeismicContext<EmptyDB>>().0.difference(Precompiles::prague()).len(), 6)
     }
 
     #[test]
     fn test_default_precompiles_is_latest() {
-        let context = SeismicContext::<EmptyDB>::seismic();
         let latest = SeismicPrecompiles::<SeismicContext<EmptyDB>>::new_with_spec(SeismicSpecId::default())
             .inner
             .precompiles;

--- a/crates/seismic/src/precompiles/rng.rs
+++ b/crates/seismic/src/precompiles/rng.rs
@@ -1,5 +1,4 @@
 pub mod precompile;
 pub mod domain_sep_rng;
-pub mod rng_container;
 #[cfg(test)]
 pub mod test;

--- a/crates/seismic/src/precompiles/rng/precompile.rs
+++ b/crates/seismic/src/precompiles/rng/precompile.rs
@@ -14,7 +14,7 @@ Constants & Setup
 // to produce different randomness
 pub const RNG_ADDRESS: u64 = 100; // Hex address `0x64`.
 
-pub fn precompiles<CTX: SeismicContextTr>() -> impl Iterator<Item = StatefulPrecompileWithAddress<CTX>> {
+pub fn rng_precompile_iter<CTX: SeismicContextTr>() -> impl Iterator<Item = StatefulPrecompileWithAddress<CTX>> {
     [rng_precompile::<CTX>()].into_iter()
 }
 

--- a/crates/seismic/src/precompiles/rng/precompile.rs
+++ b/crates/seismic/src/precompiles/rng/precompile.rs
@@ -1,5 +1,5 @@
 use revm::{
-    context::ContextTr, precompile::{calc_linear_cost_u32, u64_to_address, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress}, primitives::{Address, Bytes}
+    context::ContextTr, precompile::{calc_linear_cost_u32, u64_to_address, PrecompileError, PrecompileOutput, PrecompileResult}, primitives::Bytes
 };
 
 use crate::{api::exec::SeismicContextTr, precompiles::stateful_precompile::StatefulPrecompileWithAddress, transaction::abstraction::SeismicTxTr};
@@ -181,19 +181,38 @@ mod tests {
 
     use super::*;
     use revm::database::EmptyDB;
-    use revm::primitives::{alloy_primitives::U32, B256, Bytes};
+    use revm::primitives::{B256, Bytes};
     use revm::precompile::PrecompileError;
     use revm::Context;
 
+    fn setup_rng_test(bytes_requested: u32, personalization: Option<Vec<u8>>) -> (u64, Bytes, SeismicContext<EmptyDB>, StatefulPrecompileWithAddress<SeismicContext<EmptyDB>>) {
+        let gas_limit = 6000;
+        
+        // Prepare input bytes
+        let mut input_data = bytes_requested.to_be_bytes().to_vec();
+        
+        // Add personalization if provided
+        if let Some(pers) = personalization {
+            input_data.extend(pers);
+        }
+        
+        let input = Bytes::from(input_data);
+        
+        // Setup transaction and context
+        let tx = SeismicTransaction::default().with_tx_hash(B256::from([0u8; 32]));
+        let context = Context::seismic().with_tx(tx);
+        
+        // Get precompile function
+        let precompile = rng_precompile::<SeismicContext<EmptyDB>>;
+        
+        (gas_limit, input, context, precompile())
+    }
+
     #[test]
     fn test_rng_init_no_pers() {
-        let gas_limit = 6000;
-        let input = Bytes::from(32u32.to_be_bytes()); // request 32 bytes, no pers
-        let tx = SeismicTransaction::default().with_tx_hash(B256::from([0u8; 32]));
-        let mut context = Context::seismic().with_tx(tx);
-        let precompile = rng_precompile::<SeismicContext<EmptyDB>>;
+        let (gas_limit, input, mut context, precompile) = setup_rng_test(32, None);
 
-        let result = precompile().1(&mut context, &input.into(), gas_limit);
+        let result = precompile.1(&mut context, &input.into(), gas_limit);
         assert!(
             result.is_ok(),
             "Should succeed without default personalization"
@@ -204,144 +223,123 @@ mod tests {
         assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
     }
 
-    //#[test]
-    //fn test_rng_init_00_pers_different_than_no_pers() {
-    //    let gas_limit = 6000;
-    //    let empty_pers = U32::ZERO;
-    //    let mut input_vector = Vec::new();
-    //    input_vector.extend(32u32.to_be_bytes());
-    //    input_vector.extend(empty_pers.to_be_bytes_vec());
-    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-    //    evmctx.env().tx.tx_hash = B256::from([0u8; 32]);
-    //    let precompile = RngPrecompile;
+    #[test]
+    fn test_rng_init_00_pers_different_than_no_pers() {
+        // Test with explicit zero personalization
+        let empty_pers = vec![0, 0, 0, 0]; // U32::ZERO.to_be_bytes_vec()
+        let (gas_limit, input_with_pers, mut context_with_pers, precompile) = setup_rng_test(32, Some(empty_pers));
 
-    //    let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
-    //    assert!(
-    //        result.is_ok(),
-    //        "Should succeed with default personalization"
-    //    );
+        let result_with_pers = precompile.1(&mut context_with_pers, &input_with_pers.into(), gas_limit);
+        assert!(
+            result_with_pers.is_ok(),
+            "Should succeed with default personalization"
+        );
 
-    //    let output = result.unwrap();
-    //    assert_eq!(output.gas_used, 3510, "Should consume exactly 3505 gas");
-    //    assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
+        let output_with_pers = result_with_pers.unwrap();
+        assert_eq!(output_with_pers.gas_used, 3510, "Should consume exactly 3510 gas");
+        assert!(output_with_pers.bytes.len() == 32, "RNG output should be 32 bytes");
 
-    //    let gas_limit = 6000;
-    //    let input = Bytes::from(32u32.to_be_bytes()); // request 32 bytes, no pers
-    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-    //    evmctx.env().tx.tx_hash = B256::from([0u8; 32]);
-    //    let precompile = RngPrecompile;
+        // Test without personalization
+        let (gas_limit, input_no_pers, mut context_no_pers, precompile) = setup_rng_test(32, None);
 
-    //    let result = precompile.call(&input.into(), gas_limit, &mut evmctx);
-    //    assert!(
-    //        result.is_ok(),
-    //        "Should succeed without default personalization"
-    //    );
+        let result_no_pers = precompile.1(&mut context_no_pers, &input_no_pers.into(), gas_limit);
+        assert!(
+            result_no_pers.is_ok(),
+            "Should succeed without default personalization"
+        );
 
-    //    let output = result.unwrap();
-    //    assert_eq!(output.gas_used, 3505, "Should consume exactly 3505 gas");
-    //    assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
-    //}
+        let output_no_pers = result_no_pers.unwrap();
+        assert_eq!(output_no_pers.gas_used, 3505, "Should consume exactly 3505 gas");
+        assert!(output_no_pers.bytes.len() == 32, "RNG output should be 32 bytes");
+    }
 
-    //#[test]
-    //fn test_rng_init_with_pers() {
-    //    let gas_limit = 6000;
-    //    let mut input = 32u32.to_be_bytes().to_vec();
-    //    input.extend(vec![1, 2, 3, 4]); // use 4 pers bytes, gets rounted up to one word
-    //    let input = Bytes::from(Bytes::from(input));
-    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-    //    let precompile = RngPrecompile;
+    #[test]
+    fn test_rng_init_with_pers() {
+        let personalization = vec![1, 2, 3, 4]; // use 4 pers bytes, gets rounded up to one word
+        let (gas_limit, input, mut context, precompile) = setup_rng_test(32, Some(personalization));
 
-    //    let result = precompile.call(&input, gas_limit, &mut evmctx);
-    //    assert!(result.is_ok(), "Should succeed with personalization");
+        let result = precompile.1(&mut context, &input.into(), gas_limit);
+        assert!(result.is_ok(), "Should succeed with personalization");
 
-    //    let output = result.unwrap();
-    //    assert_eq!(output.gas_used, 3510, "Should consume exactly 3510 gas");
-    //    assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
-    //}
+        let output = result.unwrap();
+        assert_eq!(output.gas_used, 3510, "Should consume exactly 3510 gas");
+        assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
+    }
 
-    //#[test]
-    //fn test_rng_already_initialized() {
-    //    let gas_limit = 500;
-    //    let empty_pers = U32::ZERO;
-    //    let mut input_vector = Vec::new();
-    //    input_vector.extend(32u32.to_be_bytes());
-    //    input_vector.extend(empty_pers.to_be_bytes_vec());
-    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-    //    let precompile = RngPrecompile;
+    #[test]
+    fn test_rng_already_initialized() {
+        let empty_pers = vec![0, 0, 0, 0]; // U32::ZERO.to_be_bytes_vec()
+        let (_, input, mut context, precompile) = setup_rng_test(32, Some(empty_pers));
 
-    //    // call once to initialize the RNG
-    //    let _ = precompile.call(&input_vector.clone().into(), 6000, &mut evmctx);
+        // Call once to initialize the RNG
+        let _ = precompile.1(&mut context, &input.clone().into(), 6000);
 
-    //    // make a second call with the leaf rng already initialized
-    //    let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
-    //    assert!(result.is_ok(), "Should succeed with initialized RNG");
+        // Make a second call with the leaf rng already initialized
+        let reduced_gas_limit = 500;
+        let result = precompile.1(&mut context, &input.into(), reduced_gas_limit);
+        assert!(result.is_ok(), "Should succeed with initialized RNG");
 
-    //    let output = result.unwrap();
-    //    assert_eq!(output.gas_used, 5, "Should consume exactly 5 gas");
-    //    assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
-    //}
+        let output = result.unwrap();
+        assert_eq!(output.gas_used, 5, "Should consume exactly 5 gas");
+        assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
+    }
 
-    //#[test]
-    //fn test_rng_out_of_gas_on_init() {
-    //    let gas_limit = 2500; // less than the init cost
-    //    let empty_pers = U32::ZERO;
-    //    let mut input_vector = Vec::new();
-    //    input_vector.extend(16u32.to_be_bytes());
-    //    input_vector.extend(empty_pers.to_be_bytes_vec());
-    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-    //    let precompile = RngPrecompile;
+    #[test]
+    fn test_rng_out_of_gas_on_init() {
+        let empty_pers = vec![0, 0, 0, 0]; // U32::ZERO.to_be_bytes_vec()
+        let (_, input, mut context, precompile) = setup_rng_test(16, Some(empty_pers));
+        
+        let insufficient_gas = 2500; // less than the init cost
+        let result = precompile.1(&mut context, &input.into(), insufficient_gas);
+        assert!(result.is_err());
 
-    //    let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
-    //    assert!(result.is_err());
+        match result.err() {
+            Some(PrecompileError::OutOfGas) => {}
+            other => panic!("Expected OutOfGas, got {:?}", other),
+        }
+    }
 
-    //    match result.err() {
-    //        Some(PrecompileErrors::Error(PrecompileError::OutOfGas)) => {}
-    //        other => panic!("Expected OutOfGas, got {:?}", other),
-    //    }
-    //}
+    #[test]
+    fn test_rng_out_of_gas_on_fill() {
+        let empty_pers = vec![0, 0, 0, 0]; // U32::ZERO.to_be_bytes_vec()
+        let (_, input, mut context, precompile) = setup_rng_test(6000, Some(empty_pers));
+        
+        // Call once to initialize the RNG
+        let _ = precompile.1(&mut context, &input.clone().into(), 6000);
 
-    //#[test]
-    //fn test_rng_out_of_gas_on_fill() {
-    //    let gas_limit = 100;
-    //    let empty_pers = U32::ZERO;
-    //    let mut input_vector = Vec::new();
-    //    input_vector.extend(6000u16.to_be_bytes());
-    //    input_vector.extend(empty_pers.to_be_bytes_vec());
-    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-    //    let precompile = RngPrecompile;
+        // Make a second call with the leaf rng already initialized
+        let insufficient_gas = 100;
+        let result = precompile.1(&mut context, &input.into(), insufficient_gas);
+        assert!(result.is_err());
 
-    //    // call once to initialize the RNG
-    //    let _ = precompile.call(&input_vector.clone().into(), 6000, &mut evmctx);
+        match result.err() {
+            Some(PrecompileError::OutOfGas) => {}
+            other => panic!("Expected OutOfGas, got {:?}", other),
+        }
+    }
 
-    //    // make a second call with the leaf rng already initialized
-    //    let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
-    //    assert!(result.is_err());
+    #[test]
+    fn test_invalid_input_length() {
+        // Create an invalid input (too short)
+        let input_vector = vec![0x00, 0x01, 0x02]; // 3 bytes only
+        let input = Bytes::from(input_vector);
+        
+        // Use our setup function to get the context and precompile
+        // We can use dummy values for bytes_requested and personalization since we'll override the input
+        let (gas_limit, _, mut context, precompile) = setup_rng_test(0, None);
+        
+        let result = precompile.1(&mut context, &input.into(), gas_limit);
+        assert!(result.is_err());
 
-    //    match result.err() {
-    //        Some(PrecompileErrors::Error(PrecompileError::OutOfGas)) => {}
-    //        other => panic!("Expected OutOfGas, got {:?}", other),
-    //    }
-    //}
-
-    //#[test]
-    //fn test_invalid_input_length() {
-    //    let gas_limit = 6000;
-    //    let input_vector = vec![0x00, 0x01, 0x02]; // 3 bytes only
-    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-    //    let precompile = RngPrecompile;
-
-    //    let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
-    //    assert!(result.is_err());
-
-    //    // We expect a PCError::Other complaining about input length
-    //    match result.err() {
-    //        Some(PrecompileErrors::Error(PrecompileError::Other(msg))) => {
-    //            assert!(
-    //                msg.contains("Insufficient input: need at least 4 bytes for length"),
-    //                "Should mention invalid input length"
-    //            );
-    //        }
-    //        other => panic!("Expected PrecompileError with length msg, got {:?}", other),
-    //    }
-    //}
+        // We expect a PCError::Other complaining about input length
+        match result.err() {
+            Some(PrecompileError::Other(msg)) => {
+                assert!(
+                    msg.contains("Insufficient input: need at least 4 bytes for length"),
+                    "Should mention invalid input length"
+                );
+            }
+            other => panic!("Expected PrecompileError with length msg, got {:?}", other),
+        }
+    }
 }

--- a/crates/seismic/src/precompiles/rng/precompile.rs
+++ b/crates/seismic/src/precompiles/rng/precompile.rs
@@ -2,7 +2,7 @@ use revm::{
     context::ContextTr, precompile::{calc_linear_cost_u32, u64_to_address, PrecompileError, PrecompileOutput, PrecompileResult, PrecompileWithAddress}, primitives::{Address, Bytes}
 };
 
-use crate::precompiles::stateful_precompile::StatefulPrecompileWithAddress;
+use crate::{api::exec::SeismicContextTr, precompiles::stateful_precompile::StatefulPrecompileWithAddress, transaction::abstraction::SeismicTxTr};
 
 /* --------------------------------------------------------------------------
 Constants & Setup
@@ -14,11 +14,11 @@ Constants & Setup
 // to produce different randomness
 pub const RNG_ADDRESS: u64 = 100; // Hex address `0x64`.
 
-pub fn precompiles<CTX: ContextTr>() -> impl Iterator<Item = StatefulPrecompileWithAddress<CTX>> {
+pub fn precompiles<CTX: SeismicContextTr>() -> impl Iterator<Item = StatefulPrecompileWithAddress<CTX>> {
     [rng_precompile::<CTX>()].into_iter()
 }
 
-pub fn rng_precompile<CTX: ContextTr>() -> StatefulPrecompileWithAddress<CTX> {
+pub fn rng_precompile<CTX: SeismicContextTr>() -> StatefulPrecompileWithAddress<CTX> {
     StatefulPrecompileWithAddress(u64_to_address(RNG_ADDRESS), rng::<CTX>)
 }
 
@@ -104,7 +104,7 @@ Precompile Logic
 /// RNG_INIT_BASE = round(100 + 395 + 3000) = 3500
 /// fill_cost     = ceil(fill_len / 32) * 5
 /// ```
-fn rng<CTX: ContextTr>(
+fn rng<CTX: SeismicContextTr>(
     evmctx: &mut CTX,
     input: &Bytes,
     gas_limit: u64,
@@ -116,19 +116,19 @@ fn rng<CTX: ContextTr>(
     
     // Compute the gas cost.
     let gas_used = evmctx
-        .rng_container
+        .chain()
         .calculate_gas_cost(&pers, requested_output_len);
     if gas_used > gas_limit {
         return Err(PrecompileError::OutOfGas); // Changed REVM_ERROR to PrecompileError
     }
     
     // Obtain kernel mode and transaction hash.
-    let kernel_mode = evmctx.env().tx.rng_mode;
-    let tx_hash = evmctx.env().tx.tx_hash;
+    let kernel_mode = evmctx.tx().rng_mode();
+    let tx_hash = evmctx.tx().tx_hash();
     
     // Let the container update its state and produce the random bytes.
     let output = evmctx
-        .rng_container
+        .chain()
         .process_rng(&pers, requested_output_len, kernel_mode, &tx_hash)
         .map_err(|e| PrecompileError::Other(e.to_string()))?; // Changed PCError to PrecompileError
     
@@ -176,19 +176,24 @@ pub(crate) fn validate_input_length(
 #[cfg(test)]
 mod tests {
     use std::vec;
+    use crate::transaction::abstraction::SeismicTransaction;
+    use crate::{SeismicContext, DefaultSeismic};
+
     use super::*;
+    use revm::database::EmptyDB;
     use revm::primitives::{alloy_primitives::U32, B256, Bytes};
     use revm::precompile::PrecompileError;
+    use revm::Context;
 
     #[test]
     fn test_rng_init_no_pers() {
         let gas_limit = 6000;
         let input = Bytes::from(32u32.to_be_bytes()); // request 32 bytes, no pers
-        let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-        evmctx.env().tx.tx_hash = B256::from([0u8; 32]);
-        let precompile = RngPrecompile;
+        let tx = SeismicTransaction::default().with_tx_hash(B256::from([0u8; 32]));
+        let mut context = Context::seismic().with_tx(tx);
+        let precompile = rng_precompile::<SeismicContext<EmptyDB>>;
 
-        let result = precompile.call(&input.into(), gas_limit, &mut evmctx);
+        let result = precompile().1(&mut context, &input.into(), gas_limit);
         assert!(
             result.is_ok(),
             "Should succeed without default personalization"
@@ -199,144 +204,144 @@ mod tests {
         assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
     }
 
-    #[test]
-    fn test_rng_init_00_pers_different_than_no_pers() {
-        let gas_limit = 6000;
-        let empty_pers = U32::ZERO;
-        let mut input_vector = Vec::new();
-        input_vector.extend(32u32.to_be_bytes());
-        input_vector.extend(empty_pers.to_be_bytes_vec());
-        let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-        evmctx.env().tx.tx_hash = B256::from([0u8; 32]);
-        let precompile = RngPrecompile;
+    //#[test]
+    //fn test_rng_init_00_pers_different_than_no_pers() {
+    //    let gas_limit = 6000;
+    //    let empty_pers = U32::ZERO;
+    //    let mut input_vector = Vec::new();
+    //    input_vector.extend(32u32.to_be_bytes());
+    //    input_vector.extend(empty_pers.to_be_bytes_vec());
+    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
+    //    evmctx.env().tx.tx_hash = B256::from([0u8; 32]);
+    //    let precompile = RngPrecompile;
 
-        let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
-        assert!(
-            result.is_ok(),
-            "Should succeed with default personalization"
-        );
+    //    let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
+    //    assert!(
+    //        result.is_ok(),
+    //        "Should succeed with default personalization"
+    //    );
 
-        let output = result.unwrap();
-        assert_eq!(output.gas_used, 3510, "Should consume exactly 3505 gas");
-        assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
+    //    let output = result.unwrap();
+    //    assert_eq!(output.gas_used, 3510, "Should consume exactly 3505 gas");
+    //    assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
 
-        let gas_limit = 6000;
-        let input = Bytes::from(32u32.to_be_bytes()); // request 32 bytes, no pers
-        let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-        evmctx.env().tx.tx_hash = B256::from([0u8; 32]);
-        let precompile = RngPrecompile;
+    //    let gas_limit = 6000;
+    //    let input = Bytes::from(32u32.to_be_bytes()); // request 32 bytes, no pers
+    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
+    //    evmctx.env().tx.tx_hash = B256::from([0u8; 32]);
+    //    let precompile = RngPrecompile;
 
-        let result = precompile.call(&input.into(), gas_limit, &mut evmctx);
-        assert!(
-            result.is_ok(),
-            "Should succeed without default personalization"
-        );
+    //    let result = precompile.call(&input.into(), gas_limit, &mut evmctx);
+    //    assert!(
+    //        result.is_ok(),
+    //        "Should succeed without default personalization"
+    //    );
 
-        let output = result.unwrap();
-        assert_eq!(output.gas_used, 3505, "Should consume exactly 3505 gas");
-        assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
-    }
+    //    let output = result.unwrap();
+    //    assert_eq!(output.gas_used, 3505, "Should consume exactly 3505 gas");
+    //    assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
+    //}
 
-    #[test]
-    fn test_rng_init_with_pers() {
-        let gas_limit = 6000;
-        let mut input = 32u32.to_be_bytes().to_vec();
-        input.extend(vec![1, 2, 3, 4]); // use 4 pers bytes, gets rounted up to one word
-        let input = Bytes::from(Bytes::from(input));
-        let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-        let precompile = RngPrecompile;
+    //#[test]
+    //fn test_rng_init_with_pers() {
+    //    let gas_limit = 6000;
+    //    let mut input = 32u32.to_be_bytes().to_vec();
+    //    input.extend(vec![1, 2, 3, 4]); // use 4 pers bytes, gets rounted up to one word
+    //    let input = Bytes::from(Bytes::from(input));
+    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
+    //    let precompile = RngPrecompile;
 
-        let result = precompile.call(&input, gas_limit, &mut evmctx);
-        assert!(result.is_ok(), "Should succeed with personalization");
+    //    let result = precompile.call(&input, gas_limit, &mut evmctx);
+    //    assert!(result.is_ok(), "Should succeed with personalization");
 
-        let output = result.unwrap();
-        assert_eq!(output.gas_used, 3510, "Should consume exactly 3510 gas");
-        assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
-    }
+    //    let output = result.unwrap();
+    //    assert_eq!(output.gas_used, 3510, "Should consume exactly 3510 gas");
+    //    assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
+    //}
 
-    #[test]
-    fn test_rng_already_initialized() {
-        let gas_limit = 500;
-        let empty_pers = U32::ZERO;
-        let mut input_vector = Vec::new();
-        input_vector.extend(32u32.to_be_bytes());
-        input_vector.extend(empty_pers.to_be_bytes_vec());
-        let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-        let precompile = RngPrecompile;
+    //#[test]
+    //fn test_rng_already_initialized() {
+    //    let gas_limit = 500;
+    //    let empty_pers = U32::ZERO;
+    //    let mut input_vector = Vec::new();
+    //    input_vector.extend(32u32.to_be_bytes());
+    //    input_vector.extend(empty_pers.to_be_bytes_vec());
+    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
+    //    let precompile = RngPrecompile;
 
-        // call once to initialize the RNG
-        let _ = precompile.call(&input_vector.clone().into(), 6000, &mut evmctx);
+    //    // call once to initialize the RNG
+    //    let _ = precompile.call(&input_vector.clone().into(), 6000, &mut evmctx);
 
-        // make a second call with the leaf rng already initialized
-        let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
-        assert!(result.is_ok(), "Should succeed with initialized RNG");
+    //    // make a second call with the leaf rng already initialized
+    //    let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
+    //    assert!(result.is_ok(), "Should succeed with initialized RNG");
 
-        let output = result.unwrap();
-        assert_eq!(output.gas_used, 5, "Should consume exactly 5 gas");
-        assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
-    }
+    //    let output = result.unwrap();
+    //    assert_eq!(output.gas_used, 5, "Should consume exactly 5 gas");
+    //    assert!(output.bytes.len() == 32, "RNG output should be 32 bytes");
+    //}
 
-    #[test]
-    fn test_rng_out_of_gas_on_init() {
-        let gas_limit = 2500; // less than the init cost
-        let empty_pers = U32::ZERO;
-        let mut input_vector = Vec::new();
-        input_vector.extend(16u32.to_be_bytes());
-        input_vector.extend(empty_pers.to_be_bytes_vec());
-        let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-        let precompile = RngPrecompile;
+    //#[test]
+    //fn test_rng_out_of_gas_on_init() {
+    //    let gas_limit = 2500; // less than the init cost
+    //    let empty_pers = U32::ZERO;
+    //    let mut input_vector = Vec::new();
+    //    input_vector.extend(16u32.to_be_bytes());
+    //    input_vector.extend(empty_pers.to_be_bytes_vec());
+    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
+    //    let precompile = RngPrecompile;
 
-        let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
-        assert!(result.is_err());
+    //    let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
+    //    assert!(result.is_err());
 
-        match result.err() {
-            Some(PrecompileErrors::Error(PrecompileError::OutOfGas)) => {}
-            other => panic!("Expected OutOfGas, got {:?}", other),
-        }
-    }
+    //    match result.err() {
+    //        Some(PrecompileErrors::Error(PrecompileError::OutOfGas)) => {}
+    //        other => panic!("Expected OutOfGas, got {:?}", other),
+    //    }
+    //}
 
-    #[test]
-    fn test_rng_out_of_gas_on_fill() {
-        let gas_limit = 100;
-        let empty_pers = U32::ZERO;
-        let mut input_vector = Vec::new();
-        input_vector.extend(6000u16.to_be_bytes());
-        input_vector.extend(empty_pers.to_be_bytes_vec());
-        let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-        let precompile = RngPrecompile;
+    //#[test]
+    //fn test_rng_out_of_gas_on_fill() {
+    //    let gas_limit = 100;
+    //    let empty_pers = U32::ZERO;
+    //    let mut input_vector = Vec::new();
+    //    input_vector.extend(6000u16.to_be_bytes());
+    //    input_vector.extend(empty_pers.to_be_bytes_vec());
+    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
+    //    let precompile = RngPrecompile;
 
-        // call once to initialize the RNG
-        let _ = precompile.call(&input_vector.clone().into(), 6000, &mut evmctx);
+    //    // call once to initialize the RNG
+    //    let _ = precompile.call(&input_vector.clone().into(), 6000, &mut evmctx);
 
-        // make a second call with the leaf rng already initialized
-        let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
-        assert!(result.is_err());
+    //    // make a second call with the leaf rng already initialized
+    //    let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
+    //    assert!(result.is_err());
 
-        match result.err() {
-            Some(PrecompileErrors::Error(PrecompileError::OutOfGas)) => {}
-            other => panic!("Expected OutOfGas, got {:?}", other),
-        }
-    }
+    //    match result.err() {
+    //        Some(PrecompileErrors::Error(PrecompileError::OutOfGas)) => {}
+    //        other => panic!("Expected OutOfGas, got {:?}", other),
+    //    }
+    //}
 
-    #[test]
-    fn test_invalid_input_length() {
-        let gas_limit = 6000;
-        let input_vector = vec![0x00, 0x01, 0x02]; // 3 bytes only
-        let mut evmctx = InnerEvmContext::new(EmptyDB::default());
-        let precompile = RngPrecompile;
+    //#[test]
+    //fn test_invalid_input_length() {
+    //    let gas_limit = 6000;
+    //    let input_vector = vec![0x00, 0x01, 0x02]; // 3 bytes only
+    //    let mut evmctx = InnerEvmContext::new(EmptyDB::default());
+    //    let precompile = RngPrecompile;
 
-        let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
-        assert!(result.is_err());
+    //    let result = precompile.call(&input_vector.into(), gas_limit, &mut evmctx);
+    //    assert!(result.is_err());
 
-        // We expect a PCError::Other complaining about input length
-        match result.err() {
-            Some(PrecompileErrors::Error(PrecompileError::Other(msg))) => {
-                assert!(
-                    msg.contains("Insufficient input: need at least 4 bytes for length"),
-                    "Should mention invalid input length"
-                );
-            }
-            other => panic!("Expected PrecompileError with length msg, got {:?}", other),
-        }
-    }
+    //    // We expect a PCError::Other complaining about input length
+    //    match result.err() {
+    //        Some(PrecompileErrors::Error(PrecompileError::Other(msg))) => {
+    //            assert!(
+    //                msg.contains("Insufficient input: need at least 4 bytes for length"),
+    //                "Should mention invalid input length"
+    //            );
+    //        }
+    //        other => panic!("Expected PrecompileError with length msg, got {:?}", other),
+    //    }
+    //}
 }

--- a/crates/seismic/src/rng_container.rs
+++ b/crates/seismic/src/rng_container.rs
@@ -1,11 +1,11 @@
 use core::fmt;
 use rand_core::RngCore;
-use revm::primitives::{B256, Bytes};
+use revm::{precompile::PrecompileError, primitives::{Bytes, B256}};
 
 use crate::transaction::abstraction::RngMode;
 use seismic_enclave::get_sample_schnorrkel_keypair;
 
-use super::precompile::{calculate_fill_cost, calculate_init_cost};
+use crate::precompiles::rng::{domain_sep_rng::{LeafRng, RootRng}, precompile::{calculate_fill_cost, calculate_init_cost}};
 
 pub struct RngContainer {
     rng: RootRng,
@@ -38,7 +38,7 @@ impl Default for RngContainer {
 }
 
 impl RngContainer {
-    pub fn new(root_vrf_key: SchnorrkelKeypair) -> Self {
+    pub fn new(root_vrf_key: schnorrkel::Keypair) -> Self {
         Self {
             rng: RootRng::new(root_vrf_key),
             leaf_rng: None,

--- a/crates/seismic/src/transaction/abstraction.rs
+++ b/crates/seismic/src/transaction/abstraction.rs
@@ -19,7 +19,7 @@ pub enum RngMode {
 #[auto_impl(&, &mut, Box, Arc)]
 pub trait SeismicTxTr: Transaction {
     /// tx hash of the transaction
-    fn tx_hash(&self) -> Option<B256>;
+    fn tx_hash(&self) -> B256;
 
     /// rng mode for this transaction 
     fn rng_mode(&self) -> RngMode;
@@ -30,7 +30,7 @@ pub trait SeismicTxTr: Transaction {
 pub struct SeismicTransaction<T: Transaction> {
     pub base: T,
     /// tx hash of the transaction. Used for domain separation in the RNG.
-    pub tx_hash: Option<B256>,
+    pub tx_hash: B256,
     pub rng_mode: RngMode,
 }
 
@@ -38,9 +38,19 @@ impl<T: Transaction> SeismicTransaction<T> {
     pub fn new(base: T) -> Self {
         Self {
             base,
-            tx_hash: None,
+            tx_hash: B256::ZERO,
             rng_mode: RngMode::Execution,
         }
+    }
+
+    pub fn with_tx_hash(mut self, tx_hash: B256) -> Self {
+        self.tx_hash = tx_hash;
+        self
+    }
+
+    pub fn with_rng_mode(mut self, rng_mode: RngMode) -> Self {
+        self.rng_mode = rng_mode;
+        self
     }
 }
 
@@ -48,7 +58,7 @@ impl Default for SeismicTransaction<TxEnv> {
     fn default() -> Self {
         Self {
             base: TxEnv::default(),
-            tx_hash: None,
+            tx_hash: B256::ZERO,
             rng_mode: RngMode::Execution,
         }
     }
@@ -128,7 +138,7 @@ impl<T: Transaction> Transaction for SeismicTransaction<T> {
 }
 
 impl<T: Transaction> SeismicTxTr for SeismicTransaction<T> {
-    fn tx_hash(&self) -> Option<B256> {
+    fn tx_hash(&self) -> B256 {
         self.tx_hash
     }
 

--- a/crates/seismic/src/transaction/abstraction.rs
+++ b/crates/seismic/src/transaction/abstraction.rs
@@ -4,7 +4,6 @@ use revm::{
     context_interface::transaction::Transaction,
     primitives::{Address, Bytes, TxKind, B256, U256},
 };
-use std::vec;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
Add Stateful Precompiles and ensure integration works up to precompile level.

Missing RNG resets still, handled at EVM level.