### PR TITLE
WIP: SRC20 Gas

### DIFF
--- a/crates/seismic/Cargo.toml
+++ b/crates/seismic/Cargo.toml
@@ -40,6 +40,8 @@ hkdf = { version = "0.12", default-features = false }
 seismic-enclave = { workspace = true, default-features = false}
 sha2 = { workspace = true } 
 secp256k1 = { workspace = true }
+alloy-sol-types = { workspace = true }
+anyhow = { workspace = true }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/seismic/Cargo.toml
+++ b/crates/seismic/Cargo.toml
@@ -49,6 +49,7 @@ indicatif.workspace = true
 rstest.workspace = true
 alloy-sol-types.workspace = true
 serde_json = { workspace = true, features = ["alloc"] }
+revm = { workspace = true, features = ["secp256r1", "serde-json"] }
 
 [features]
 default = ["std", "c-kzg", "secp256k1", "portable", "blst"]

--- a/crates/seismic/src/api/default_ctx.rs
+++ b/crates/seismic/src/api/default_ctx.rs
@@ -1,7 +1,10 @@
+use crate::src20_gas::gas_contract_account_info;
+use crate::src20_gas::GAS_SRC20_ADDRESS;
 use crate::{transaction::abstraction::SeismicTransaction, SeismicChain, SeismicSpecId};
+use revm::context::ContextTr;
+use revm::database::InMemoryDB;
 use revm::{
     context::{BlockEnv, CfgEnv, TxEnv},
-    database_interface::EmptyDB,
     Context, Journal, MainContext,
 };
 
@@ -15,18 +18,28 @@ pub type SeismicContext<DB> = Context<
     SeismicChain,
 >;
 
+pub type DefaultSeismicDB = InMemoryDB;
+
 /// Trait that allows for a default context to be created.
 pub trait DefaultSeismicContext {
     /// Create a default context.
-    fn seismic() -> SeismicContext<EmptyDB>;
+    fn seismic() -> SeismicContext<DefaultSeismicDB>;
 }
 
-impl DefaultSeismicContext for SeismicContext<EmptyDB> {
+impl DefaultSeismicContext for SeismicContext<DefaultSeismicDB> {
     fn seismic() -> Self {
-        Context::mainnet()
+        let mut ctx = Context::mainnet()
             .with_tx(SeismicTransaction::default())
             .with_cfg(CfgEnv::new_with_spec(SeismicSpecId::MERCURY))
             .with_chain(SeismicChain::default())
+            .with_db(DefaultSeismicDB::default());
+
+        // Set up the seismic gas contract
+        let gas_contract_info = gas_contract_account_info();
+        ctx.db()
+            .insert_account_info(GAS_SRC20_ADDRESS, gas_contract_info);
+
+        ctx
     }
 }
 

--- a/crates/seismic/src/evm.rs
+++ b/crates/seismic/src/evm.rs
@@ -147,20 +147,27 @@ mod tests {
     use crate::precompiles::rng::precompile::{calculate_fill_cost, calculate_init_cost};
     use crate::transaction::abstraction::SeismicTransaction;
     use crate::{
-        DefaultSeismicContext, SeismicBuilder, SeismicChain, SeismicContext, SeismicHaltReason,
-        SeismicSpecId,
+        DefaultSeismicContext, DefaultSeismicDB, SeismicBuilder, SeismicChain, SeismicContext,
+        SeismicHaltReason, SeismicSpecId,
     };
     use anyhow::bail;
     use rand_core::RngCore;
-    use revm::context::result::{ExecutionResult, Output, ResultAndState};
+    use revm::context::result::{
+        EVMError, ExecutionResult, InvalidTransaction, Output, ResultAndState,
+    };
     use revm::context::{BlockEnv, CfgEnv, Context, ContextTr, JournalTr, TxEnv};
-    use revm::database::{EmptyDB, InMemoryDB, BENCH_CALLER};
+    use revm::database::{BENCH_CALLER, BENCH_CALLER_BALANCE};
     use revm::interpreter::gas::calculate_initial_tx_gas;
     use revm::interpreter::InitialAndFloorGas;
     use revm::precompile::u64_to_address;
     use revm::primitives::{Address, Bytes, TxKind, B256, U256};
     use revm::{ExecuteCommitEvm, ExecuteEvm, Journal};
     use seismic_enclave::get_unsecure_sample_schnorrkel_keypair;
+    use std::convert::Infallible;
+
+    use crate::src20_gas::{
+        gas_set_balance, map_storage, GAS_SRC20_ADDRESS, GAS_SRC20_BALANCE_SLOT,
+    };
 
     // === Fixture data ===
 
@@ -180,16 +187,30 @@ mod tests {
         (bytecode, selector)
     }
 
+    fn setup_ctx() -> SeismicContext<DefaultSeismicDB> {
+        let mut ctx = Context::seismic();
+
+        // set the bench caller balance to have gas
+        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        gas_set_balance::<SeismicContext<DefaultSeismicDB>, EVMError<Infallible, InvalidTransaction>>(
+            &mut ctx,
+            BENCH_CALLER,
+            BENCH_CALLER_BALANCE,
+        )
+        .unwrap();
+
+        ctx
+    }
+
     // === Test helpers ===
 
-    fn deploy_contract() -> anyhow::Result<(SeismicContext<InMemoryDB>, Address)> {
+    fn deploy_contract() -> anyhow::Result<(SeismicContext<DefaultSeismicDB>, Address)> {
+        let ctx = setup_ctx();
         let (bytecode, _) = get_meta_data();
-        let ctx = Context::seismic()
-            .modify_tx_chained(|tx| {
-                tx.base.kind = TxKind::Create;
-                tx.base.data = bytecode.clone();
-            })
-            .with_db(InMemoryDB::default());
+        let ctx = ctx.modify_tx_chained(|tx| {
+            tx.base.kind = TxKind::Create;
+            tx.base.data = bytecode.clone();
+        });
 
         let mut evm = ctx.build_seismic_evm();
         let receipt = evm.replay_commit()?;
@@ -205,12 +226,12 @@ mod tests {
     }
 
     fn prepare_call(
-        ctx: SeismicContext<InMemoryDB>,
+        ctx: SeismicContext<DefaultSeismicDB>,
         contract: Address,
         selector: Bytes,
         gas_limit: u64,
         gas_price: u64,
-    ) -> SeismicContext<InMemoryDB> {
+    ) -> SeismicContext<DefaultSeismicDB> {
         let mut ctx = ctx;
 
         ctx.modify_tx(|tx| {
@@ -240,11 +261,17 @@ mod tests {
         ));
 
         let expected = U256::from(starting_balance - gas_limit * gas_price);
-        assert_eq!(
-            result.state.get(&BENCH_CALLER).unwrap().info.balance,
-            expected,
-            "Caller balance after gas"
-        );
+        let actual = result
+            .state
+            .get(&GAS_SRC20_ADDRESS)
+            .unwrap()
+            .storage
+            .get(&map_storage(BENCH_CALLER, GAS_SRC20_BALANCE_SLOT))
+            .unwrap()
+            .present_value
+            .value;
+
+        assert_eq!(actual, expected, "Caller balance after gas");
 
         let final_nonce = result.state.get(&BENCH_CALLER).unwrap().info.nonce;
         assert_eq!(final_nonce, 1, "Caller nonce incremented by 1");
@@ -262,16 +289,19 @@ mod tests {
         let call_ctx = prepare_call(ctx, contract, selector, gas_limit, gas_price);
 
         let mut evm = call_ctx.build_seismic_evm();
-        let account = evm.ctx().journal().load_account(BENCH_CALLER).unwrap();
-        account.data.info.balance = U256::from(balance);
+        JournalTr::load_account(evm.ctx().journal(), GAS_SRC20_ADDRESS).unwrap();
+        gas_set_balance::<
+            SeismicContext<DefaultSeismicDB>,
+            EVMError<Infallible, InvalidTransaction>,
+        >(evm.ctx(), BENCH_CALLER, U256::from(balance))?;
 
         let result = evm.replay()?;
-
         assert_cload_error(&result, balance, gas_limit, gas_price);
         Ok(())
     }
 
-    fn rng_test_tx(
+    fn rng_test_ctx(
+        base_ctx: SeismicContext<DefaultSeismicDB>,
         spec: SeismicSpecId,
         bytes_requested: u32,
         personalization: Vec<u8>,
@@ -279,8 +309,8 @@ mod tests {
         BlockEnv,
         SeismicTransaction<TxEnv>,
         CfgEnv<SeismicSpecId>,
-        EmptyDB,
-        Journal<EmptyDB>,
+        DefaultSeismicDB,
+        Journal<DefaultSeismicDB>,
         SeismicChain,
     > {
         let mut input_data = bytes_requested.to_be_bytes().to_vec();
@@ -294,7 +324,7 @@ mod tests {
             + calculate_init_cost(personalization.len())
             + calculate_fill_cost(bytes_requested as usize);
 
-        Context::seismic()
+        base_ctx
             .modify_tx_chained(|tx| {
                 tx.base.kind = TxKind::Call(u64_to_address(rng::precompile::RNG_ADDRESS));
                 tx.base.data = input;
@@ -310,7 +340,9 @@ mod tests {
         let personalization = vec![0xAA, 0xBB, 0xCC, 0xDD];
 
         // Get EVM output
-        let ctx = rng_test_tx(
+        let base_ctx = setup_ctx();
+        let ctx = rng_test_ctx(
+            base_ctx,
             SeismicSpecId::MERCURY,
             bytes_requested,
             personalization.clone(),

--- a/crates/seismic/src/handler.rs
+++ b/crates/seismic/src/handler.rs
@@ -15,7 +15,7 @@ use revm::{
         Frame, FrameResult, Handler, MainnetHandler,
     },
     inspector::{Inspector, InspectorEvmTr, InspectorFrame, InspectorHandler},
-    interpreter::{interpreter::EthInterpreter, FrameInput, InstructionResult},
+    interpreter::{interpreter::EthInterpreter, FrameInput},
     primitives::U256,
 };
 
@@ -136,7 +136,6 @@ where
         evm: &mut Self::Evm,
         exec_result: &mut <Self::Frame as Frame>::FrameResult,
     ) -> Result<(), Self::Error> {
-        println!("entered reimburse_caller");
         let context = evm.ctx();
         let basefee = context.block().basefee() as u128;
         let caller = context.tx().caller();

--- a/crates/seismic/src/handler.rs
+++ b/crates/seismic/src/handler.rs
@@ -15,7 +15,7 @@ use revm::{
         Frame, FrameResult, Handler, MainnetHandler,
     },
     inspector::{Inspector, InspectorEvmTr, InspectorFrame, InspectorHandler},
-    interpreter::{interpreter::EthInterpreter, FrameInput},
+    interpreter::{interpreter::EthInterpreter, FrameInput, InstructionResult},
     primitives::U256,
 };
 
@@ -82,14 +82,16 @@ where
             .effective_balance_spending(basefee, blob_price)
             .expect("effective balance is always smaller than max balance so it can't overflow");
 
-        // Load the SRC20 Gas contract into the journal and mark it as warm,
-        // as the value should almost always update
+        // Load the SRC20 Gas contract into the journal and mark it as touched,
+        // as the value should always update
         // Then validate the caller's balance
         let caller_slot = gas_caller_key(caller);
         context
             .journal()
             .warm_account_and_storage(GAS_SRC20_ADDRESS, [caller_slot])
             .unwrap();
+        context.journal().touch_account(GAS_SRC20_ADDRESS);
+        
         let account_balance = gas_balance_of::<EVM::Context, ERROR>(context, caller)?;
 
         if account_balance < max_balance_spending && !is_balance_check_disabled {
@@ -134,6 +136,7 @@ where
         evm: &mut Self::Evm,
         exec_result: &mut <Self::Frame as Frame>::FrameResult,
     ) -> Result<(), Self::Error> {
+        println!("entered reimburse_caller");
         let context = evm.ctx();
         let basefee = context.block().basefee() as u128;
         let caller = context.tx().caller();

--- a/crates/seismic/src/handler.rs
+++ b/crates/seismic/src/handler.rs
@@ -91,7 +91,7 @@ where
             .warm_account_and_storage(GAS_SRC20_ADDRESS, [caller_slot])
             .unwrap();
         context.journal().touch_account(GAS_SRC20_ADDRESS);
-        
+
         let account_balance = gas_balance_of::<EVM::Context, ERROR>(context, caller)?;
 
         if account_balance < max_balance_spending && !is_balance_check_disabled {

--- a/crates/seismic/src/handler.rs
+++ b/crates/seismic/src/handler.rs
@@ -1,16 +1,22 @@
 //!Handler related to Seismic chain
+use crate::src20_gas::{
+    gas_balance_of, gas_caller_key, gas_set_balance, gas_token_operation, GAS_SRC20_ADDRESS,
+    TREASURY,
+};
 use crate::{api::exec::SeismicContextTr, SeismicHaltReason};
 use revm::{
     context::{
         result::{ExecutionResult, InvalidTransaction, ResultAndState},
         ContextTr, JournalTr, Transaction,
     },
-    context_interface::{context::ContextError, result::FromStringError},
+    context_interface::{context::ContextError, result::FromStringError, Block, Cfg},
     handler::{
-        handler::EvmTrError, post_execution, EvmTr, Frame, FrameResult, Handler, MainnetHandler,
+        handler::EvmTrError, post_execution, pre_execution::validate_account_nonce_and_code, EvmTr,
+        Frame, FrameResult, Handler, MainnetHandler,
     },
     inspector::{Inspector, InspectorEvmTr, InspectorFrame, InspectorHandler},
     interpreter::{interpreter::EthInterpreter, FrameInput},
+    primitives::U256,
 };
 
 pub struct SeismicHandler<EVM, ERROR, FRAME> {
@@ -43,6 +49,143 @@ where
     type Error = ERROR;
     type Frame = FRAME;
     type HaltReason = SeismicHaltReason;
+
+    /// Validates the transaction against the state and deducts gas from the caller
+    fn validate_against_state_and_deduct_caller(&self, evm: &mut Self::Evm) -> Result<(), ERROR> {
+        let context = evm.ctx();
+        let basefee = context.block().basefee() as u128;
+        let blob_price = context.block().blob_gasprice().unwrap_or_default();
+        let is_balance_check_disabled = context.cfg().is_balance_check_disabled();
+        let is_eip3607_disabled = context.cfg().is_eip3607_disabled();
+        let is_nonce_check_disabled = context.cfg().is_nonce_check_disabled();
+        let caller = context.tx().caller();
+        let value = context.tx().value();
+
+        let (tx, journal) = context.tx_journal();
+
+        // Load caller's account.
+        let caller_account = journal.load_account_code(tx.caller())?.data;
+
+        validate_account_nonce_and_code(
+            &mut caller_account.info,
+            tx.nonce(),
+            tx.kind().is_call(),
+            is_eip3607_disabled,
+            is_nonce_check_disabled,
+        )?;
+
+        // Touch account so we know it is changed.
+        caller_account.mark_touch();
+
+        let max_balance_spending = tx.max_balance_spending()?;
+        let effective_balance_spending = tx
+            .effective_balance_spending(basefee, blob_price)
+            .expect("effective balance is always smaller than max balance so it can't overflow");
+
+        // Load the SRC20 Gas contract into the journal and mark it as warm,
+        // as the value should almost always update
+        // Then validate the caller's balance
+        let caller_slot = gas_caller_key(caller);
+        context
+            .journal()
+            .warm_account_and_storage(GAS_SRC20_ADDRESS, [caller_slot])
+            .unwrap();
+        let account_balance = gas_balance_of::<EVM::Context, ERROR>(context, caller)?;
+
+        if account_balance < max_balance_spending && !is_balance_check_disabled {
+            return Err(InvalidTransaction::LackOfFundForMaxFee {
+                fee: Box::new(max_balance_spending),
+                balance: Box::new(account_balance),
+            }
+            .into());
+        };
+
+        // Check if account has enough balance for `gas_limit * max_fee`` and value transfer.
+        // Transfer will be done inside `*_inner` functions.
+        if is_balance_check_disabled {
+            // TODO: adjust with GAS_SRC20_CONVERATION_RATIO?
+            let temp_caller_balance =
+                gas_balance_of::<EVM::Context, ERROR>(context, caller)?.max(max_balance_spending);
+            gas_set_balance::<EVM::Context, ERROR>(context, caller, temp_caller_balance)?;
+        } else if max_balance_spending > account_balance {
+            return Err(InvalidTransaction::LackOfFundForMaxFee {
+                fee: Box::new(max_balance_spending),
+                balance: Box::new(account_balance),
+            }
+            .into());
+        } else {
+            // subtracting max balance spending with value that is going to be deducted later in the call.
+            let gas_balance_spending = effective_balance_spending - value;
+
+            gas_token_operation::<EVM::Context, ERROR>(
+                context,
+                caller,
+                TREASURY,
+                gas_balance_spending,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Reimburses the caller for unused gas
+    fn reimburse_caller(
+        &self,
+        evm: &mut Self::Evm,
+        exec_result: &mut <Self::Frame as Frame>::FrameResult,
+    ) -> Result<(), Self::Error> {
+        let context = evm.ctx();
+        let basefee = context.block().basefee() as u128;
+        let caller = context.tx().caller();
+        let effective_gas_price = context.tx().effective_gas_price(basefee);
+        let gas = exec_result.gas();
+
+        let reimbursement =
+            effective_gas_price.saturating_mul((gas.remaining() + gas.refunded() as u64) as u128);
+        gas_token_operation::<EVM::Context, ERROR>(
+            context,
+            TREASURY,
+            caller,
+            U256::from(reimbursement),
+        )?;
+
+        Ok(())
+    }
+
+    /// Rewards the beneficiary (miner/validator) with gas fees
+    fn reward_beneficiary(
+        &self,
+        evm: &mut Self::Evm,
+        exec_result: &mut <Self::Frame as Frame>::FrameResult,
+    ) -> Result<(), Self::Error> {
+        let context = evm.ctx();
+        let tx = context.tx();
+        let beneficiary = context.block().beneficiary();
+        let basefee = context.block().basefee() as u128;
+        let effective_gas_price = tx.effective_gas_price(basefee);
+        let gas = exec_result.gas();
+
+        let coinbase_gas_price = if context
+            .cfg()
+            .spec()
+            .is_enabled_in(revm::primitives::hardfork::SpecId::LONDON.into())
+        {
+            effective_gas_price.saturating_sub(basefee)
+        } else {
+            effective_gas_price
+        };
+
+        let reward =
+            coinbase_gas_price.saturating_mul((gas.spent() - gas.refunded() as u64) as u128);
+        gas_token_operation::<EVM::Context, ERROR>(
+            context,
+            TREASURY,
+            beneficiary,
+            U256::from(reward),
+        )?;
+
+        Ok(())
+    }
 
     /// Processes the final execution output.
     ///
@@ -127,10 +270,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{api::default_ctx::SeismicContext, DefaultSeismicContext, SeismicBuilder};
+    use crate::{
+        api::default_ctx::{DefaultSeismicContext, DefaultSeismicDB, SeismicContext},
+        SeismicBuilder,
+    };
     use revm::{
         context::{result::EVMError, Context},
-        database_interface::EmptyDB,
         handler::EthFrame,
         interpreter::{CallOutcome, Gas, InstructionResult, InterpreterResult},
         primitives::Bytes,
@@ -138,7 +283,7 @@ mod tests {
 
     /// Creates frame result.
     fn call_last_frame_return(
-        ctx: SeismicContext<EmptyDB>,
+        ctx: SeismicContext<DefaultSeismicDB>,
         instruction_result: InstructionResult,
         gas: Gas,
     ) -> Gas {

--- a/crates/seismic/src/lib.rs
+++ b/crates/seismic/src/lib.rs
@@ -13,11 +13,12 @@ pub mod instructions;
 pub mod precompiles;
 pub mod result;
 pub mod spec;
+pub mod src20_gas;
 pub mod transaction;
 
 pub use api::{
     builder::SeismicBuilder,
-    default_ctx::{DefaultSeismicContext, SeismicContext},
+    default_ctx::{DefaultSeismicContext, DefaultSeismicDB, SeismicContext},
 };
 pub use chain::seismic_chain::SeismicChain;
 pub use evm::SeismicEvm;

--- a/crates/seismic/src/precompiles.rs
+++ b/crates/seismic/src/precompiles.rs
@@ -201,7 +201,7 @@ mod tests {
     use super::*;
     use revm::{database::EmptyDB, primitives::hex};
 
-    use crate::{DefaultSeismicContext, SeismicContext};
+    use crate::{DefaultSeismicContext, DefaultSeismicDB, SeismicContext};
 
     #[test]
     fn test_cancun_precompiles_in_mercury() {
@@ -216,11 +216,12 @@ mod tests {
 
     #[test]
     fn test_default_precompiles_is_latest() {
-        let latest =
-            SeismicPrecompiles::<SeismicContext<EmptyDB>>::new_with_spec(SeismicSpecId::default())
-                .inner
-                .precompiles;
-        let default = SeismicPrecompiles::<SeismicContext<EmptyDB>>::default()
+        let latest = SeismicPrecompiles::<SeismicContext<DefaultSeismicDB>>::new_with_spec(
+            SeismicSpecId::default(),
+        )
+        .inner
+        .precompiles;
+        let default = SeismicPrecompiles::<SeismicContext<DefaultSeismicDB>>::default()
             .inner
             .precompiles;
         assert_eq!(latest.len(), default.len());
@@ -231,9 +232,10 @@ mod tests {
 
     #[test]
     fn test_seismic_precompiles_rng() {
-        let mut precompiles =
-            SeismicPrecompiles::<SeismicContext<EmptyDB>>::new_with_spec(SeismicSpecId::MERCURY);
-        let mut context = SeismicContext::<EmptyDB>::seismic();
+        let mut precompiles = SeismicPrecompiles::<SeismicContext<DefaultSeismicDB>>::new_with_spec(
+            SeismicSpecId::MERCURY,
+        );
+        let mut context = SeismicContext::<DefaultSeismicDB>::seismic();
         let rng_address = *precompiles
             .stateful_precompiles
             .addresses()

--- a/crates/seismic/src/precompiles/rng/precompile.rs
+++ b/crates/seismic/src/precompiles/rng/precompile.rs
@@ -180,11 +180,10 @@ pub(crate) fn validate_input_length(
 #[cfg(test)]
 mod tests {
     use crate::transaction::abstraction::SeismicTransaction;
-    use crate::{DefaultSeismicContext, SeismicContext};
+    use crate::{DefaultSeismicContext, DefaultSeismicDB, SeismicContext};
     use std::vec;
 
     use super::*;
-    use revm::database::EmptyDB;
     use revm::precompile::PrecompileError;
     use revm::primitives::{Bytes, B256};
     use revm::Context;
@@ -195,8 +194,8 @@ mod tests {
     ) -> (
         u64,
         Bytes,
-        SeismicContext<EmptyDB>,
-        StatefulPrecompileWithAddress<SeismicContext<EmptyDB>>,
+        SeismicContext<DefaultSeismicDB>,
+        StatefulPrecompileWithAddress<SeismicContext<DefaultSeismicDB>>,
     ) {
         let gas_limit = 6000;
 
@@ -215,7 +214,7 @@ mod tests {
         let context = Context::seismic().with_tx(tx);
 
         // Get precompile function
-        let precompile = rng_precompile::<SeismicContext<EmptyDB>>;
+        let precompile = rng_precompile::<SeismicContext<DefaultSeismicDB>>;
 
         (gas_limit, input, context, precompile())
     }

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -75,7 +75,10 @@ where
 
     if sender_balance < amount {
         return Err(ERROR::from(
-            InvalidTransaction::MaxFeePerBlobGasNotSupported, // TODO: this error seems wrong
+            InvalidTransaction::LackOfFundForMaxFee {
+                fee: Box::new(amount),
+                balance: Box::new(sender_balance),
+            },
         ));
     }
     // Subtract the amount from the sender's balance

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -1,7 +1,7 @@
 //! This module contains the logic for the GAS_SRC20 token contract.
 //! Seismic uses a custom ERC20 token contract to handle gas fees
 
-use alloy_sol_types::SolValue;
+use alloy_sol_types::{SolValue};
 use anyhow::Result;
 use revm::{
     bytecode::Bytecode,
@@ -23,7 +23,7 @@ pub const GAS_SRC20_BALANCE_SLOT: u64 = 0;
 pub const GAS_SRC20_CODE: Bytes = bytes!("0x608060405234801561000f575f5ffd5b50600436106100fb575f3560e01c80635687f2b81161009357806395d89b411161006357806395d89b4114610218578063aa8beaf014610238578063be09129c1461024b578063f43064fb1461025e575f5ffd5b80635687f2b8146101a85780635f84a3cd146101df57806388412c20146101f25780638cdb7b3414610205575f5ffd5b8063221b7180116100ce578063221b71801461019557806323de6651146101a8578063313ce567146101bd5780633ab43673146101cc575f5ffd5b806306fdde03146100ff57806314f228031461013857806318160ddd1461015b5780632176518a1461016b575b5f5ffd5b60408051808201909152600b81526a577261707065642047617360a81b60208201525b60405161012f9190610734565b60405180910390f35b61014b610146366004610780565b610271565b604051901515815260200161012f565b5f5b60405190815260200161012f565b61017e6101793660046107aa565b6102ef565b60408051921515835260208301919091520161012f565b61015d6101a33660046107e1565b61035d565b6101bb6101b6366004610803565b505050565b005b6040516012815260200161012f565b61017e6101da3660046107e1565b6103a2565b61015d6101ed3660046107aa565b6103dc565b61014b610200366004610780565b610437565b61014b610213366004610780565b61044e565b6040805180820190915260048152635747415360e01b6020820152610122565b61014b610246366004610780565b61045b565b61014b610259366004610803565b610495565b61014b61026c366004610780565b6104b8565b335f8181526001602090815260408083206001600160a01b03871684529091528120b0909190838110156102d557604051637dc7a0d960e11b81526001600160a01b03861660048201525f6024820181905260448201526064015b60405180910390fd5b6102e282868684036104cc565b6001925050505b92915050565b5f80336001600160a01b03851681148061031a5750836001600160a01b0316816001600160a01b0316145b1561034e575050506001600160a01b038083165f9081526001602081815260408084209486168452939052919020b0610356565b5f5f92509250505b9250929050565b5f336001600160a01b0383160361038957506001600160a01b03165f908152602081905260409020b090565b60405163263e159360e11b815260040160405180910390fd5b5f80336001600160a01b038416036103d25750506001600160a01b03165f908152602081905260409020b0600191565b505f928392509050565b5f336001600160a01b0384168114806104065750826001600160a01b0316816001600160a01b0316145b156103895750506001600160a01b038083165f908152600160209081526040808320938516835292905220b06102e9565b5f336104448185856104cc565b5060019392505050565b5f3361044481858561054e565b335f8181526001602090815260408083206001600160a01b03871684529091528120b09091906102e282866104908785610855565b6104cc565b5f336104a28582856105ab565b6104ad85858561054e565b506001949350505050565b5f6104c38383610625565b50600192915050565b6001600160a01b0383166104f55760405163e602df0560e01b81525f60048201526024016102cc565b6001600160a01b03821661051e57604051634a1406b160e11b81525f60048201526024016102cc565b6001600160a01b038084165f9081526001602090815260408083209386168352929052208190b16101b683838383565b6001600160a01b03831661057757604051634b637e8f60e11b81525f60048201526024016102cc565b6001600160a01b0382166105a05760405163ec442f0560e01b81525f60048201526024016102cc565b6101b683838361065d565b6001600160a01b038084165f908152600160209081526040808320938616835292905220b05f1981101561061f578181101561061257604051637dc7a0d960e11b81526001600160a01b03841660048201525f6024820181905260448201526064016102cc565b61061f84848484036104cc565b50505050565b6001600160a01b03821661064e5760405163ec442f0560e01b81525f60048201526024016102cc565b6106595f838361065d565b5050565b6001600160a01b038316610687578060025f82825461067c9190610855565b909155506106f69050565b6001600160a01b0383165f908152602081905260409020b0818110156106d85760405163391434e360e21b81526001600160a01b03851660048201525f6024820181905260448201526064016102cc565b6001600160a01b0384165f9081526020819052604090209082900390b15b6001600160a01b03821661071257600280548290039055505050565b6001600160a01b0382165f90815260208190526040902080b0820190b1505050565b602081525f82518060208401528060208501604085015e5f604082850101526040601f19601f83011684010191505092915050565b6001600160a01b038116811461077d575f5ffd5b50565b5f5f60408385031215610791575f5ffd5b823561079c81610769565b946020939093013593505050565b5f5f604083850312156107bb575f5ffd5b82356107c681610769565b915060208301356107d681610769565b809150509250929050565b5f602082840312156107f1575f5ffd5b81356107fc81610769565b9392505050565b5f5f5f60608486031215610815575f5ffd5b833561082081610769565b9250602084013561083081610769565b929592945050506040919091013590565b634e487b7160e01b5f52601160045260245ffd5b808201808211156102e9576102e961084156fea26469706673582212204a01d1adaa4e7bd539c389daeea5cb99e1fd2f73b65a98e415c7b17605f932c764736f6c637828302e382e32382d646576656c6f702e323032352e322e31332b636f6d6d69742e39363462353035320059");
 /// The amount of gas covered by a single GAS_SRC20
 /// The goal is to denominate the token in USD, and have 21000 GAS cost 1 cent
-pub const GAS_SRC20_CONVERATION_RATIO: u64 = 2100000;
+pub const GAS_SRC20_CONVERATION_RATIO: u64 = 2100000; // TODO: actually use this somewhere
 /// Treasury address for gas fees
 pub const TREASURY: Address = Address::new([0u8; 20]); // TODO: update this to a seismic controlled address
 
@@ -160,6 +160,26 @@ mod tests {
     use crate::api::default_ctx::{DefaultSeismicContext, DefaultSeismicDB, SeismicContext};
     use revm::context::result::{EVMError, InvalidTransaction};
     use std::convert::Infallible;
+    use crate::api::builder::SeismicBuilder;
+    use revm::{
+        primitives::{Bytes, U256},
+    };
+    use revm::primitives::TxKind;
+    use alloy_sol_types::{sol, SolCall};
+
+    use revm::{
+        inspector::{InspectEvm, inspectors::TracerEip3155},
+    };
+
+
+    fn transfer_call_data(recipient: Address, amount: U256) -> Bytes {
+        sol! {
+            function transfer(address to, uint256 amount) external returns (bool);
+        }
+
+        let encoded = transferCall { to: recipient, amount }.abi_encode();
+        encoded.into()
+    }
 
     #[test]
     fn test_gas_balance_of_unwritten_storage_returns_zero() {
@@ -183,14 +203,81 @@ mod tests {
     }
 
     #[test]
-    fn test_gas_plus_transfer_success() {}
+    fn test_gas_plus_transfer_success() {
+        // Create a context with the gas contract
+        let mut ctx = SeismicContext::<DefaultSeismicDB>::seismic();
+
+        // Set up test addresses
+        let sender = Address::from([0x01; 20]);
+        let recipient = Address::from([0x02; 20]);
+        let treasury = TREASURY;
+
+        // Set initial balances
+        let sender_initial_balance = U256::from(1000000);
+        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        gas_set_balance::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut ctx,
+            sender,
+            sender_initial_balance,
+        )
+        .unwrap();
+
+        // make a transfer tx
+        let call_data = transfer_call_data(recipient, U256::from(10000));
+        let tx = ctx.modify_tx_chained(|tx| {
+            tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
+            tx.base.caller = sender;
+            tx.base.data = call_data;
+            tx.base.gas_limit = 100000;
+            tx.base.gas_price = 1;
+        });
+
+        
+        let inspector = TracerEip3155::new_stdout();
+        let mut evm = tx.build_seismic_evm_with_inspector(inspector);
+        let result = evm.inspect_replay().unwrap();
+
+        todo!("todo: check the result");
+        
+        // assert!(matches!(
+        //     result.result,
+        //     revm::context::result::ExecutionResult::Success { .. }
+        // ), "Transaction should succeed. Result: {:?}", result);
+
+        // // Check that resulting balances - need to use the context from the EVM
+        // let mut ctx = evm.ctx().clone();
+        // let sender_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+        //     &mut ctx,
+        //     sender,
+        // )
+        // .unwrap();
+        // let recipient_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+        //     &mut ctx,
+        //     recipient,
+        // )
+        // .unwrap();
+        // let treasury_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+        //     &mut ctx,
+        //     treasury,
+        // )
+        // .unwrap();
+
+        // // assert_eq!(sender_final_balance, sender_initial_balance.saturating_sub(U256::from(10000)));
+        // assert_eq!(recipient_final_balance, U256::from(10000));
+        // assert_eq!(treasury_final_balance, U256::ZERO);
+    }
 
     #[test]
-    fn test_treasury_and_beneficiary_rewards() {}
+    fn test_treasury_and_beneficiary_rewards() {
+    }
 
     #[test]
-    fn test_gas_plus_transfer_over_the_limit() {}
+    fn test_gas_plus_transfer_over_the_limit() {
+
+    }
 
     #[test]
-    fn test_gas_across_multiple_transactions() {}
+    fn test_gas_across_multiple_transactions() {
+
+    }
 }

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -74,12 +74,10 @@ where
         .data;
 
     if sender_balance < amount {
-        return Err(ERROR::from(
-            InvalidTransaction::LackOfFundForMaxFee {
-                fee: Box::new(amount),
-                balance: Box::new(sender_balance),
-            },
-        ));
+        return Err(ERROR::from(InvalidTransaction::LackOfFundForMaxFee {
+            fee: Box::new(amount),
+            balance: Box::new(sender_balance),
+        }));
     }
     // Subtract the amount from the sender's balance
     let sender_new_balance = sender_balance.saturating_sub(amount);
@@ -185,19 +183,14 @@ mod tests {
     }
 
     #[test]
-    fn test_gas_plus_transfer_success() {
-    }
+    fn test_gas_plus_transfer_success() {}
 
     #[test]
-    fn test_treasury_and_beneficiary_rewards() {
-    }
+    fn test_treasury_and_beneficiary_rewards() {}
 
     #[test]
-    fn test_gas_plus_transfer_over_the_limit() {
-    }
+    fn test_gas_plus_transfer_over_the_limit() {}
 
     #[test]
-    fn test_gas_across_multiple_transactions() {
-    }
-    
+    fn test_gas_across_multiple_transactions() {}
 }

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -206,7 +206,7 @@ mod tests {
         JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
 
         // make a transfer tx
-        let transfer_amount = U256::from(5000);
+        let transfer_amount = U256::from(20000);
         let call_data = transfer_call_data(recipient, transfer_amount);
         let tx = ctx.modify_tx_chained(|tx| {
             tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
@@ -266,7 +266,6 @@ mod tests {
         let sender = Address::from([0x01; 20]);
         let recipient = Address::from([0x02; 20]);
         let beneficiary = Address::from([0x03; 20]); // Block beneficiary (miner/validator)
-        let treasury = TREASURY;
 
         // Set initial balance for sender
         let sender_initial_balance = U256::from(1000000000);

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -344,7 +344,99 @@ mod tests {
 
     /// Test that if gas + transfer is over the limit, the transaction fails
     #[test]
-    fn test_gas_plus_transfer_over_the_limit() {}
+    fn test_gas_plus_transfer_over_the_limit() {
+        // Create a context with the gas contract
+        let mut ctx = SeismicContext::<DefaultSeismicDB>::seismic();
+
+        // Set up test addresses
+        let sender = Address::from([0x01; 20]);
+        let recipient = Address::from([0x02; 20]);
+
+        // Set initial balance that is too low to cover both transfer and gas
+        let sender_initial_balance = U256::from(200000); // 200k balance should cover gas, but not the transfer
+        let sender_balance_slot = gas_caller_key(sender);
+        ctx.db()
+            .insert_account_storage(
+                GAS_SRC20_ADDRESS,
+                sender_balance_slot,
+                FlaggedStorage::new(sender_initial_balance, true),
+            )
+            .unwrap();
+        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+
+        // Make a transfer tx
+        let transfer_amount = U256::from(190000); // 190k < 200k
+        let gas_price = 1; 
+        let gas_limit = 100000; // 190k + 100k > 200k
+        
+        let call_data = transfer_call_data(recipient, transfer_amount);
+        let tx = ctx.modify_tx_chained(|tx| {
+            tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
+            tx.base.caller = sender;
+            tx.base.data = call_data;
+            tx.base.gas_limit = gas_limit;
+            tx.base.gas_price = gas_price;
+        });
+        
+        let inspector = revm::inspector::NoOpInspector::default();
+        let mut evm = tx.build_seismic_evm_with_inspector(inspector);
+        let result = evm.inspect_replay_commit().unwrap();
+
+        // The transaction should fail due to insufficient funds
+        assert!(
+            matches!(
+                result,
+                revm::context::result::ExecutionResult::Revert { .. }
+            ),
+            "Transaction should fail due to insufficient funds. Result: {:?}",
+            result
+        );
+
+        // Verify that the sender's balance decreased by the gas spent
+        let mut post_tx_ctx = evm.ctx().clone();
+        JournalTr::load_account(post_tx_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        let sender_final_balance =
+            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(&mut post_tx_ctx, sender)
+                .unwrap();
+
+        let gas_spent = match result {
+            revm::context::result::ExecutionResult::Revert { gas_used, .. } => gas_used,
+            _ => unreachable!("Transaction should revert as checked above"),
+        };
+        let expected_gas_cost = U256::from(gas_spent * gas_price as u64);
+
+        assert_eq!(
+            sender_final_balance, sender_initial_balance.saturating_sub(expected_gas_cost),
+            "Sender balance should decrease by gas cost ({} tokens) when transaction fails. Expected: {}, Actual: {}",
+            expected_gas_cost, sender_initial_balance.saturating_sub(expected_gas_cost), sender_final_balance
+        );
+
+        // Verify that the recipient received nothing
+        let recipient_final_balance =
+            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+                &mut post_tx_ctx,
+                recipient,
+            )
+            .unwrap();
+
+        assert_eq!(
+            recipient_final_balance, U256::ZERO,
+            "Recipient should receive nothing when transaction fails"
+        );
+
+        // Verify that the treasury received the gas fees
+        let treasury_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx_ctx,
+            TREASURY,
+        )
+        .unwrap();
+
+        assert_eq!(
+            treasury_final_balance, U256::from(gas_spent),
+            "Treasury should receive the gas fees ({} tokens) when transaction fails",
+            gas_spent
+        );
+    }
 
     /// Test that state is persisted correctly across multiple transactions
     #[test]

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -250,7 +250,8 @@ mod tests {
             recipient_final_balance, transfer_amount,
             "recipient did not receive the transfer amount"
         );
-        let total_token = sender_final_balance + recipient_final_balance + treasury_final_balance;
+        let beneficiary_reward = U256::ZERO; // We do not set up the block beneficiary for this test
+        let total_token = sender_final_balance + recipient_final_balance + treasury_final_balance + beneficiary_reward;
         assert_eq!(
             total_token, sender_initial_balance,
             "Total token should be conserved in a tx"
@@ -325,6 +326,22 @@ mod tests {
         let mut post_tx_ctx = evm.ctx().clone();
         JournalTr::load_account(post_tx_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
 
+        let sender_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx_ctx,
+            sender,
+        )
+        .unwrap();
+        let recipient_final_balance =
+        gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx_ctx,
+            recipient,
+        )
+        .unwrap();
+        let treasury_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx_ctx,
+            TREASURY,
+        )
+        .unwrap();
         let beneficiary_final_balance =
             gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
                 &mut post_tx_ctx,
@@ -356,6 +373,11 @@ mod tests {
             beneficiary_final_balance, U256::from(expected_reward),
             "Beneficiary should receive exactly {} tokens as gas rewards (gas_spent: {}, coinbase_gas_price: {})",
             expected_reward, gas_spent, coinbase_gas_price
+        );
+        let total_token = sender_final_balance + recipient_final_balance + treasury_final_balance + beneficiary_final_balance;
+        assert_eq!(
+            total_token, sender_initial_balance,
+            "Total token should be conserved in a tx"
         );
     }
 

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -164,7 +164,9 @@ mod tests {
     use revm::primitives::{Bytes, U256};
     use std::convert::Infallible;
     use revm::inspector::{InspectEvm};
+    use revm::InspectCommitEvm;
     use revm::handler::EvmTr;
+    use revm::primitives::FlaggedStorage;
 
     fn transfer_call_data(recipient: Address, amount: U256) -> Bytes {
         // Function selector for transfer(saddress,suint256)
@@ -190,18 +192,16 @@ mod tests {
         let recipient = Address::from([0x02; 20]);
         let treasury = TREASURY;
 
-        // Set initial balances
+        // Set initial balance
         let sender_initial_balance = U256::from(1000000);
+        let sender_balance_slot = gas_caller_key(sender);
+        ctx.db()
+            .insert_account_storage(GAS_SRC20_ADDRESS, sender_balance_slot, FlaggedStorage::new(sender_initial_balance, true))
+            .unwrap();
         JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
-        gas_set_balance::<_, EVMError<Infallible, InvalidTransaction>>(
-            &mut ctx,
-            sender,
-            sender_initial_balance,
-        )
-        .unwrap();
-
+        
         // make a transfer tx
-        let call_data = transfer_call_data(recipient, U256::from(10000));
+        let call_data = transfer_call_data(recipient, U256::from(5000));
         let tx = ctx.modify_tx_chained(|tx| {
             tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
             tx.base.caller = sender;
@@ -209,36 +209,36 @@ mod tests {
             tx.base.gas_limit = 100000;
             tx.base.gas_price = 1;
         });
-
         let inspector = revm::inspector::NoOpInspector::default(); // use revm::inspector::inspectors::TracerEip3155::new_stdout() for more detailed output
         let mut evm = tx.build_seismic_evm_with_inspector(inspector);
-        let result = evm.inspect_replay().unwrap();
+        let result = evm.inspect_replay_commit().unwrap();
 
         assert!(matches!(
-            result.result,
+            result,
             revm::context::result::ExecutionResult::Success { .. }
-        ), "Transaction should succeed. Result: {:?}", result.result);
+        ), "Transaction should succeed. Result: {:?}", result);
 
-        // Check that resulting balances - need to use the context from the EVM
-        let mut ctx = evm.ctx().clone();
-        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        // Check the balances in the resulting evm context
+        let mut post_tx_ctx = evm.ctx().clone();
+        JournalTr::load_account(post_tx_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
         let sender_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
-            &mut ctx,
+            &mut post_tx_ctx,
             sender,
         )
         .unwrap();
         let recipient_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
-            &mut ctx,
+            &mut post_tx_ctx,
             recipient,
         )
         .unwrap();
         let treasury_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
-            &mut ctx,
+            &mut post_tx_ctx,
             treasury,
         )
         .unwrap();
 
-        // assert_eq!(sender_final_balance, sender_initial_balance.saturating_sub(U256::from(10000)));
+        assert_ne!(sender_final_balance, U256::ZERO, "Sender balance should not be zero");
+        assert_eq!(sender_final_balance, sender_initial_balance.saturating_sub(U256::from(10000)));
         assert_eq!(recipient_final_balance, U256::from(10000));
         assert_eq!(treasury_final_balance, U256::ZERO);
     }

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -703,7 +703,68 @@ mod tests {
 
     #[test]
     fn test_insufficient_balance_for_gas_limit() {
-        todo!()
+        // Create a context with the gas contract
+        let mut ctx = SeismicContext::<DefaultSeismicDB>::seismic();
+
+        // Set up test addresses
+        let sender = Address::from([0x01; 20]);
+        let recipient = Address::from([0x02; 20]);
+
+        // Set initial balance that is enough for transfer but not enough for gas limit
+        let transfer_amount = U256::from(50000);
+        let gas_limit = 100000;
+        let gas_price = 1;
+        let max_gas_cost = U256::from(gas_limit * gas_price as u64);
+        let total_required = transfer_amount + max_gas_cost;
+        
+        // Set balance to be less than total required but more than transfer amount
+        let sender_initial_balance = transfer_amount + U256::from(10000); // 60k total, needs 150k
+        
+        let sender_balance_slot = gas_caller_key(sender);
+        ctx.db()
+            .insert_account_storage(
+                GAS_SRC20_ADDRESS,
+                sender_balance_slot,
+                FlaggedStorage::new(sender_initial_balance, true),
+            )
+            .unwrap();
+        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+
+        // Verify initial state
+        let initial_sender_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut ctx,
+            sender,
+        )
+        .unwrap();
+        assert_eq!(
+            initial_sender_balance, sender_initial_balance,
+            "Initial sender balance should match"
+        );
+        assert!(
+            sender_initial_balance < total_required,
+            "Sender should have insufficient balance for gas limit + transfer"
+        );
+        assert!(
+            sender_initial_balance > transfer_amount,
+            "Sender should have enough balance for transfer alone"
+        );
+
+        // Attempt transaction with insufficient balance for gas limit
+        let call_data = transfer_call_data(recipient, transfer_amount);
+        let tx = ctx.modify_tx_chained(|tx| {
+            tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
+            tx.base.caller = sender;
+            tx.base.data = call_data;
+            tx.base.gas_limit = gas_limit;
+            tx.base.gas_price = gas_price;
+            tx.base.nonce = 0;
+        });
+        
+        let inspector = revm::inspector::NoOpInspector::default();
+        let mut evm = tx.build_seismic_evm_with_inspector(inspector);
+        let result = evm.inspect_replay_commit();
+
+        assert!(result.is_err(), "Transaction should fail due to LackOfFundForMaxFee");
     }
 
     /// Test that if the storage slot is not written, the balance is 0

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -163,7 +163,7 @@ mod tests {
     use revm::handler::EvmTr;
     use revm::primitives::FlaggedStorage;
     use revm::primitives::TxKind;
-    use revm::primitives::{Bytes, U256};
+    use revm::primitives::{Bytes, U256, b256, B256};
     use revm::InspectCommitEvm;
     use std::convert::Infallible;
 
@@ -787,5 +787,16 @@ mod tests {
             U256::ZERO,
             "Balance should be zero for unwritten storage slot"
         );
+    }
+
+    #[test]
+    fn test_map_storage() {
+        let alice = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+        let storage_slot = map_storage(alice, 0);
+        let storage_slot_b256: B256 = storage_slot.into();
+
+        let expected_key: B256 = b256!("0x723077b8a1b173adc35e5f0e7e3662fd1208212cb629f9c128551ea7168da722");
+
+        assert_eq!(storage_slot_b256, expected_key);
     }
 }

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -1,7 +1,7 @@
 //! This module contains the logic for the GAS_SRC20 token contract.
 //! Seismic uses a custom ERC20 token contract to handle gas fees
 
-use alloy_sol_types::{SolValue};
+use alloy_sol_types::SolValue;
 use anyhow::Result;
 use revm::{
     bytecode::Bytecode,
@@ -157,49 +157,27 @@ pub fn gas_contract_account_info() -> revm::state::AccountInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::builder::SeismicBuilder;
     use crate::api::default_ctx::{DefaultSeismicContext, DefaultSeismicDB, SeismicContext};
     use revm::context::result::{EVMError, InvalidTransaction};
-    use std::convert::Infallible;
-    use crate::api::builder::SeismicBuilder;
-    use revm::{
-        primitives::{Bytes, U256},
-    };
     use revm::primitives::TxKind;
-    use alloy_sol_types::{sol, SolCall};
-
-    use revm::{
-        inspector::{InspectEvm, inspectors::TracerEip3155},
-    };
-
+    use revm::primitives::{Bytes, U256};
+    use std::convert::Infallible;
+    use revm::inspector::{InspectEvm};
+    use revm::handler::EvmTr;
 
     fn transfer_call_data(recipient: Address, amount: U256) -> Bytes {
-        sol! {
-            function transfer(address to, uint256 amount) external returns (bool);
-        }
+        // Function selector for transfer(saddress,suint256)
+        let selector = bytes!("0x8cdb7b34");
 
-        let encoded = transferCall { to: recipient, amount }.abi_encode();
-        encoded.into()
-    }
+        // ABI encode just the arguments (not including selector)
+        let encoded_args = (recipient, amount).abi_encode();
 
-    #[test]
-    fn test_gas_balance_of_unwritten_storage_returns_zero() {
-        // Create a context with the gas contract
-        let mut ctx = SeismicContext::<DefaultSeismicDB>::seismic();
+        // Concatenate selector and encoded args
+        let mut data = selector.to_vec();
+        data.extend_from_slice(&encoded_args);
 
-        // Try to get balance for an address that has never had any balance set
-        // This should return 0 even though the storage slot has never been written to
-        let test_address = Address::from([0x42; 20]);
-
-        // This should return 0, not panic
-        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
-        let balance =
-            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(&mut ctx, test_address)
-                .unwrap();
-        assert_eq!(
-            balance,
-            U256::ZERO,
-            "Balance should be zero for unwritten storage slot"
-        );
+        data.into()
     }
 
     #[test]
@@ -232,52 +210,66 @@ mod tests {
             tx.base.gas_price = 1;
         });
 
-        
-        let inspector = TracerEip3155::new_stdout();
+        let inspector = revm::inspector::NoOpInspector::default(); // use revm::inspector::inspectors::TracerEip3155::new_stdout() for more detailed output
         let mut evm = tx.build_seismic_evm_with_inspector(inspector);
         let result = evm.inspect_replay().unwrap();
 
-        todo!("todo: check the result");
-        
-        // assert!(matches!(
-        //     result.result,
-        //     revm::context::result::ExecutionResult::Success { .. }
-        // ), "Transaction should succeed. Result: {:?}", result);
+        assert!(matches!(
+            result.result,
+            revm::context::result::ExecutionResult::Success { .. }
+        ), "Transaction should succeed. Result: {:?}", result.result);
 
-        // // Check that resulting balances - need to use the context from the EVM
-        // let mut ctx = evm.ctx().clone();
-        // let sender_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
-        //     &mut ctx,
-        //     sender,
-        // )
-        // .unwrap();
-        // let recipient_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
-        //     &mut ctx,
-        //     recipient,
-        // )
-        // .unwrap();
-        // let treasury_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
-        //     &mut ctx,
-        //     treasury,
-        // )
-        // .unwrap();
+        // Check that resulting balances - need to use the context from the EVM
+        let mut ctx = evm.ctx().clone();
+        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        let sender_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut ctx,
+            sender,
+        )
+        .unwrap();
+        let recipient_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut ctx,
+            recipient,
+        )
+        .unwrap();
+        let treasury_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut ctx,
+            treasury,
+        )
+        .unwrap();
 
-        // // assert_eq!(sender_final_balance, sender_initial_balance.saturating_sub(U256::from(10000)));
-        // assert_eq!(recipient_final_balance, U256::from(10000));
-        // assert_eq!(treasury_final_balance, U256::ZERO);
+        // assert_eq!(sender_final_balance, sender_initial_balance.saturating_sub(U256::from(10000)));
+        assert_eq!(recipient_final_balance, U256::from(10000));
+        assert_eq!(treasury_final_balance, U256::ZERO);
     }
 
     #[test]
-    fn test_treasury_and_beneficiary_rewards() {
-    }
+    fn test_treasury_and_beneficiary_rewards() {}
 
     #[test]
-    fn test_gas_plus_transfer_over_the_limit() {
-
-    }
+    fn test_gas_plus_transfer_over_the_limit() {}
 
     #[test]
-    fn test_gas_across_multiple_transactions() {
+    fn test_gas_across_multiple_transactions() {}
 
+    #[test]
+    fn test_gas_balance_of_unwritten_storage_returns_zero() {
+        // Create a context with the gas contract
+        let mut ctx = SeismicContext::<DefaultSeismicDB>::seismic();
+
+        // Try to get balance for an address that has never had any balance set
+        // This should return 0 even though the storage slot has never been written to
+        let test_address = Address::from([0x42; 20]);
+
+        // This should return 0, not panic
+        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        let balance =
+            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(&mut ctx, test_address)
+                .unwrap();
+        assert_eq!(
+            balance,
+            U256::ZERO,
+            "Balance should be zero for unwritten storage slot"
+        );
     }
 }

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -163,7 +163,7 @@ mod tests {
     use revm::handler::EvmTr;
     use revm::primitives::FlaggedStorage;
     use revm::primitives::TxKind;
-    use revm::primitives::{Bytes, U256, b256, B256};
+    use revm::primitives::{b256, Bytes, B256, U256};
     use revm::InspectCommitEvm;
     use std::convert::Infallible;
 
@@ -246,14 +246,24 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(recipient_final_balance, transfer_amount, "recipient did not receive the transfer amount");
+        assert_eq!(
+            recipient_final_balance, transfer_amount,
+            "recipient did not receive the transfer amount"
+        );
         let total_token = sender_final_balance + recipient_final_balance + treasury_final_balance;
         assert_eq!(
             total_token, sender_initial_balance,
             "Total token should be conserved in a tx"
         );
-        assert!(sender_final_balance < sender_initial_balance - transfer_amount, "sender should have paid more than just the transfer amount due to gas");
-        assert_eq!(treasury_final_balance, U256::from(result.gas_used()), "treasury should have received the gas fees");
+        assert!(
+            sender_final_balance < sender_initial_balance - transfer_amount,
+            "sender should have paid more than just the transfer amount due to gas"
+        );
+        assert_eq!(
+            treasury_final_balance,
+            U256::from(result.gas_used()),
+            "treasury should have received the gas fees"
+        );
     }
 
     /// Test that beneficiary rewards are distributed correctly
@@ -281,21 +291,23 @@ mod tests {
 
         // Set up transaction with specific gas parameters
         let gas_limit = 100000;
-        let gas_price = 10; 
+        let gas_price = 10;
         let basefee = 2;
-        
+
         let call_data = transfer_call_data(recipient, U256::from(5000));
-        let tx = ctx.modify_tx_chained(|tx| {
-            tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
-            tx.base.caller = sender;
-            tx.base.data = call_data;
-            tx.base.gas_limit = gas_limit;
-            tx.base.gas_price = gas_price;
-        }).modify_block_chained(|block| {
-            block.beneficiary = beneficiary;
-            block.basefee = basefee;
-        });
-        
+        let tx = ctx
+            .modify_tx_chained(|tx| {
+                tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
+                tx.base.caller = sender;
+                tx.base.data = call_data;
+                tx.base.gas_limit = gas_limit;
+                tx.base.gas_price = gas_price;
+            })
+            .modify_block_chained(|block| {
+                block.beneficiary = beneficiary;
+                block.basefee = basefee;
+            });
+
         let inspector = revm::inspector::NoOpInspector::default();
         let mut evm = tx.build_seismic_evm_with_inspector(inspector);
         let result = evm.inspect_replay_commit().unwrap();
@@ -312,13 +324,14 @@ mod tests {
         // Check the balances in the resulting evm context
         let mut post_tx_ctx = evm.ctx().clone();
         JournalTr::load_account(post_tx_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
-        
-        let beneficiary_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
-            &mut post_tx_ctx,
-            beneficiary,
-        )
-        .unwrap();
-    
+
+        let beneficiary_final_balance =
+            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+                &mut post_tx_ctx,
+                beneficiary,
+            )
+            .unwrap();
+
         // Verify that the beneficiary received rewards
         assert!(
             beneficiary_final_balance > U256::ZERO,
@@ -328,12 +341,17 @@ mod tests {
         // Calculate the exact expected beneficiary rewards
         let gas_spent = result.gas_used();
         let gas_refunded = match result {
-            revm::context::result::ExecutionResult::Success { gas_used: _, gas_refunded, .. } => gas_refunded,
+            revm::context::result::ExecutionResult::Success {
+                gas_used: _,
+                gas_refunded,
+                ..
+            } => gas_refunded,
             _ => unreachable!("Transaction should succeed as checked above"),
         };
         let coinbase_gas_price = gas_price.saturating_sub(basefee as u128);
-        let expected_reward = coinbase_gas_price.saturating_mul((gas_spent - gas_refunded as u64) as u128);
-        
+        let expected_reward =
+            coinbase_gas_price.saturating_mul((gas_spent - gas_refunded as u64) as u128);
+
         assert_eq!(
             beneficiary_final_balance, U256::from(expected_reward),
             "Beneficiary should receive exactly {} tokens as gas rewards (gas_spent: {}, coinbase_gas_price: {})",
@@ -365,9 +383,9 @@ mod tests {
 
         // Make a transfer tx
         let transfer_amount = U256::from(190000); // 190k < 200k
-        let gas_price = 1; 
+        let gas_price = 1;
         let gas_limit = 100000; // 190k + 100k > 200k
-        
+
         let call_data = transfer_call_data(recipient, transfer_amount);
         let tx = ctx.modify_tx_chained(|tx| {
             tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
@@ -376,7 +394,7 @@ mod tests {
             tx.base.gas_limit = gas_limit;
             tx.base.gas_price = gas_price;
         });
-        
+
         let inspector = revm::inspector::NoOpInspector::default();
         let mut evm = tx.build_seismic_evm_with_inspector(inspector);
         let result = evm.inspect_replay_commit().unwrap();
@@ -419,7 +437,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            recipient_final_balance, U256::ZERO,
+            recipient_final_balance,
+            U256::ZERO,
             "Recipient should receive nothing when transaction fails"
         );
 
@@ -431,7 +450,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            treasury_final_balance, U256::from(gas_spent),
+            treasury_final_balance,
+            U256::from(gas_spent),
             "Treasury should receive the gas fees ({} tokens) when transaction fails",
             gas_spent
         );
@@ -462,11 +482,9 @@ mod tests {
         JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
 
         // Verify initial state
-        let initial_sender_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
-            &mut ctx,
-            sender,
-        )
-        .unwrap();
+        let initial_sender_balance =
+            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(&mut ctx, sender)
+                .unwrap();
         assert_eq!(
             initial_sender_balance, sender_initial_balance,
             "Initial sender balance should match"
@@ -483,7 +501,7 @@ mod tests {
             tx.base.gas_price = 1;
             tx.base.nonce = 0;
         });
-        
+
         let inspector1 = revm::inspector::NoOpInspector::default();
         let mut evm1 = tx1.build_seismic_evm_with_inspector(inspector1);
         let result1 = evm1.inspect_replay_commit().unwrap();
@@ -500,7 +518,7 @@ mod tests {
         // Check balances after first transaction
         let mut post_tx1_ctx = evm1.ctx().clone();
         JournalTr::load_account(post_tx1_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
-        
+
         let recipient1_after_tx1 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
             &mut post_tx1_ctx,
             recipient1,
@@ -523,7 +541,8 @@ mod tests {
             "Recipient1 should receive the transfer amount"
         );
         assert_eq!(
-            treasury_after_tx1, U256::from(gas_used1),
+            treasury_after_tx1,
+            U256::from(gas_used1),
             "Treasury should receive gas fees from first transaction"
         );
 
@@ -538,7 +557,7 @@ mod tests {
             tx.base.gas_price = 1;
             tx.base.nonce = 0;
         });
-        
+
         let inspector2 = revm::inspector::NoOpInspector::default();
         let mut evm2 = tx2.build_seismic_evm_with_inspector(inspector2);
         let result2 = evm2.inspect_replay_commit().unwrap();
@@ -555,7 +574,7 @@ mod tests {
         // Check balances after second transaction
         let mut post_tx2_ctx = evm2.ctx().clone();
         JournalTr::load_account(post_tx2_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
-        
+
         let sender_after_tx2 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
             &mut post_tx2_ctx,
             sender,
@@ -588,12 +607,14 @@ mod tests {
             "Recipient2 should receive the transfer amount"
         );
         assert_eq!(
-            recipient1_after_tx2, 
-            recipient1_after_tx1.saturating_sub(transfer2_amount).saturating_sub(U256::from(gas_used2)),
+            recipient1_after_tx2,
+            recipient1_after_tx1
+                .saturating_sub(transfer2_amount)
+                .saturating_sub(U256::from(gas_used2)),
             "Recipient1 should have balance reduced by transfer amount plus gas fees"
         );
         assert_eq!(
-            treasury_after_tx2, 
+            treasury_after_tx2,
             treasury_after_tx1.saturating_add(U256::from(gas_used2)),
             "Treasury should accumulate gas fees from both transactions"
         );
@@ -609,7 +630,7 @@ mod tests {
             tx.base.gas_price = 1;
             tx.base.nonce = 1;
         });
-        
+
         let inspector3 = revm::inspector::NoOpInspector::default();
         let mut evm3 = tx3.build_seismic_evm_with_inspector(inspector3);
         let result3 = evm3.inspect_replay_commit().unwrap();
@@ -626,7 +647,7 @@ mod tests {
         // Check balances after failed transaction
         let mut post_tx3_ctx = evm3.ctx().clone();
         JournalTr::load_account(post_tx3_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
-        
+
         let recipient1_after_tx3 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
             &mut post_tx3_ctx,
             recipient1,
@@ -654,18 +675,19 @@ mod tests {
             "Recipient2 balance should not change after failed transaction"
         );
         assert_eq!(
-            recipient1_after_tx3, 
+            recipient1_after_tx3,
             recipient1_after_tx2.saturating_sub(U256::from(gas_used3)),
             "Recipient1 should lose gas fees even when transaction fails"
         );
         assert_eq!(
-            treasury_after_tx3, 
+            treasury_after_tx3,
             treasury_after_tx2.saturating_add(U256::from(gas_used3)),
             "Treasury should receive gas fees even from failed transaction"
         );
 
         // Verify total token conservation across all transactions
-        let total_final_balance = sender_after_tx2 + recipient1_after_tx3 + recipient2_after_tx3 + treasury_after_tx3;
+        let total_final_balance =
+            sender_after_tx2 + recipient1_after_tx3 + recipient2_after_tx3 + treasury_after_tx3;
         assert_eq!(
             total_final_balance, sender_initial_balance,
             "Total token balance should be conserved across all transactions. Expected: {}, Actual: {}",
@@ -716,10 +738,10 @@ mod tests {
         let gas_price = 1;
         let max_gas_cost = U256::from(gas_limit * gas_price as u64);
         let total_required = transfer_amount + max_gas_cost;
-        
+
         // Set balance to be less than total required but more than transfer amount
         let sender_initial_balance = transfer_amount + U256::from(10000); // 60k total, needs 150k
-        
+
         let sender_balance_slot = gas_caller_key(sender);
         ctx.db()
             .insert_account_storage(
@@ -731,11 +753,9 @@ mod tests {
         JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
 
         // Verify initial state
-        let initial_sender_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
-            &mut ctx,
-            sender,
-        )
-        .unwrap();
+        let initial_sender_balance =
+            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(&mut ctx, sender)
+                .unwrap();
         assert_eq!(
             initial_sender_balance, sender_initial_balance,
             "Initial sender balance should match"
@@ -759,12 +779,15 @@ mod tests {
             tx.base.gas_price = gas_price;
             tx.base.nonce = 0;
         });
-        
+
         let inspector = revm::inspector::NoOpInspector::default();
         let mut evm = tx.build_seismic_evm_with_inspector(inspector);
         let result = evm.inspect_replay_commit();
 
-        assert!(result.is_err(), "Transaction should fail due to LackOfFundForMaxFee");
+        assert!(
+            result.is_err(),
+            "Transaction should fail due to LackOfFundForMaxFee"
+        );
     }
 
     #[test]
@@ -803,10 +826,7 @@ mod tests {
         let result = evm.inspect_replay_commit().unwrap();
 
         assert!(
-            matches!(
-                result,
-                revm::context::result::ExecutionResult::Halt { .. }
-            ),
+            matches!(result, revm::context::result::ExecutionResult::Halt { .. }),
             "Transaction should fail. Result: {:?}",
             result
         );
@@ -829,13 +849,21 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(recipient_final_balance, U256::ZERO, "recipient should not have received any tokens");
+        assert_eq!(
+            recipient_final_balance,
+            U256::ZERO,
+            "recipient should not have received any tokens"
+        );
         let total_token = sender_final_balance + recipient_final_balance + treasury_final_balance;
         assert_eq!(
             total_token, sender_initial_balance,
             "Total token should be conserved in a tx"
         );
-        assert_eq!(sender_initial_balance, sender_final_balance + treasury_final_balance, "only movement of funds should be gas spent from sender to treasury");
+        assert_eq!(
+            sender_initial_balance,
+            sender_final_balance + treasury_final_balance,
+            "only movement of funds should be gas spent from sender to treasury"
+        );
     }
 
     /// Test that if the storage slot is not written, the balance is 0
@@ -866,7 +894,8 @@ mod tests {
         let storage_slot = map_storage(alice, 0);
         let storage_slot_b256: B256 = storage_slot.into();
 
-        let expected_key: B256 = b256!("0x723077b8a1b173adc35e5f0e7e3662fd1208212cb629f9c128551ea7168da722");
+        let expected_key: B256 =
+            b256!("0x723077b8a1b173adc35e5f0e7e3662fd1208212cb629f9c128551ea7168da722");
 
         assert_eq!(storage_slot_b256, expected_key);
     }

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -1,0 +1,200 @@
+//! This module contains the logic for the GAS_SRC20 token contract.
+//! Seismic uses a custom ERC20 token contract to handle gas fees
+
+use alloy_sol_types::SolValue;
+use anyhow::Result;
+use revm::{
+    bytecode::Bytecode,
+    context_interface::{
+        result::{InvalidHeader, InvalidTransaction},
+        ContextTr, JournalTr,
+    },
+    primitives::{address, bytes, keccak256, Address, Bytes, U256},
+    state::AccountInfo,
+    Database,
+};
+
+// ********** GAS_SRC20 constants **********
+/// The address of the GAS_SRC20 contract
+pub const GAS_SRC20_ADDRESS: Address = address!("1000000000000000000000000000000000000003");
+/// The storage slot of the balances mapping in the GAS_SRC20 contract
+pub const GAS_SRC20_BALANCE_SLOT: u64 = 0;
+/// The code of the GAS_SRC20 contract
+pub const GAS_SRC20_CODE: Bytes = bytes!("0x608060405234801561000f575f5ffd5b50600436106100fb575f3560e01c80635687f2b81161009357806395d89b411161006357806395d89b4114610218578063aa8beaf014610238578063be09129c1461024b578063f43064fb1461025e575f5ffd5b80635687f2b8146101a85780635f84a3cd146101df57806388412c20146101f25780638cdb7b3414610205575f5ffd5b8063221b7180116100ce578063221b71801461019557806323de6651146101a8578063313ce567146101bd5780633ab43673146101cc575f5ffd5b806306fdde03146100ff57806314f228031461013857806318160ddd1461015b5780632176518a1461016b575b5f5ffd5b60408051808201909152600b81526a577261707065642047617360a81b60208201525b60405161012f9190610734565b60405180910390f35b61014b610146366004610780565b610271565b604051901515815260200161012f565b5f5b60405190815260200161012f565b61017e6101793660046107aa565b6102ef565b60408051921515835260208301919091520161012f565b61015d6101a33660046107e1565b61035d565b6101bb6101b6366004610803565b505050565b005b6040516012815260200161012f565b61017e6101da3660046107e1565b6103a2565b61015d6101ed3660046107aa565b6103dc565b61014b610200366004610780565b610437565b61014b610213366004610780565b61044e565b6040805180820190915260048152635747415360e01b6020820152610122565b61014b610246366004610780565b61045b565b61014b610259366004610803565b610495565b61014b61026c366004610780565b6104b8565b335f8181526001602090815260408083206001600160a01b03871684529091528120b0909190838110156102d557604051637dc7a0d960e11b81526001600160a01b03861660048201525f6024820181905260448201526064015b60405180910390fd5b6102e282868684036104cc565b6001925050505b92915050565b5f80336001600160a01b03851681148061031a5750836001600160a01b0316816001600160a01b0316145b1561034e575050506001600160a01b038083165f9081526001602081815260408084209486168452939052919020b0610356565b5f5f92509250505b9250929050565b5f336001600160a01b0383160361038957506001600160a01b03165f908152602081905260409020b090565b60405163263e159360e11b815260040160405180910390fd5b5f80336001600160a01b038416036103d25750506001600160a01b03165f908152602081905260409020b0600191565b505f928392509050565b5f336001600160a01b0384168114806104065750826001600160a01b0316816001600160a01b0316145b156103895750506001600160a01b038083165f908152600160209081526040808320938516835292905220b06102e9565b5f336104448185856104cc565b5060019392505050565b5f3361044481858561054e565b335f8181526001602090815260408083206001600160a01b03871684529091528120b09091906102e282866104908785610855565b6104cc565b5f336104a28582856105ab565b6104ad85858561054e565b506001949350505050565b5f6104c38383610625565b50600192915050565b6001600160a01b0383166104f55760405163e602df0560e01b81525f60048201526024016102cc565b6001600160a01b03821661051e57604051634a1406b160e11b81525f60048201526024016102cc565b6001600160a01b038084165f9081526001602090815260408083209386168352929052208190b16101b683838383565b6001600160a01b03831661057757604051634b637e8f60e11b81525f60048201526024016102cc565b6001600160a01b0382166105a05760405163ec442f0560e01b81525f60048201526024016102cc565b6101b683838361065d565b6001600160a01b038084165f908152600160209081526040808320938616835292905220b05f1981101561061f578181101561061257604051637dc7a0d960e11b81526001600160a01b03841660048201525f6024820181905260448201526064016102cc565b61061f84848484036104cc565b50505050565b6001600160a01b03821661064e5760405163ec442f0560e01b81525f60048201526024016102cc565b6106595f838361065d565b5050565b6001600160a01b038316610687578060025f82825461067c9190610855565b909155506106f69050565b6001600160a01b0383165f908152602081905260409020b0818110156106d85760405163391434e360e21b81526001600160a01b03851660048201525f6024820181905260448201526064016102cc565b6001600160a01b0384165f9081526020819052604090209082900390b15b6001600160a01b03821661071257600280548290039055505050565b6001600160a01b0382165f90815260208190526040902080b0820190b1505050565b602081525f82518060208401528060208501604085015e5f604082850101526040601f19601f83011684010191505092915050565b6001600160a01b038116811461077d575f5ffd5b50565b5f5f60408385031215610791575f5ffd5b823561079c81610769565b946020939093013593505050565b5f5f604083850312156107bb575f5ffd5b82356107c681610769565b915060208301356107d681610769565b809150509250929050565b5f602082840312156107f1575f5ffd5b81356107fc81610769565b9392505050565b5f5f5f60608486031215610815575f5ffd5b833561082081610769565b9250602084013561083081610769565b929592945050506040919091013590565b634e487b7160e01b5f52601160045260245ffd5b808201808211156102e9576102e961084156fea26469706673582212204a01d1adaa4e7bd539c389daeea5cb99e1fd2f73b65a98e415c7b17605f932c764736f6c637828302e382e32382d646576656c6f702e323032352e322e31332b636f6d6d69742e39363462353035320059");
+/// The amount of gas covered by a single GAS_SRC20
+/// The goal is to denominate the token in USD, and have 21000 GAS cost 1 cent
+pub const GAS_SRC20_CONVERATION_RATIO: u64 = 2100000;
+/// Treasury address for gas fees
+pub const TREASURY: Address = Address::new([0u8; 20]); // TODO: update this to a seismic controlled address
+
+/// Computes the storage slot for solidity mapping
+///
+/// This function calculates the keccak256 hash of the concatenated padded address and slot number,
+/// which is the standard way to compute storage slots for Solidity mappings.
+///
+/// # Arguments
+/// * `address` - The address to compute the storage slot for
+/// * `slot_number` - The slot number (usually 0 for _balances mapping)
+///
+/// # Returns
+/// The storage slot as a B256 (32-byte array)
+pub fn map_storage(address: Address, slot: u64) -> U256 {
+    keccak256((address, U256::from(slot)).abi_encode()).into()
+}
+
+pub fn gas_caller_key(caller: Address) -> U256 {
+    map_storage(caller, GAS_SRC20_BALANCE_SLOT)
+}
+
+/// Transfers SRC20 gas tokens from one address to another by modifying the balances mapping in storage.
+///
+/// This function performs a confidential token transfer operation using Seismic's confidential storage
+/// operations (`cload` and `cstore`). It transfers the specified amount from the sender's balance to
+/// the recipient's balance within the SRC20 token contract's storage.
+///
+/// # Returns
+///
+/// Returns `Ok(())` on successful transfer, or an error if:
+/// * The sender has insufficient balance
+/// * A storage operation fails
+pub fn gas_token_operation<CTX, ERROR>(
+    context: &mut CTX,
+    sender: Address,
+    recipient: Address,
+    amount: U256,
+) -> Result<(), ERROR>
+where
+    CTX: ContextTr,
+    ERROR: From<InvalidTransaction> + From<InvalidHeader> + From<<CTX::Db as Database>::Error>,
+{
+    let sender_balance_slot = gas_caller_key(sender);
+    let sender_balance = context
+        .journal()
+        .cload(GAS_SRC20_ADDRESS, sender_balance_slot)?
+        .data;
+
+    if sender_balance < amount {
+        return Err(ERROR::from(
+            InvalidTransaction::MaxFeePerBlobGasNotSupported, // TODO: this error seems wrong
+        ));
+    }
+    // Subtract the amount from the sender's balance
+    let sender_new_balance = sender_balance.saturating_sub(amount);
+    context
+        .journal()
+        .cstore(GAS_SRC20_ADDRESS, sender_balance_slot, sender_new_balance)?;
+
+    // Add the amount to the recipient's balance
+    let recipient_balance_slot = gas_caller_key(recipient);
+    let recipient_balance = context
+        .journal()
+        .cload(GAS_SRC20_ADDRESS, recipient_balance_slot)?
+        .data;
+
+    let recipient_new_balance = recipient_balance.saturating_add(amount);
+    context.journal().cstore(
+        GAS_SRC20_ADDRESS,
+        recipient_balance_slot,
+        recipient_new_balance,
+    )?;
+
+    Ok(())
+}
+
+/// Sets the balance of a given address to a specific amount in the GAS_SRC20 token contract.
+pub fn gas_set_balance<CTX, ERROR>(
+    context: &mut CTX,
+    address: Address,
+    amount: U256,
+) -> Result<(), ERROR>
+where
+    CTX: ContextTr,
+    ERROR: From<InvalidTransaction> + From<InvalidHeader> + From<<CTX::Db as Database>::Error>,
+{
+    let balance_slot = gas_caller_key(address);
+    context
+        .journal()
+        .cstore(GAS_SRC20_ADDRESS, balance_slot, amount)?;
+
+    Ok(())
+}
+
+/// Get the balance of an address from the GAS_SRC20 token contract
+///
+/// This reads the active balance from the journal, as opposed to the db's persistent balance
+///
+/// # Returns
+/// The balance as U256 wrapped in a Result
+pub fn gas_balance_of<CTX, ERROR>(context: &mut CTX, address: Address) -> Result<U256, ERROR>
+where
+    CTX: ContextTr,
+    ERROR: From<InvalidTransaction> + From<InvalidHeader> + From<<CTX::Db as Database>::Error>,
+{
+    let key = gas_caller_key(address);
+    let storage = context.journal().cload(GAS_SRC20_ADDRESS, key)?;
+    Ok(storage.data)
+}
+
+/// Creates the expected AccountInfo for the GAS_SRC20 contract.
+///
+/// This function creates the account info with the proper bytecode and code hash
+/// for the gas contract, which can then be inserted into a database.
+pub fn gas_contract_account_info() -> revm::state::AccountInfo {
+    // Create the bytecode from the hex string
+    let bytecode = Bytecode::new_raw(GAS_SRC20_CODE);
+    let code_hash = bytecode.hash_slow();
+
+    // Create the account info for the gas contract
+    AccountInfo {
+        balance: U256::ZERO,
+        nonce: 0,
+        code: Some(bytecode),
+        code_hash,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::default_ctx::{DefaultSeismicContext, DefaultSeismicDB, SeismicContext};
+    use revm::context::result::{EVMError, InvalidTransaction};
+    use std::convert::Infallible;
+
+    #[test]
+    fn test_gas_balance_of_unwritten_storage_returns_zero() {
+        // Create a context with the gas contract
+        let mut ctx = SeismicContext::<DefaultSeismicDB>::seismic();
+
+        // Try to get balance for an address that has never had any balance set
+        // This should return 0 even though the storage slot has never been written to
+        let test_address = Address::from([0x42; 20]);
+
+        // This should return 0, not panic
+        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        let balance =
+            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(&mut ctx, test_address)
+                .unwrap();
+        assert_eq!(
+            balance,
+            U256::ZERO,
+            "Balance should be zero for unwritten storage slot"
+        );
+    }
+
+    #[test]
+    fn test_gas_plus_transfer_success() {
+    }
+
+    #[test]
+    fn test_treasury_and_beneficiary_rewards() {
+    }
+
+    #[test]
+    fn test_gas_plus_transfer_over_the_limit() {
+    }
+
+    #[test]
+    fn test_gas_across_multiple_transactions() {
+    }
+    
+}

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -184,7 +184,7 @@ mod tests {
 
     /// Test good path for a transfer transaction
     #[test]
-    fn test_gas_plus_transfer_success() {
+    fn test_transfer_good_path() {
         // Create a context with the gas contract
         let mut ctx = SeismicContext::<DefaultSeismicDB>::seismic();
 
@@ -206,7 +206,8 @@ mod tests {
         JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
 
         // make a transfer tx
-        let call_data = transfer_call_data(recipient, U256::from(5000));
+        let transfer_amount = U256::from(5000);
+        let call_data = transfer_call_data(recipient, transfer_amount);
         let tx = ctx.modify_tx_chained(|tx| {
             tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
             tx.base.caller = sender;
@@ -245,12 +246,13 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(recipient_final_balance, U256::from(5000));
+        assert_eq!(recipient_final_balance, transfer_amount);
         let total_token = sender_final_balance + recipient_final_balance + treasury_final_balance;
         assert_eq!(
             total_token, sender_initial_balance,
             "Total token should be conserved in a tx"
         );
+        assert!(sender_final_balance < sender_initial_balance - transfer_amount);
     }
 
     /// Test that beneficiary rewards are distributed correctly

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -257,7 +257,81 @@ mod tests {
 
     /// Test that beneficiary rewards are distributed correctly
     #[test]
-    fn test_beneficiary_rewards() {}
+    fn test_beneficiary_rewards() {
+        // Create a context with the gas contract
+        let mut ctx = SeismicContext::<DefaultSeismicDB>::seismic();
+
+        // Set up test addresses
+        let sender = Address::from([0x01; 20]);
+        let recipient = Address::from([0x02; 20]);
+        let beneficiary = Address::from([0x03; 20]); // Block beneficiary (miner/validator)
+        let treasury = TREASURY;
+
+        // Set initial balance for sender
+        let sender_initial_balance = U256::from(1000000000);
+        let sender_balance_slot = gas_caller_key(sender);
+        ctx.db()
+            .insert_account_storage(
+                GAS_SRC20_ADDRESS,
+                sender_balance_slot,
+                FlaggedStorage::new(sender_initial_balance, true),
+            )
+            .unwrap();
+        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+
+        // Set up transaction with specific gas parameters
+        let gas_limit = 100000;
+        let gas_price = 10; 
+        let basefee = 2;
+        
+        let call_data = transfer_call_data(recipient, U256::from(5000));
+        let tx = ctx.modify_tx_chained(|tx| {
+            tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
+            tx.base.caller = sender;
+            tx.base.data = call_data;
+            tx.base.gas_limit = gas_limit;
+            tx.base.gas_price = gas_price;
+        }).modify_block_chained(|block| {
+            block.beneficiary = beneficiary;
+            block.basefee = basefee;
+        });
+        
+        let inspector = revm::inspector::NoOpInspector::default();
+        let mut evm = tx.build_seismic_evm_with_inspector(inspector);
+        let result = evm.inspect_replay_commit().unwrap();
+
+        assert!(
+            matches!(
+                result,
+                revm::context::result::ExecutionResult::Success { .. }
+            ),
+            "Transaction should succeed. Result: {:?}",
+            result
+        );
+
+        // Check the balances in the resulting evm context
+        let mut post_tx_ctx = evm.ctx().clone();
+        JournalTr::load_account(post_tx_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        
+        let beneficiary_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx_ctx,
+            beneficiary,
+        )
+        .unwrap();
+
+        // Verify that the beneficiary received rewards
+        assert!(
+            beneficiary_final_balance > U256::ZERO,
+            "Beneficiary should receive gas rewards"
+        );
+
+        // // Verify that the beneficiary rewards are correct
+        // // The beneficiary should receive rewards based on gas spent * (gas_price - basefee)
+        // assert!(
+        //     beneficiary_final_balance > U256::ZERO && beneficiary_final_balance < sender_initial_balance,
+        //     "Beneficiary rewards should be positive and less than sender's initial balance"
+        // );
+    }
 
     /// Test that if gas + transfer is over the limit, the transaction fails
     #[test]

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -167,6 +167,7 @@ mod tests {
     use revm::InspectCommitEvm;
     use std::convert::Infallible;
 
+    /// Helper function to create the call data for a transfer transaction
     fn transfer_call_data(recipient: Address, amount: U256) -> Bytes {
         // Function selector for transfer(saddress,suint256)
         let selector = bytes!("0x8cdb7b34");
@@ -181,6 +182,7 @@ mod tests {
         data.into()
     }
 
+    /// Test good path for a transfer transaction
     #[test]
     fn test_gas_plus_transfer_success() {
         // Create a context with the gas contract
@@ -251,15 +253,19 @@ mod tests {
         );
     }
 
+    /// Test that beneficiary rewards are distributed correctly
     #[test]
-    fn test_treasury_and_beneficiary_rewards() {}
+    fn test_beneficiary_rewards() {}
 
+    /// Test that if gas + transfer is over the limit, the transaction fails
     #[test]
     fn test_gas_plus_transfer_over_the_limit() {}
 
+    /// Test that state is persisted correctly across multiple transactions
     #[test]
     fn test_gas_across_multiple_transactions() {}
 
+    /// Test that if the storage slot is not written, the balance is 0
     #[test]
     fn test_gas_balance_of_unwritten_storage_returns_zero() {
         // Create a context with the gas contract

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -246,13 +246,14 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(recipient_final_balance, transfer_amount);
+        assert_eq!(recipient_final_balance, transfer_amount, "recipient did not receive the transfer amount");
         let total_token = sender_final_balance + recipient_final_balance + treasury_final_balance;
         assert_eq!(
             total_token, sender_initial_balance,
             "Total token should be conserved in a tx"
         );
-        assert!(sender_final_balance < sender_initial_balance - transfer_amount);
+        assert!(sender_final_balance < sender_initial_balance - transfer_amount, "sender should have paid more than just the transfer amount due to gas");
+        assert_eq!(treasury_final_balance, U256::from(result.gas_used()), "treasury should have received the gas fees");
     }
 
     /// Test that beneficiary rewards are distributed correctly
@@ -318,19 +319,27 @@ mod tests {
             beneficiary,
         )
         .unwrap();
-
+    
         // Verify that the beneficiary received rewards
         assert!(
             beneficiary_final_balance > U256::ZERO,
             "Beneficiary should receive gas rewards"
         );
 
-        // // Verify that the beneficiary rewards are correct
-        // // The beneficiary should receive rewards based on gas spent * (gas_price - basefee)
-        // assert!(
-        //     beneficiary_final_balance > U256::ZERO && beneficiary_final_balance < sender_initial_balance,
-        //     "Beneficiary rewards should be positive and less than sender's initial balance"
-        // );
+        // Calculate the exact expected beneficiary rewards
+        let gas_spent = result.gas_used();
+        let gas_refunded = match result {
+            revm::context::result::ExecutionResult::Success { gas_used: _, gas_refunded, .. } => gas_refunded,
+            _ => unreachable!("Transaction should succeed as checked above"),
+        };
+        let coinbase_gas_price = gas_price.saturating_sub(basefee as u128);
+        let expected_reward = coinbase_gas_price.saturating_mul((gas_spent - gas_refunded as u64) as u128);
+        
+        assert_eq!(
+            beneficiary_final_balance, U256::from(expected_reward),
+            "Beneficiary should receive exactly {} tokens as gas rewards (gas_spent: {}, coinbase_gas_price: {})",
+            expected_reward, gas_spent, coinbase_gas_price
+        );
     }
 
     /// Test that if gas + transfer is over the limit, the transaction fails

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -439,7 +439,272 @@ mod tests {
 
     /// Test that state is persisted correctly across multiple transactions
     #[test]
-    fn test_gas_across_multiple_transactions() {}
+    fn test_gas_across_multiple_transactions() {
+        // Create a context with the gas contract
+        let mut ctx = SeismicContext::<DefaultSeismicDB>::seismic();
+
+        // Set up test addresses
+        let sender = Address::from([0x01; 20]);
+        let recipient1 = Address::from([0x02; 20]);
+        let recipient2 = Address::from([0x03; 20]);
+        let treasury = TREASURY;
+
+        // Set initial balance for sender
+        let sender_initial_balance = U256::from(1000000);
+        let sender_balance_slot = gas_caller_key(sender);
+        ctx.db()
+            .insert_account_storage(
+                GAS_SRC20_ADDRESS,
+                sender_balance_slot,
+                FlaggedStorage::new(sender_initial_balance, true),
+            )
+            .unwrap();
+        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+
+        // Verify initial state
+        let initial_sender_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut ctx,
+            sender,
+        )
+        .unwrap();
+        assert_eq!(
+            initial_sender_balance, sender_initial_balance,
+            "Initial sender balance should match"
+        );
+
+        // Transaction 1: Successful transfer to recipient1
+        let transfer1_amount = U256::from(200000);
+        let call_data1 = transfer_call_data(recipient1, transfer1_amount);
+        let tx1 = ctx.modify_tx_chained(|tx| {
+            tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
+            tx.base.caller = sender;
+            tx.base.data = call_data1;
+            tx.base.gas_limit = 60000;
+            tx.base.gas_price = 1;
+            tx.base.nonce = 0;
+        });
+        
+        let inspector1 = revm::inspector::NoOpInspector::default();
+        let mut evm1 = tx1.build_seismic_evm_with_inspector(inspector1);
+        let result1 = evm1.inspect_replay_commit().unwrap();
+
+        assert!(
+            matches!(
+                result1,
+                revm::context::result::ExecutionResult::Success { .. }
+            ),
+            "First transaction should succeed. Result: {:?}",
+            result1
+        );
+
+        // Check balances after first transaction
+        let mut post_tx1_ctx = evm1.ctx().clone();
+        JournalTr::load_account(post_tx1_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        
+        let recipient1_after_tx1 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx1_ctx,
+            recipient1,
+        )
+        .unwrap();
+        let treasury_after_tx1 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx1_ctx,
+            treasury,
+        )
+        .unwrap();
+
+        let gas_used1 = match result1 {
+            revm::context::result::ExecutionResult::Success { gas_used, .. } => gas_used,
+            _ => unreachable!("Transaction should succeed as checked above"),
+        };
+
+        // Verify first transaction results
+        assert_eq!(
+            recipient1_after_tx1, transfer1_amount,
+            "Recipient1 should receive the transfer amount"
+        );
+        assert_eq!(
+            treasury_after_tx1, U256::from(gas_used1),
+            "Treasury should receive gas fees from first transaction"
+        );
+
+        // Transaction 2: Transfer from recipient1 to recipient2 (using the gas they received)
+        let transfer2_amount = U256::from(70000);
+        let call_data2 = transfer_call_data(recipient2, transfer2_amount);
+        let tx2 = post_tx1_ctx.modify_tx_chained(|tx| {
+            tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
+            tx.base.caller = recipient1;
+            tx.base.data = call_data2;
+            tx.base.gas_limit = 60000;
+            tx.base.gas_price = 1;
+            tx.base.nonce = 0;
+        });
+        
+        let inspector2 = revm::inspector::NoOpInspector::default();
+        let mut evm2 = tx2.build_seismic_evm_with_inspector(inspector2);
+        let result2 = evm2.inspect_replay_commit().unwrap();
+
+        assert!(
+            matches!(
+                result2,
+                revm::context::result::ExecutionResult::Success { .. }
+            ),
+            "Second transaction should succeed. Result: {:?}",
+            result2
+        );
+
+        // Check balances after second transaction
+        let mut post_tx2_ctx = evm2.ctx().clone();
+        JournalTr::load_account(post_tx2_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        
+        let sender_after_tx2 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx2_ctx,
+            sender,
+        )
+        .unwrap();
+        let recipient1_after_tx2 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx2_ctx,
+            recipient1,
+        )
+        .unwrap();
+        let recipient2_after_tx2 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx2_ctx,
+            recipient2,
+        )
+        .unwrap();
+        let treasury_after_tx2 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx2_ctx,
+            treasury,
+        )
+        .unwrap();
+
+        let gas_used2 = match result2 {
+            revm::context::result::ExecutionResult::Success { gas_used, .. } => gas_used,
+            _ => unreachable!("Transaction should succeed as checked above"),
+        };
+
+        // Verify second transaction results
+        assert_eq!(
+            recipient2_after_tx2, transfer2_amount,
+            "Recipient2 should receive the transfer amount"
+        );
+        assert_eq!(
+            recipient1_after_tx2, 
+            recipient1_after_tx1.saturating_sub(transfer2_amount).saturating_sub(U256::from(gas_used2)),
+            "Recipient1 should have balance reduced by transfer amount plus gas fees"
+        );
+        assert_eq!(
+            treasury_after_tx2, 
+            treasury_after_tx1.saturating_add(U256::from(gas_used2)),
+            "Treasury should accumulate gas fees from both transactions"
+        );
+
+        // Transaction 3: Failed transaction (insufficient balance)
+        let transfer3_amount = U256::from(100000); // More than recipient1 has
+        let call_data3 = transfer_call_data(recipient2, transfer3_amount);
+        let tx3 = post_tx2_ctx.modify_tx_chained(|tx| {
+            tx.base.kind = TxKind::Call(GAS_SRC20_ADDRESS);
+            tx.base.caller = recipient1;
+            tx.base.data = call_data3;
+            tx.base.gas_limit = 60000;
+            tx.base.gas_price = 1;
+            tx.base.nonce = 1;
+        });
+        
+        let inspector3 = revm::inspector::NoOpInspector::default();
+        let mut evm3 = tx3.build_seismic_evm_with_inspector(inspector3);
+        let result3 = evm3.inspect_replay_commit().unwrap();
+
+        assert!(
+            matches!(
+                result3,
+                revm::context::result::ExecutionResult::Revert { .. }
+            ),
+            "Third transaction should fail due to insufficient funds. Result: {:?}",
+            result3
+        );
+
+        // Check balances after failed transaction
+        let mut post_tx3_ctx = evm3.ctx().clone();
+        JournalTr::load_account(post_tx3_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        
+        let recipient1_after_tx3 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx3_ctx,
+            recipient1,
+        )
+        .unwrap();
+        let recipient2_after_tx3 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx3_ctx,
+            recipient2,
+        )
+        .unwrap();
+        let treasury_after_tx3 = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx3_ctx,
+            treasury,
+        )
+        .unwrap();
+
+        let gas_used3 = match result3 {
+            revm::context::result::ExecutionResult::Revert { gas_used, .. } => gas_used,
+            _ => unreachable!("Transaction should revert as checked above"),
+        };
+
+        // Verify failed transaction results
+        assert_eq!(
+            recipient2_after_tx3, recipient2_after_tx2,
+            "Recipient2 balance should not change after failed transaction"
+        );
+        assert_eq!(
+            recipient1_after_tx3, 
+            recipient1_after_tx2.saturating_sub(U256::from(gas_used3)),
+            "Recipient1 should lose gas fees even when transaction fails"
+        );
+        assert_eq!(
+            treasury_after_tx3, 
+            treasury_after_tx2.saturating_add(U256::from(gas_used3)),
+            "Treasury should receive gas fees even from failed transaction"
+        );
+
+        // Verify total token conservation across all transactions
+        let total_final_balance = sender_after_tx2 + recipient1_after_tx3 + recipient2_after_tx3 + treasury_after_tx3;
+        assert_eq!(
+            total_final_balance, sender_initial_balance,
+            "Total token balance should be conserved across all transactions. Expected: {}, Actual: {}",
+            sender_initial_balance, total_final_balance
+        );
+
+        // Verify that sender's balance decreased appropriately
+        let expected_sender_final = sender_initial_balance
+            .saturating_sub(transfer1_amount)
+            .saturating_sub(U256::from(gas_used1));
+        assert_eq!(
+            sender_after_tx2, expected_sender_final,
+            "Sender should have paid transfer amount plus gas fees"
+        );
+
+        // Verify that the state changes are properly persisted
+        // This demonstrates that the gas contract state is maintained across transaction boundaries
+        assert!(
+            sender_after_tx2 < sender_initial_balance,
+            "Sender balance should be less than initial after transactions"
+        );
+        assert!(
+            recipient1_after_tx3 > U256::ZERO,
+            "Recipient1 should still have some balance after failed transaction"
+        );
+        assert!(
+            recipient2_after_tx3 > U256::ZERO,
+            "Recipient2 should have received tokens from successful transaction"
+        );
+        assert!(
+            treasury_after_tx3 > U256::ZERO,
+            "Treasury should have accumulated gas fees from all transactions"
+        );
+    }
+
+    #[test]
+    fn test_insufficient_balance_for_gas_limit() {
+        todo!()
+    }
 
     /// Test that if the storage slot is not written, the balance is 0
     #[test]

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -205,7 +205,7 @@ mod tests {
             .unwrap();
         JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
 
-        // make a transfer tx
+        // make a transfer contract call
         let transfer_amount = U256::from(20000);
         let call_data = transfer_call_data(recipient, transfer_amount);
         let tx = ctx.modify_tx_chained(|tx| {
@@ -765,6 +765,77 @@ mod tests {
         let result = evm.inspect_replay_commit();
 
         assert!(result.is_err(), "Transaction should fail due to LackOfFundForMaxFee");
+    }
+
+    #[test]
+    fn test_transfer_with_value_reverts_with_out_of_funds() {
+        // Create a context with the gas contract
+        let mut ctx = SeismicContext::<DefaultSeismicDB>::seismic();
+
+        // Set up test addresses
+        let sender = Address::from([0x01; 20]);
+        let recipient = Address::from([0x02; 20]);
+        let treasury = TREASURY;
+
+        // Set initial balance
+        let sender_initial_balance = U256::from(1000000);
+        let sender_balance_slot = gas_caller_key(sender);
+        ctx.db()
+            .insert_account_storage(
+                GAS_SRC20_ADDRESS,
+                sender_balance_slot,
+                FlaggedStorage::new(sender_initial_balance, true),
+            )
+            .unwrap();
+        JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+
+        // make a tx with native tokenvalue
+        let transfer_amount = U256::from(20000);
+        let tx = ctx.modify_tx_chained(|tx| {
+            tx.base.kind = TxKind::Call(recipient);
+            tx.base.caller = sender;
+            tx.base.value = transfer_amount;
+            tx.base.gas_limit = 100000;
+            tx.base.gas_price = 1;
+        });
+        let inspector = revm::inspector::NoOpInspector::default(); // use revm::inspector::inspectors::TracerEip3155::new_stdout() for more detailed output
+        let mut evm = tx.build_seismic_evm_with_inspector(inspector);
+        let result = evm.inspect_replay_commit().unwrap();
+
+        assert!(
+            matches!(
+                result,
+                revm::context::result::ExecutionResult::Halt { .. }
+            ),
+            "Transaction should fail. Result: {:?}",
+            result
+        );
+
+        // Check the balances in the resulting evm context
+        let mut post_tx_ctx = evm.ctx().clone();
+        JournalTr::load_account(post_tx_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
+        let sender_final_balance =
+            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(&mut post_tx_ctx, sender)
+                .unwrap();
+        let recipient_final_balance =
+            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+                &mut post_tx_ctx,
+                recipient,
+            )
+            .unwrap();
+        let treasury_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+            &mut post_tx_ctx,
+            treasury,
+        )
+        .unwrap();
+
+        assert_eq!(recipient_final_balance, U256::ZERO, "recipient should not have received any tokens");
+        let total_token = sender_final_balance + recipient_final_balance + treasury_final_balance;
+        assert_eq!(
+            total_token, sender_initial_balance,
+            "Total token should be conserved in a tx"
+        );
+        assert_eq!(sender_initial_balance, sender_final_balance + treasury_final_balance, "only movement of funds should be gas spent from sender to treasury");
     }
 
     /// Test that if the storage slot is not written, the balance is 0

--- a/crates/seismic/src/src20_gas.rs
+++ b/crates/seismic/src/src20_gas.rs
@@ -160,13 +160,12 @@ mod tests {
     use crate::api::builder::SeismicBuilder;
     use crate::api::default_ctx::{DefaultSeismicContext, DefaultSeismicDB, SeismicContext};
     use revm::context::result::{EVMError, InvalidTransaction};
-    use revm::primitives::TxKind;
-    use revm::primitives::{Bytes, U256};
-    use std::convert::Infallible;
-    use revm::inspector::{InspectEvm};
-    use revm::InspectCommitEvm;
     use revm::handler::EvmTr;
     use revm::primitives::FlaggedStorage;
+    use revm::primitives::TxKind;
+    use revm::primitives::{Bytes, U256};
+    use revm::InspectCommitEvm;
+    use std::convert::Infallible;
 
     fn transfer_call_data(recipient: Address, amount: U256) -> Bytes {
         // Function selector for transfer(saddress,suint256)
@@ -196,10 +195,14 @@ mod tests {
         let sender_initial_balance = U256::from(1000000);
         let sender_balance_slot = gas_caller_key(sender);
         ctx.db()
-            .insert_account_storage(GAS_SRC20_ADDRESS, sender_balance_slot, FlaggedStorage::new(sender_initial_balance, true))
+            .insert_account_storage(
+                GAS_SRC20_ADDRESS,
+                sender_balance_slot,
+                FlaggedStorage::new(sender_initial_balance, true),
+            )
             .unwrap();
         JournalTr::load_account(ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
-        
+
         // make a transfer tx
         let call_data = transfer_call_data(recipient, U256::from(5000));
         let tx = ctx.modify_tx_chained(|tx| {
@@ -213,34 +216,39 @@ mod tests {
         let mut evm = tx.build_seismic_evm_with_inspector(inspector);
         let result = evm.inspect_replay_commit().unwrap();
 
-        assert!(matches!(
-            result,
-            revm::context::result::ExecutionResult::Success { .. }
-        ), "Transaction should succeed. Result: {:?}", result);
+        assert!(
+            matches!(
+                result,
+                revm::context::result::ExecutionResult::Success { .. }
+            ),
+            "Transaction should succeed. Result: {:?}",
+            result
+        );
 
         // Check the balances in the resulting evm context
         let mut post_tx_ctx = evm.ctx().clone();
         JournalTr::load_account(post_tx_ctx.journal(), GAS_SRC20_ADDRESS).unwrap();
-        let sender_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
-            &mut post_tx_ctx,
-            sender,
-        )
-        .unwrap();
-        let recipient_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
-            &mut post_tx_ctx,
-            recipient,
-        )
-        .unwrap();
+        let sender_final_balance =
+            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(&mut post_tx_ctx, sender)
+                .unwrap();
+        let recipient_final_balance =
+            gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
+                &mut post_tx_ctx,
+                recipient,
+            )
+            .unwrap();
         let treasury_final_balance = gas_balance_of::<_, EVMError<Infallible, InvalidTransaction>>(
             &mut post_tx_ctx,
             treasury,
         )
         .unwrap();
 
-        assert_ne!(sender_final_balance, U256::ZERO, "Sender balance should not be zero");
-        assert_eq!(sender_final_balance, sender_initial_balance.saturating_sub(U256::from(10000)));
-        assert_eq!(recipient_final_balance, U256::from(10000));
-        assert_eq!(treasury_final_balance, U256::ZERO);
+        assert_eq!(recipient_final_balance, U256::from(5000));
+        let total_token = sender_final_balance + recipient_final_balance + treasury_final_balance;
+        assert_eq!(
+            total_token, sender_initial_balance,
+            "Total token should be conserved in a tx"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Uses Seismic SRC20 contract for gas instead of native account balance. Involves the following

- Custom evm handlers to override
    - validate_against_state_and_deduct_caller
    - reimburse_caller
    - reward_beneficiary
- src20_gas.rs - helpers to interact with the gas contract
- Test suite + modifications to existing tests
- Misc
    - refactor to alias default seismic db