### PR TITLE
feat: add live rng key support from enclave for execute mode transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "517e5acbd38b6d4c59da380e8bbadc6d365bf001903ce46cf5521c53c647e07b"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum 0.27.1",
+ "strum",
 ]
 
 [[package]]
@@ -869,7 +869,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-std 0.5.0",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3109,12 +3109,15 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6441ed73b0faa50707d4de41c6b45c76654b661b96aaf7b26a41331eedc0a5"
+version = "0.12.0"
+source = "git+https://github.com/virtee/kbs-types.git?rev=e3cc706#e3cc706ec4c1a88565598c5ce224da06a03f2265"
 dependencies = [
+ "base64",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
+ "strum",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3266,15 +3269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,16 +3327,6 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
 ]
 
 [[package]]
@@ -3578,12 +3562,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -4036,7 +4014,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -4188,17 +4166,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4209,14 +4178,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4238,9 +4201,7 @@ checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -4884,36 +4845,29 @@ dependencies = [
 [[package]]
 name = "seismic-enclave"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=30a53d5#30a53d53375de3dfa66938793dd739ec1c386a5b"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=12bf284#12bf284cc6cec2bb49ce24879200dcff16857aa9"
 dependencies = [
  "aes-gcm",
  "anyhow",
- "bincode",
- "byteorder",
- "bytes",
- "clap",
+ "base64",
  "hkdf",
  "jsonrpsee",
  "kbs-types",
- "once_cell",
  "rand 0.9.1",
- "reqwest",
  "schnorrkel",
  "secp256k1",
  "seismic-enclave-derive",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "strum 0.26.3",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
 name = "seismic-enclave-derive"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=30a53d5#30a53d53375de3dfa66938793dd739ec1c386a5b"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=12bf284#12bf284cc6cec2bb49ce24879200dcff16857aa9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5134,15 +5088,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5299,33 +5244,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros 0.27.1",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.101",
+ "strum_macros",
 ]
 
 [[package]]
@@ -5480,16 +5403,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-dependencies = [
- "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -5759,41 +5672,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,5 +174,5 @@ inherits = "test"
 opt-level = 3
 
 [patch.crates-io]
-seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "30a53d5"}
+seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "12bf284"}
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "bc4b5ed" }

--- a/crates/seismic/src/api/default_ctx.rs
+++ b/crates/seismic/src/api/default_ctx.rs
@@ -19,6 +19,8 @@ pub type SeismicContext<DB> = Context<
 pub trait DefaultSeismicContext {
     /// Create a default context.
     fn seismic() -> SeismicContext<EmptyDB>;
+    /// Create a context with a specific RNG keypair.
+    fn seismic_with_rng_key(rng_keypair: schnorrkel::Keypair) -> SeismicContext<EmptyDB>;
 }
 
 impl DefaultSeismicContext for SeismicContext<EmptyDB> {
@@ -27,6 +29,13 @@ impl DefaultSeismicContext for SeismicContext<EmptyDB> {
             .with_tx(SeismicTransaction::default())
             .with_cfg(CfgEnv::new_with_spec(SeismicSpecId::MERCURY))
             .with_chain(SeismicChain::default())
+    }
+
+    fn seismic_with_rng_key(rng_keypair: schnorrkel::Keypair) -> Self {
+        Context::mainnet()
+            .with_tx(SeismicTransaction::default())
+            .with_cfg(CfgEnv::new_with_spec(SeismicSpecId::MERCURY))
+            .with_chain(SeismicChain::with_live_rng_key(Some(rng_keypair)))
     }
 }
 

--- a/crates/seismic/src/chain/rng_container.rs
+++ b/crates/seismic/src/chain/rng_container.rs
@@ -97,7 +97,7 @@ impl RngContainer {
             // Note: live_key is only provided for RngMode::Execution
             let live_rng = RootRng::new(key);
             live_rng.append_tx(tx_hash);
-            
+
             let mut leaf_rng = live_rng.fork(pers);
             let mut rng_bytes = vec![0u8; requested_output_len];
             leaf_rng.fill_bytes(&mut rng_bytes);

--- a/crates/seismic/src/chain/rng_container.rs
+++ b/crates/seismic/src/chain/rng_container.rs
@@ -80,21 +80,45 @@ impl RngContainer {
         kernel_mode: RngMode,
         tx_hash: &B256,
     ) -> Result<Bytes, PrecompileError> {
-        // Domain separation: update the root RNG
-        self.maybe_append_entropy(kernel_mode);
-        self.rng.append_tx(tx_hash);
+        self.process_rng_with_key(pers, requested_output_len, kernel_mode, tx_hash, None)
+    }
 
-        // Initialize the leaf RNG if not done already.
-        if self.leaf_rng.is_none() {
-            let leaf_rng = self.rng.fork(pers);
-            self.leaf_rng = Some(leaf_rng);
+    pub fn process_rng_with_key(
+        &mut self,
+        pers: &[u8],
+        requested_output_len: usize,
+        kernel_mode: RngMode,
+        tx_hash: &B256,
+        live_key: Option<schnorrkel::Keypair>,
+    ) -> Result<Bytes, PrecompileError> {
+        // Use live key for Execute mode, otherwise use default container
+        if let Some(key) = live_key {
+            // Create a temporary RNG with the live key for this operation
+            // Note: live_key is only provided for RngMode::Execution
+            let live_rng = RootRng::new(key);
+            live_rng.append_tx(tx_hash);
+            
+            let mut leaf_rng = live_rng.fork(pers);
+            let mut rng_bytes = vec![0u8; requested_output_len];
+            leaf_rng.fill_bytes(&mut rng_bytes);
+            Ok(Bytes::from(rng_bytes))
+        } else {
+            // Use the default container's RNG
+            self.maybe_append_entropy(kernel_mode);
+            self.rng.append_tx(tx_hash);
+
+            // Initialize the leaf RNG if not done already.
+            if self.leaf_rng.is_none() {
+                let leaf_rng = self.rng.fork(pers);
+                self.leaf_rng = Some(leaf_rng);
+            }
+
+            // Get the random bytes.
+            let leaf_rng = self.leaf_rng.as_mut().unwrap();
+            let mut rng_bytes = vec![0u8; requested_output_len];
+            leaf_rng.fill_bytes(&mut rng_bytes);
+            Ok(Bytes::from(rng_bytes))
         }
-
-        // Get the random bytes.
-        let leaf_rng = self.leaf_rng.as_mut().unwrap();
-        let mut rng_bytes = vec![0u8; requested_output_len];
-        leaf_rng.fill_bytes(&mut rng_bytes);
-        Ok(Bytes::from(rng_bytes))
     }
 
     #[cfg(test)]

--- a/crates/seismic/src/chain/seismic_chain.rs
+++ b/crates/seismic/src/chain/seismic_chain.rs
@@ -10,12 +10,14 @@ use super::rng_container::RngContainer;
 #[derive(Clone, Debug)]
 pub struct SeismicChain {
     rng_container: RngContainer,
+    live_rng_key: Option<schnorrkel::Keypair>,
 }
 
 impl Default for SeismicChain {
     fn default() -> Self {
         Self {
             rng_container: RngContainer::default(),
+            live_rng_key: None,
         }
     }
 }
@@ -23,8 +25,20 @@ impl Default for SeismicChain {
 impl SeismicChain {
     pub fn new(root_vrf_key: schnorrkel::Keypair) -> Self {
         Self {
-            rng_container: RngContainer::new(root_vrf_key),
+            rng_container: RngContainer::new(root_vrf_key.clone()),
+            live_rng_key: Some(root_vrf_key),
         }
+    }
+
+    pub fn with_live_rng_key(live_rng_key: Option<schnorrkel::Keypair>) -> Self {
+        Self {
+            rng_container: RngContainer::default(),
+            live_rng_key,
+        }
+    }
+
+    pub fn set_rng_key(&mut self, root_vrf_key: schnorrkel::Keypair) {
+        self.rng_container = RngContainer::new(root_vrf_key);
     }
 
     pub fn rng_container(&self) -> &RngContainer {
@@ -55,7 +69,14 @@ impl SeismicChain {
         kernel_mode: RngMode,
         tx_hash: &B256,
     ) -> Result<Bytes, PrecompileError> {
+        // Check if we should use live key for Execute mode
+        let rng_key = match (&kernel_mode, &self.live_rng_key) {
+            (RngMode::Execution, Some(live_key)) => Some(live_key.clone()),
+            _ => None,
+        };
+        
         self.rng_container
-            .process_rng(pers, requested_output_len, kernel_mode, tx_hash)
+            .process_rng_with_key(pers, requested_output_len, kernel_mode, tx_hash, rng_key)
     }
+
 }

--- a/crates/seismic/src/chain/seismic_chain.rs
+++ b/crates/seismic/src/chain/seismic_chain.rs
@@ -74,9 +74,13 @@ impl SeismicChain {
             (RngMode::Execution, Some(live_key)) => Some(live_key.clone()),
             _ => None,
         };
-        
-        self.rng_container
-            .process_rng_with_key(pers, requested_output_len, kernel_mode, tx_hash, rng_key)
-    }
 
+        self.rng_container.process_rng_with_key(
+            pers,
+            requested_output_len,
+            kernel_mode,
+            tx_hash,
+            rng_key,
+        )
+    }
 }


### PR DESCRIPTION
Part of this initiative https://github.com/SeismicSystems/seismic-revm/issues/147

Changes:
- Make it possible to create a `SeismicContext` with a provided rng key
- Extends the `RngContainer`. If a live rng key exists and the rng mode is `Execute`, then the live rng key is used, otherwise the default key is used