### PR TITLE
remove seismic-enclave dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
  "wasmtimer",
@@ -529,7 +529,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.16",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
  "wasmtimer",
@@ -545,7 +545,7 @@ dependencies = [
  "alloy-transport",
  "reqwest",
  "serde_json",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "url",
 ]
@@ -1288,12 +1288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,16 +1462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "console"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,16 +1518,6 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2247,10 +2221,6 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-dependencies = [
- "gloo-timers",
- "send_wrapper",
-]
 
 [[package]]
 name = "futures-util"
@@ -2316,7 +2286,6 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand 0.8.5",
  "rand_core 0.6.4",
 ]
 
@@ -2343,52 +2312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "gloo-net"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils",
- "http",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "gmp-mpfr-sys"
 version = "1.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,25 +2330,6 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.11.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -2566,12 +2470,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,34 +2485,15 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -2937,28 +2816,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,177 +2823,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonrpsee"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b26c20e2178756451cfeb0661fb74c47dd5988cb7e3939de7e9241fd604d42"
-dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-http-client",
- "jsonrpsee-proc-macros",
- "jsonrpsee-server",
- "jsonrpsee-types",
- "jsonrpsee-wasm-client",
- "jsonrpsee-ws-client",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacb85abf4117092455e1573625e21b8f8ef4dec8aff13361140b2dc266cdff2"
-dependencies = [
- "base64",
- "futures-channel",
- "futures-util",
- "gloo-net",
- "http",
- "jsonrpsee-core",
- "pin-project",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "soketto",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456196007ca3a14db478346f58c7238028d55ee15c1df15115596e411ff27925"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-timer",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "jsonrpsee-types",
- "parking_lot",
- "pin-project",
- "rand 0.8.5",
- "rustc-hash",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c872b6c9961a4ccc543e321bb5b89f6b2d2c7fe8b61906918273a3333c95400c"
-dependencies = [
- "async-trait",
- "base64",
- "http-body",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "rustls",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e65763c942dfc9358146571911b0cd1c361c2d63e2d2305622d40d36376ca80"
-dependencies = [
- "heck",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "jsonrpsee-server"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e363146da18e50ad2b51a0a7925fc423137a0b1371af8235b1c231a0647328"
-dependencies = [
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "pin-project",
- "route-recognizer",
- "serde",
- "serde_json",
- "soketto",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower 0.4.13",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a8e70baf945b6b5752fc8eb38c918a48f1234daf11355e07106d963f860089"
-dependencies = [
- "http",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "jsonrpsee-wasm-client"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6558a9586cad43019dafd0b6311d0938f46efc116b34b28c74778bc11a2edf6"
-dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b3323d890aa384f12148e8d2a1fd18eb66e9e7e825f9de4fa53bcc19b93eef"
-dependencies = [
- "http",
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "url",
 ]
 
 [[package]]
@@ -3151,19 +2837,6 @@ dependencies = [
  "once_cell",
  "serdect",
  "sha2",
-]
-
-[[package]]
-name = "kbs-types"
-version = "0.12.0"
-source = "git+https://github.com/virtee/kbs-types.git?rev=e3cc706#e3cc706ec4c1a88565598c5ce224da06a03f2265"
-dependencies = [
- "base64",
- "serde",
- "serde_json",
- "sha2",
- "strum",
- "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -3304,7 +2977,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4094,7 +3767,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -4366,20 +4039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.16",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4397,12 +4056,6 @@ dependencies = [
  "bytes",
  "rustc-hex",
 ]
-
-[[package]]
-name = "route-recognizer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rstest"
@@ -4532,77 +4185,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
-dependencies = [
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework 3.4.0",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework 3.4.0",
- "security-framework-sys",
- "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -4680,13 +4268,10 @@ dependencies = [
  "aead",
  "arrayref",
  "arrayvec",
- "cfg-if",
  "curve25519-dalek",
  "getrandom_or_panic",
  "merlin",
  "rand_core 0.6.4",
- "serde",
- "serde_bytes",
  "sha2",
  "subtle",
  "zeroize",
@@ -4761,20 +4346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4791,41 +4363,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "seismic-enclave"
-version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=12bf284cc6cec2bb49ce24879200dcff16857aa9#12bf284cc6cec2bb49ce24879200dcff16857aa9"
-dependencies = [
- "aes-gcm",
- "anyhow",
- "base64",
- "hkdf",
- "jsonrpsee",
- "kbs-types",
- "rand 0.9.2",
- "schnorrkel",
- "secp256k1 0.30.0",
- "seismic-enclave-derive",
- "serde",
- "serde_json",
- "sha2",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "seismic-enclave-derive"
-version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=12bf284cc6cec2bb49ce24879200dcff16857aa9#12bf284cc6cec2bb49ce24879200dcff16857aa9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "seismic-revm"
 version = "1.0.0"
 dependencies = [
+ "aes-gcm",
  "alloy-sol-types",
  "anyhow",
  "auto_impl",
@@ -4838,7 +4379,6 @@ dependencies = [
  "rstest",
  "schnorrkel",
  "secp256k1 0.31.1",
- "seismic-enclave",
  "serde",
  "serde_json",
  "sha2",
@@ -4872,27 +4412,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4974,17 +4499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5032,15 +4546,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5079,22 +4584,6 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "soketto"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
-dependencies = [
- "base64",
- "bytes",
- "futures",
- "http",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
 ]
 
 [[package]]
@@ -5383,9 +4872,7 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "slab",
  "socket2",
  "tokio-macros",
@@ -5414,16 +4901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5443,7 +4920,6 @@ checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -5464,21 +4940,6 @@ dependencies = [
  "indexmap 2.11.0",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5509,7 +4970,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -5532,7 +4993,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5647,12 +5107,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unty"
@@ -5868,24 +5322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.2",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5977,15 +5413,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6009,21 +5436,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6061,12 +5473,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6079,12 +5485,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6094,12 +5494,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6127,12 +5521,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6142,12 +5530,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6163,12 +5545,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6178,12 +5554,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 seismic-revm = { path = "crates/seismic" }
-seismic-enclave = { version = "0.1.0", default-features = false }
 cargo_metadata = "0.18"
 
 # revm
@@ -94,6 +93,7 @@ secp256k1 = { version = "0.31.1", default-features = false }
 sha2 = { version = "0.10.9", default-features = false }
 ripemd = { version = "0.1.3", default-features = false }
 p256 = { version = "0.13.2", default-features = false }
+aes-gcm = "0.10"
 
 # bytecode
 bitvec = { version = "1", default-features = false }
@@ -179,5 +179,4 @@ inherits = "test"
 opt-level = 3
 
 [patch.crates-io]
-seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "12bf284cc6cec2bb49ce24879200dcff16857aa9"}
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }

--- a/crates/seismic/Cargo.toml
+++ b/crates/seismic/Cargo.toml
@@ -33,13 +33,13 @@ once_cell = { version = "1.21", features = ["alloc"] }
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
 # seismic 
-schnorrkel = { version = "0.11.2", default-features = false }
+schnorrkel = { version = "0.11.2", default-features = false, features = ["getrandom"] }
 merlin = { version = "3.0.0", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 hkdf = { version = "0.12", default-features = false }
-seismic-enclave = { workspace = true, default-features = false}
 sha2 = { workspace = true } 
 secp256k1 = { workspace = true, features = ["recovery"] }
+aes-gcm.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/seismic/src/chain/rng_container.rs
+++ b/crates/seismic/src/chain/rng_container.rs
@@ -6,11 +6,12 @@ use revm::{
 };
 
 use crate::transaction::abstraction::RngMode;
-use seismic_enclave::get_unsecure_sample_schnorrkel_keypair;
-
-use crate::precompiles::rng::{
-    domain_sep_rng::{LeafRng, RootRng},
-    precompile::{calculate_fill_cost, calculate_init_cost},
+use crate::{
+    get_unsecure_sample_schnorrkel_keypair,
+    precompiles::rng::{
+        domain_sep_rng::{LeafRng, RootRng},
+        precompile::{calculate_fill_cost, calculate_init_cost},
+    },
 };
 
 pub struct RngContainer {

--- a/crates/seismic/src/evm.rs
+++ b/crates/seismic/src/evm.rs
@@ -187,8 +187,8 @@ mod tests {
     use crate::precompiles::rng::precompile::{calculate_fill_cost, calculate_init_cost};
     use crate::transaction::abstraction::SeismicTransaction;
     use crate::{
-        DefaultSeismicContext, SeismicBuilder, SeismicChain, SeismicContext, SeismicHaltReason,
-        SeismicSpecId,
+        get_unsecure_sample_schnorrkel_keypair, DefaultSeismicContext, SeismicBuilder,
+        SeismicChain, SeismicContext, SeismicHaltReason, SeismicSpecId,
     };
     use anyhow::bail;
     use rand_core::RngCore;
@@ -200,7 +200,6 @@ mod tests {
     use revm::precompile::u64_to_address;
     use revm::primitives::{Address, Bytes, TxKind, B256, U256};
     use revm::{ExecuteCommitEvm, ExecuteEvm, Journal};
-    use seismic_enclave::get_unsecure_sample_schnorrkel_keypair;
 
     // === Fixture data ===
 

--- a/crates/seismic/src/lib.rs
+++ b/crates/seismic/src/lib.rs
@@ -23,5 +23,17 @@ pub use chain::seismic_chain::SeismicChain;
 pub use evm::SeismicEvm;
 pub use instructions::seismic_host::SeismicHost;
 pub use result::SeismicHaltReason;
+use schnorrkel::Keypair as SchnorrkelKeypair;
+use schnorrkel::{ExpansionMode, MiniSecretKey};
 pub use spec::*;
 pub use transaction::abstraction::SeismicTransaction;
+
+// used for testing purposes and defaults
+pub(crate) fn get_unsecure_sample_schnorrkel_keypair() -> SchnorrkelKeypair {
+    let mini_secret_key = MiniSecretKey::from_bytes(&[
+        221, 143, 4, 149, 139, 56, 101, 208, 232, 50, 47, 39, 112, 211, 4, 111, 63, 63, 202, 141,
+        138, 195, 190, 41, 139, 177, 214, 90, 176, 210, 173, 14,
+    ])
+    .unwrap();
+    mini_secret_key.expand(ExpansionMode::Uniform).into()
+}

--- a/crates/seismic/src/precompiles/aes/aes_gcm_dec.rs
+++ b/crates/seismic/src/precompiles/aes/aes_gcm_dec.rs
@@ -3,10 +3,9 @@ use revm::precompile::{
 };
 
 use super::common::{
-    calculate_cost, parse_aes_key, validate_gas_limit, validate_input_length, validate_nonce_length,
+    aes_decrypt, calculate_cost, parse_aes_key, validate_gas_limit, validate_input_length,
+    validate_nonce_length,
 };
-
-use seismic_enclave::aes_decrypt;
 
 /* --------------------------------------------------------------------------
 Constants & Setup
@@ -57,8 +56,7 @@ pub fn precompile_decrypt(input: &[u8], gas_limit: u64) -> PrecompileResult {
     let cost = calculate_cost(ciphertext.len());
     validate_gas_limit(cost, gas_limit)?;
 
-    let plaintext = aes_decrypt(&aes_key.into(), ciphertext, nonce)
-        .map_err(|e| PrecompileError::Other(format!("Decryption failed: {e}")))?;
+    let plaintext = aes_decrypt(&aes_key.into(), ciphertext, nonce)?;
 
     Ok(PrecompileOutput::new(cost, plaintext.into()))
 }

--- a/crates/seismic/src/precompiles/aes/aes_gcm_enc.rs
+++ b/crates/seismic/src/precompiles/aes/aes_gcm_enc.rs
@@ -1,12 +1,11 @@
 use revm::precompile::{
-    u64_to_address, Precompile, PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult,
+    u64_to_address, Precompile, PrecompileId, PrecompileOutput, PrecompileResult,
 };
 
 use super::common::{
-    calculate_cost, parse_aes_key, validate_gas_limit, validate_input_length, validate_nonce_length,
+    aes_encrypt, calculate_cost, parse_aes_key, validate_gas_limit, validate_input_length,
+    validate_nonce_length,
 };
-
-use seismic_enclave::aes_encrypt;
 
 /* --------------------------------------------------------------------------
 Constants & Setup
@@ -71,8 +70,7 @@ pub fn precompile_encrypt(input: &[u8], gas_limit: u64) -> PrecompileResult {
     let plaintext = &input[44..];
     let cost = calculate_cost(plaintext.len());
     validate_gas_limit(cost, gas_limit)?;
-    let ciphertext = aes_encrypt(&aes_key.into(), plaintext, nonce)
-        .map_err(|e| PrecompileError::Other(format!("Encryption failed: {e}")))?;
+    let ciphertext = aes_encrypt(&aes_key.into(), plaintext, nonce)?;
 
     Ok(PrecompileOutput::new(cost, ciphertext.into()))
 }

--- a/crates/seismic/src/precompiles/aes/common.rs
+++ b/crates/seismic/src/precompiles/aes/common.rs
@@ -1,4 +1,11 @@
+use aes_gcm::{aead::Aead, Aes256Gcm, Key, KeyInit as _};
+use hkdf::Hkdf;
 use revm::precompile::PrecompileError;
+use secp256k1::ecdh::SharedSecret;
+use sha2::{
+    digest::{consts::U12, generic_array::GenericArray},
+    Sha256,
+};
 
 /// The below gas cost are very rough estimates.
 /// Overhead cost for AES-GCM setup & finalization. We intentionally overprice to stay safe.
@@ -6,6 +13,24 @@ const AES_GCM_BASE: u64 = 1000;
 
 /// Per 16-byte block cost. One AES encryption + one GHASH multiply per block, plus cushion.
 const AES_GCM_PER_BLOCK: u64 = 30;
+
+pub const AESGCM_NONCE_SIZE: usize = 12; // Size of AES-GCM nonce in bytes
+
+/// The intermediate type to represent a nonce in the enclave
+#[derive(Debug, Clone)]
+pub struct Nonce(pub [u8; AESGCM_NONCE_SIZE]);
+
+impl From<Nonce> for aes_gcm::Nonce<U12> {
+    fn from(nonce: Nonce) -> Self {
+        GenericArray::clone_from_slice(&nonce.0)
+    }
+}
+
+impl From<[u8; AESGCM_NONCE_SIZE]> for Nonce {
+    fn from(bytes: [u8; AESGCM_NONCE_SIZE]) -> Self {
+        Nonce(bytes)
+    }
+}
 
 pub(crate) fn validate_input_length(
     input_len: usize,
@@ -49,4 +74,81 @@ pub(crate) fn validate_gas_limit(cost: u64, gas_limit: u64) -> Result<(), Precom
         return Err(PrecompileError::OutOfGas);
     }
     Ok(())
+}
+
+/// Decrypts ciphertext using AES-256 GCM with a 92-bit nonce.
+///
+/// This function requires the nonce to be exactly 92 bits (12 bytes),
+/// with no padding or truncation. The caller must pass a `Vec<u8>`
+/// containing 12 bytes.
+///
+/// # Arguments
+/// * `key` - The AES-256 GCM key used for decryption.
+/// * `ciphertext` - A slice of bytes (`&[u8]`) representing the encrypted data.
+/// * `nonce` - A `Nonce` containing exactly 12 bytes (92 bits).
+///
+/// # Returns
+/// A `Vec<u8>` containing the bytes of the decrypted plaintext.
+///
+/// # Errors
+/// Returns an error if the nonce size is incorrect or if decryption fails.
+pub(crate) fn aes_decrypt(
+    key: &Key<Aes256Gcm>,
+    ciphertext: &[u8],
+    nonce: impl Into<Nonce>,
+) -> Result<Vec<u8>, PrecompileError> {
+    let nonce_array: Nonce = nonce.into();
+    let cipher = Aes256Gcm::new(key);
+
+    cipher
+        .decrypt(&nonce_array.into(), ciphertext)
+        .map_err(|e| PrecompileError::Other(format!("Encryption failed: {e}")))
+}
+
+/// Encrypts plaintext using AES-256 GCM with a 92-bit nonce.
+///
+/// This function requires the nonce to be exactly 92 bits (12 bytes),
+/// with no padding or truncation. The caller must pass a `Vec<u8>`
+/// containing 12 bytes.
+///
+/// # Arguments
+/// * `key` - The AES-256 GCM key used for encryption.
+/// * `plaintext` - The slice of bytes to encrypt.
+/// * `nonce` - A `Nonce` containing exactly 12 bytes (92 bits).
+///
+/// # Returns
+/// A `Vec<u8>` containing the bytes of encrypted ciphertext.
+///
+/// # Errors
+/// Returns an error if the nonce size is incorrect or if encryption fails.
+pub(crate) fn aes_encrypt(
+    key: &Key<Aes256Gcm>,
+    plaintext: &[u8],
+    nonce: impl Into<Nonce>,
+) -> Result<Vec<u8>, PrecompileError> {
+    let nonce_array: Nonce = nonce.into();
+    let cipher = Aes256Gcm::new(key);
+    cipher
+        .encrypt(&nonce_array.into(), plaintext)
+        .map_err(|e| PrecompileError::Other(format!("AES encryption failed: {:?}", e)))
+}
+
+/// Derives an AES key from a shared secret using HKDF and SHA-256.
+///
+/// This function takes a `SharedSecret` and derives a 256-bit AES key using
+/// the HKDF (HMAC-based Extract-and-Expand Key Derivation Function) with SHA-256.
+///
+/// # Arguments
+/// * `shared_secret` - The shared secret from which the AES key will be derived.
+///
+/// # Returns
+/// A `Result` containing the derived AES key, or an error if key derivation fails.
+pub fn derive_aes_key(shared_secret: &SharedSecret) -> Result<Key<Aes256Gcm>, hkdf::InvalidLength> {
+    // Initialize HKDF with SHA-256
+    let hk = Hkdf::<Sha256>::new(None, &shared_secret.secret_bytes());
+
+    // Output a 32-byte key for AES-256
+    let mut okm = [0u8; 32];
+    hk.expand(b"aes-gcm key", &mut okm)?;
+    Ok(*Key::<Aes256Gcm>::from_slice(&okm))
 }

--- a/crates/seismic/src/precompiles/aes/mod.rs
+++ b/crates/seismic/src/precompiles/aes/mod.rs
@@ -4,4 +4,4 @@ pub use aes_gcm_enc::precompile_encrypt;
 pub mod aes_gcm_dec;
 pub use aes_gcm_dec::precompile_decrypt;
 
-mod common;
+pub mod common;

--- a/crates/seismic/src/precompiles/ecdh_derive_sym_key.rs
+++ b/crates/seismic/src/precompiles/ecdh_derive_sym_key.rs
@@ -1,9 +1,9 @@
+use super::aes::common::derive_aes_key;
 use super::hkdf_derive_sym_key::EXPAND_FIXED_COST;
 use revm::precompile::{
     u64_to_address, Precompile, PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult,
 };
-
-use seismic_enclave::{derive_aes_key, ecdh::SharedSecret, PublicKey, SecretKey};
+use secp256k1::{ecdh::SharedSecret, PublicKey, SecretKey};
 
 /// Address of ECDH precompile.
 pub const ECDH_ADDRESS: u64 = 101;

--- a/crates/seismic/src/precompiles/rng/domain_sep_rng.rs
+++ b/crates/seismic/src/precompiles/rng/domain_sep_rng.rs
@@ -10,8 +10,9 @@ use merlin::{Transcript, TranscriptRng};
 use rand_core::{CryptoRng, OsRng, RngCore};
 use revm::primitives::B256;
 pub use schnorrkel::keys::Keypair as SchnorrkelKeypair;
-use seismic_enclave::get_unsecure_sample_schnorrkel_keypair;
 use std::{cell::RefCell, rc::Rc};
+
+use crate::get_unsecure_sample_schnorrkel_keypair;
 
 /// RNG domain separation context.
 const RNG_CONTEXT: &[u8] = b"seismic rng context";


### PR DESCRIPTION
This pr removes seismic-enclave dep. We were mostly using it for just a few re-exported crypto functions and some consts. I think this will keep seismic-enclave a bit more in scope. 