### PR TITLE
feat(confidential_storage): new semantics for s and c store/load

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -96,7 +96,9 @@ jobs:
       - name: Clone seismic-solidity repo
         run: |
           TEMP_DIR=$(mktemp -d)
-          git clone https://github.com/SeismicSystems/seismic-solidity.git "$TEMP_DIR/seismic-solidity"
+          # Temporarily checking out the test--new-storage-opcode-semantics branch that fixes storage opcode semantic tests.
+          # TODO(samlaf): switch back to seismic (default) branch after we merge https://github.com/SeismicSystems/seismic-solidity/pull/130
+          git clone -b test--new-storage-opcode-semantics https://github.com/SeismicSystems/seismic-solidity.git "$TEMP_DIR/seismic-solidity"
           echo "SEISMIC_SOLIDITY_PATH=$TEMP_DIR/seismic-solidity" >> $GITHUB_ENV
           echo "seismic-solidity cloned to: $TEMP_DIR/seismic-solidity"
       - name: Install latest ssolc release

--- a/README.md
+++ b/README.md
@@ -34,15 +34,30 @@ Mercury introduces **Flagged Storage**, where each storage slot is now represent
 `(value, is_private)`
 
 To support private storage, Mercury provides new instructions:
-- **CLOAD:** Loads data from a slot marked as private.
-- **CSTORE:** Stores data into a slot, tagging it as private.
+| opcode | name   | gas    | stack input | stack output | description            |
+| ------ | ------ | ------ | ----------- | ------------ | ---------------------- |
+| 0xB0   | CLOAD  | 2_200  | key         | value        | load word from storage |
+| 0xB1   | CSTORE | 22_100 | key/value   |              | save word to storage   |
 
 **Access Rules:**
-- **Loading:** The operation must match the slot’s privacy flag. Attempting to load a slot using an instruction that doesn’t match its privacy (e.g., using SLOAD on a private slot or CLOAD on a public slot) is disallowed. The only caveat is that CLOAD can load public slot with value 0.
-- **Storing:** Writing to a slot is allowed regardless of its current privacy flag, enabling seamless transitions between public and private states.
+The semantics of these instructions, as well as of SLOAD/SSTORE with respect to confidential storage, are as follows:
+
+|           | (0, public)  | (x, public) | (0, private) | (x, private) |
+| --------- | ------------ | ----------- | ------------ | ------------ |
+| SLOAD     | 0            | x           | HALT         | HALT         |
+| CLOAD     | 0            | x           | 0            | x            |
+| SSTORE(y) | (y, public)  | (y, public) | HALT         | HALT         |
+| CSTORE(y) | (y, private) | HALT        | (y, private) | (y, private) |
+
+The reasoning behind these choices is that:
+- Disallowing SLOAD to read private slots is the main way privacy is enforced
+- Preventing SSTORE and CSTORE from writing to non-matching confidentiality slots is a guardrail to protect both developers writing evmasm by hand, as well as seismic-solidity compiler bugs
+- Given that public and private slots share a same address space (and trie), CSTORE'ing into an uninitialized slot has to be allowed, as that is the only way to switch a slot from public->private
+    - As a side-effect, that does mean that a public slot can be turned into a private slot by first SSTORE'ing 0, and then CSTORE'ing (y, private)
+    - However, once a slot has been turned private, there is no way to flip it back to public
 
 **Gas Costs:**  
-Confidential storage operations (both load and store) incur the same gas costs as their public counterparts.
+Confidential storage operations (both load and store) incur a flat gas cost (max that SLOAD/SSTORE could cost). This is to prevent gas cost side-channels leaking information.
 
 ---
 

--- a/bins/revme/src/cmd/semantics/semantic_tests.rs
+++ b/bins/revme/src/cmd/semantics/semantic_tests.rs
@@ -202,10 +202,7 @@ impl SemanticTests {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            error!(
-                "Compilation failed for file: {:?}\n{}",
-                path, stderr
-            );
+            error!("Compilation failed for file: {:?}\n{}", path, stderr);
             return Err(Errors::CompilationFailed);
         }
 

--- a/bins/revme/src/cmd/semantics/semantic_tests.rs
+++ b/bins/revme/src/cmd/semantics/semantic_tests.rs
@@ -201,9 +201,10 @@ impl SemanticTests {
         })?;
 
         if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
             error!(
-                "Compilation failed for file: {:?}, output: {:?}",
-                path, output
+                "Compilation failed for file: {:?}\n{}",
+                path, stderr
             );
             return Err(Errors::CompilationFailed);
         }

--- a/crates/seismic/src/evm.rs
+++ b/crates/seismic/src/evm.rs
@@ -212,12 +212,36 @@ mod tests {
 
     // === Fixture data ===
 
-    fn get_meta_data() -> (Bytes, Bytes) {
-        // bytecode for a contract whose function f() does `cload(0)` after `sstore(0,1)`
+    /// Returns bytecode for a contract that does `sstore(0, 1)` then `cstore(0, 2)`.
+    /// This tests CSTORE's InvalidPublicStorageAccess: cannot overwrite non-zero public slot.
+    fn get_cstore_violation_bytecode() -> (Bytes, Bytes) {
+        // Contract that does: sstore(0, 1) then cstore(0, 2)
+        // The sstore makes slot 0 public with value 1
+        // The cstore should fail because slot 0 is (1, public) - non-zero public
         let bytecode = Bytes::from_str(
             "6080604052348015600e575f5ffd5b5060d880601a5f395ff3fe6080604052348015600e\
              575f5ffd5b50600436106026575f3560e01c806326121ff014602a575b5f5ffd5b60306\
-             044565b604051603b91906066565b60405180910390f35b5f60015f555fb0905090565b\
+             044565b604051603b91906066565b60405180910390f35b5f60015f5560025fb1905090565b\
+             5f819050919050565b6060816050565b82525050565b5f60208201905060775f830184\
+             6059565b9291505056fea26469706673582212203976fb983ef7119eeabfd96d1698e9\
+             bca8ad8a92c6f39e22bc2c6b412755a16864736f6c637827302e382e32382d63692e32\
+             3032342e31312e342b636f6d6d69742e64396333323834372e6d6f640058",
+        )
+        .unwrap();
+        let selector = Bytes::from_str("26121ff0").unwrap();
+        (bytecode, selector)
+    }
+
+    /// Returns bytecode for a contract that does `cstore(0, 1)` then `sstore(0, 2)`.
+    /// This tests SSTORE's InvalidPrivateStorageAccess: cannot write to private slot.
+    fn get_sstore_violation_bytecode() -> (Bytes, Bytes) {
+        // Contract that does: cstore(0, 1) then sstore(0, 2)
+        // The cstore makes slot 0 private with value 1
+        // The sstore should fail because slot 0 is private
+        let bytecode = Bytes::from_str(
+            "6080604052348015600e575f5ffd5b5060d880601a5f395ff3fe6080604052348015600e\
+             575f5ffd5b50600436106026575f3560e01c806326121ff014602a575b5f5ffd5b60306\
+             044565b604051603b91906066565b60405180910390f35b60015fb160025f55905090565b\
              5f819050919050565b6060816050565b82525050565b5f60208201905060775f830184\
              6059565b9291505056fea26469706673582212203976fb983ef7119eeabfd96d1698e9\
              bca8ad8a92c6f39e22bc2c6b412755a16864736f6c637827302e382e32382d63692e32\
@@ -230,8 +254,9 @@ mod tests {
 
     // === Test helpers ===
 
-    fn deploy_contract() -> anyhow::Result<(SeismicContext<InMemoryDB>, Address)> {
-        let (bytecode, _) = get_meta_data();
+    fn deploy_contract_with_bytecode(
+        bytecode: Bytes,
+    ) -> anyhow::Result<(SeismicContext<InMemoryDB>, Address)> {
         let ctx = Context::seismic()
             .modify_tx_chained(|tx| {
                 tx.base.kind = TxKind::Create;
@@ -273,21 +298,20 @@ mod tests {
         ctx
     }
 
-    fn assert_cload_error(
+    fn assert_storage_access_error(
         result: &ResultAndState<SeismicHaltReason>,
+        expected_reason: SeismicHaltReason,
         starting_balance: u64,
         gas_limit: u64,
         gas_price: u64,
     ) {
         assert!(
             matches!(
-                result.result,
-                ExecutionResult::Halt {
-                    reason: SeismicHaltReason::InvalidPublicStorageAccess,
-                    ..
-                }
+                &result.result,
+                ExecutionResult::Halt { reason, .. } if *reason == expected_reason
             ),
-            "Received result: {:?}",
+            "Expected {:?}, received result: {:?}",
+            expected_reason,
             result.result
         );
 
@@ -302,15 +326,17 @@ mod tests {
         assert_eq!(final_nonce, 1, "Caller nonce incremented by 1");
     }
 
+    /// Tests that CSTORE halts with InvalidPublicStorageAccess when trying to
+    /// overwrite a non-zero public slot (x, public) where x != 0.
     #[test]
-    fn cload_access_violation_bubbles_up_and_charges_gas() -> anyhow::Result<()> {
-        let (ctx, contract) = deploy_contract()?;
+    fn cstore_on_nonzero_public_slot_halts() -> anyhow::Result<()> {
+        let (bytecode, selector) = get_cstore_violation_bytecode();
+        let (ctx, contract) = deploy_contract_with_bytecode(bytecode)?;
 
         let balance = 1_000_000;
-        let gas_limit = 59_000;
+        let gas_limit = 100_000;
         let gas_price = 10;
 
-        let (_, selector) = get_meta_data();
         let call_ctx = prepare_call(ctx, contract, selector, gas_limit, gas_price);
 
         let mut evm = call_ctx.build_seismic_evm();
@@ -319,7 +345,42 @@ mod tests {
 
         let result = evm.replay()?;
 
-        assert_cload_error(&result, balance, gas_limit, gas_price);
+        assert_storage_access_error(
+            &result,
+            SeismicHaltReason::InvalidPublicStorageAccess,
+            balance,
+            gas_limit,
+            gas_price,
+        );
+        Ok(())
+    }
+
+    /// Tests that SSTORE halts with InvalidPrivateStorageAccess when trying to
+    /// write to a private slot.
+    #[test]
+    fn sstore_on_private_slot_halts() -> anyhow::Result<()> {
+        let (bytecode, selector) = get_sstore_violation_bytecode();
+        let (ctx, contract) = deploy_contract_with_bytecode(bytecode)?;
+
+        let balance = 1_000_000;
+        let gas_limit = 100_000;
+        let gas_price = 10;
+
+        let call_ctx = prepare_call(ctx, contract, selector, gas_limit, gas_price);
+
+        let mut evm = call_ctx.build_seismic_evm();
+        let account = evm.ctx().journal_mut().load_account(BENCH_CALLER).unwrap();
+        account.data.info.balance = U256::from(balance);
+
+        let result = evm.replay()?;
+
+        assert_storage_access_error(
+            &result,
+            SeismicHaltReason::InvalidPrivateStorageAccess,
+            balance,
+            gas_limit,
+            gas_price,
+        );
         Ok(())
     }
 

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -8,14 +8,15 @@ use revm::{
             WARM_STORAGE_READ_COST,
         },
         interpreter_types::{InputsTr, InterpreterTypes, RuntimeFlag, StackTr},
-        popn, popn_top, require_non_staticcall, Host, Instruction, InstructionContext,
-        InstructionResult, _count, gas,
+        popn, popn_top, require_non_staticcall, Instruction, InstructionContext, InstructionResult,
+        _count, gas,
     },
 };
 
 /// Implements the SLOAD instruction.
 ///
 /// Loads a word from storage.
+/// SLOAD can only read from public slots. Attempting to read from a private slot will halt.
 pub fn sload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
     context: InstructionContext<'_, H, WIRE>,
 ) {
@@ -99,7 +100,10 @@ pub fn cload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
 /// Implements the SSTORE instruction.
 ///
 /// Stores a word to public storage.
-pub fn sstore<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionContext<'_, H, WIRE>) {
+/// SSTORE can only write to public slots. Attempting to write to a private slot will halt.
+pub fn sstore<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
+    context: InstructionContext<'_, H, WIRE>,
+) {
     require_non_staticcall!(context.interpreter);
     popn!([index, value], context.interpreter);
 
@@ -143,6 +147,15 @@ pub fn sstore<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionCont
         load
     };
 
+    // Privacy check: SSTORE cannot write to private slots
+    if state_load.data.present_value.is_private {
+        context.interpreter.halt_fatal();
+        context
+            .host
+            .set_halt_reason(SeismicHaltReason::InvalidPrivateStorageAccess);
+        return;
+    }
+
     // dynamic gas
     gas!(
         context.interpreter,
@@ -165,7 +178,17 @@ pub fn sstore<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionCont
 /// Stores a word to shielded storage with flat gas cost to prevent information leakage.
 /// Unlike SSTORE, CSTORE charges constant gas regardless of value transitions to avoid
 /// leaking information about secret values through gas observations.
-pub fn cstore<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionContext<'_, H, WIRE>) {
+///
+/// CSTORE can write to:
+/// - (0, public) -> (y, private): switching from uninitialized/zero public to private
+/// - (0, private) -> (y, private): writing to zero private slot
+/// - (x, private) -> (y, private): writing to non-zero private slot
+///
+/// CSTORE will HALT on:
+/// - (x, public) where x != 0: cannot overwrite non-zero public slot
+pub fn cstore<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
+    context: InstructionContext<'_, H, WIRE>,
+) {
     check!(context.interpreter, MERCURY);
     require_non_staticcall!(context.interpreter);
     popn!([index, value], context.interpreter);
@@ -191,8 +214,20 @@ pub fn cstore<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionCont
         + COLD_SLOAD_COST_ADDITIONAL;
     gas!(context.interpreter, flat_gas);
 
-    if context.host.cstore(target, index, value, false).is_err() {
-        context.interpreter.halt_fatal()
+    let result = context.host.cstore(target, index, value, false);
+    match result {
+        Ok(state_load) => {
+            // Privacy check: CSTORE cannot overwrite non-zero public slots
+            if !state_load.data.present_value.is_private
+                && !state_load.data.present_value.value.is_zero()
+            {
+                context.interpreter.halt_fatal();
+                context
+                    .host
+                    .set_halt_reason(SeismicHaltReason::InvalidPublicStorageAccess);
+            }
+        }
+        Err(_) => context.interpreter.halt_fatal(),
     }
 }
 
@@ -360,6 +395,7 @@ mod tests {
         use revm::database::EmptyDB;
         use revm::database_interface::Database;
         use revm::interpreter::gas::COLD_SLOAD_COST_ADDITIONAL;
+        use revm::interpreter::Host;
         use revm::primitives::{Log, B256};
 
         const CSTORE_FLAT_GAS: u64 =

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -721,4 +721,538 @@ mod tests {
             );
         }
     }
+
+    /// Tests for storage opcode semantics as defined in the table (one test per matrix entry):
+    ///
+    /// |           | (0, public)  | (x, public) | (0, private) | (x, private) |
+    /// | --------- | ------------ | ----------- | ------------ | ------------ |
+    /// | SLOAD     | 0            | x           | HALT         | HALT         |
+    /// | CLOAD     | 0            | x           | 0            | x            |
+    /// | SSTORE(y) | (y, public)  | (y, public) | HALT         | HALT         |
+    /// | CSTORE(y) | (y, private) | HALT        | (y, private) | (y, private) |
+    mod semantics_tests {
+        use super::*;
+        use crate::SeismicHaltReason;
+        use revm::context::host::LoadError;
+        use revm::context_interface::journaled_state::{AccountInfoLoad, AccountLoad, StateLoad};
+        use revm::database::EmptyDB;
+        use revm::database_interface::Database;
+        use revm::interpreter::Host;
+        use revm::primitives::{Log, B256};
+
+        /// A configurable mock host for testing storage semantics.
+        struct MockStorageHost {
+            storage_state: FlaggedStorage,
+            halt_reason: Option<SeismicHaltReason>,
+        }
+
+        impl MockStorageHost {
+            fn new(value: U256, is_private: bool) -> Self {
+                Self {
+                    storage_state: FlaggedStorage::new(value, is_private),
+                    halt_reason: None,
+                }
+            }
+
+            fn zero_public() -> Self {
+                Self::new(U256::ZERO, false)
+            }
+
+            fn nonzero_public(value: u64) -> Self {
+                Self::new(U256::from(value), false)
+            }
+
+            fn zero_private() -> Self {
+                Self::new(U256::ZERO, true)
+            }
+
+            fn nonzero_private(value: u64) -> Self {
+                Self::new(U256::from(value), true)
+            }
+        }
+
+        impl crate::instructions::seismic_host::SeismicHost for MockStorageHost {
+            type Db = EmptyDB;
+
+            #[allow(static_mut_refs)]
+            fn ctx_error(
+                &mut self,
+            ) -> &mut Result<
+                (),
+                revm::context_interface::context::ContextError<<Self::Db as Database>::Error>,
+            > {
+                static mut ERR: Result<
+                    (),
+                    revm::context_interface::context::ContextError<std::convert::Infallible>,
+                > = Ok(());
+                unsafe { &mut ERR }
+            }
+
+            fn set_halt_reason(&mut self, reason: SeismicHaltReason) {
+                self.halt_reason = Some(reason);
+            }
+        }
+
+        impl Host for MockStorageHost {
+            fn basefee(&self) -> U256 {
+                U256::ZERO
+            }
+            fn blob_gasprice(&self) -> U256 {
+                U256::ZERO
+            }
+            fn gas_limit(&self) -> U256 {
+                U256::MAX
+            }
+            fn difficulty(&self) -> U256 {
+                U256::ZERO
+            }
+            fn prevrandao(&self) -> Option<U256> {
+                None
+            }
+            fn block_number(&self) -> U256 {
+                U256::ZERO
+            }
+            fn timestamp(&self) -> U256 {
+                U256::ZERO
+            }
+            fn beneficiary(&self) -> Address {
+                Address::ZERO
+            }
+            fn chain_id(&self) -> U256 {
+                U256::from(1)
+            }
+            fn effective_gas_price(&self) -> U256 {
+                U256::ZERO
+            }
+            fn caller(&self) -> Address {
+                Address::ZERO
+            }
+            fn blob_hash(&self, _: usize) -> Option<U256> {
+                None
+            }
+            fn max_initcode_size(&self) -> usize {
+                0
+            }
+            fn block_hash(&mut self, _: u64) -> Option<B256> {
+                None
+            }
+            fn selfdestruct(
+                &mut self,
+                _: Address,
+                _: Address,
+            ) -> Option<StateLoad<revm::interpreter::SelfDestructResult>> {
+                None
+            }
+            fn log(&mut self, _: Log) {}
+            fn tstore(&mut self, _: Address, _: U256, _: U256) {}
+            fn tload(&mut self, _: Address, _: U256) -> U256 {
+                U256::ZERO
+            }
+
+            fn sload(&mut self, _: Address, _: U256) -> Option<StateLoad<U256>> {
+                Some(StateLoad::new(
+                    self.storage_state.value,
+                    false,
+                    self.storage_state.is_private,
+                ))
+            }
+
+            fn sload_skip_cold_load(
+                &mut self,
+                _: Address,
+                _: U256,
+                _: bool,
+            ) -> Result<StateLoad<U256>, LoadError> {
+                Ok(StateLoad::new(
+                    self.storage_state.value,
+                    false,
+                    self.storage_state.is_private,
+                ))
+            }
+
+            fn sstore(
+                &mut self,
+                _: Address,
+                _: U256,
+                new_value: U256,
+            ) -> Option<StateLoad<SStoreResult>> {
+                Some(StateLoad::new(
+                    SStoreResult {
+                        original_value: self.storage_state,
+                        present_value: self.storage_state,
+                        new_value: FlaggedStorage::new(new_value, false),
+                    },
+                    false,
+                    false,
+                ))
+            }
+
+            fn sstore_skip_cold_load(
+                &mut self,
+                _: Address,
+                _: U256,
+                new_value: U256,
+                _: bool,
+            ) -> Result<StateLoad<SStoreResult>, LoadError> {
+                Ok(StateLoad::new(
+                    SStoreResult {
+                        original_value: self.storage_state,
+                        present_value: self.storage_state,
+                        new_value: FlaggedStorage::new(new_value, false),
+                    },
+                    false,
+                    false,
+                ))
+            }
+
+            fn cstore(
+                &mut self,
+                _: Address,
+                _: U256,
+                new_value: U256,
+                _: bool,
+            ) -> Result<StateLoad<SStoreResult>, LoadError> {
+                Ok(StateLoad::new(
+                    SStoreResult {
+                        original_value: self.storage_state,
+                        present_value: self.storage_state,
+                        new_value: FlaggedStorage::new(new_value, true),
+                    },
+                    false,
+                    true,
+                ))
+            }
+
+            fn cload(
+                &mut self,
+                _: Address,
+                _: U256,
+                _: bool,
+            ) -> Result<StateLoad<U256>, LoadError> {
+                Ok(StateLoad::new(
+                    self.storage_state.value,
+                    false,
+                    self.storage_state.is_private,
+                ))
+            }
+
+            fn balance(&mut self, _: Address) -> Option<StateLoad<U256>> {
+                None
+            }
+            fn load_account_delegated(&mut self, _: Address) -> Option<StateLoad<AccountLoad>> {
+                None
+            }
+            fn load_account_code(&mut self, _: Address) -> Option<StateLoad<Bytes>> {
+                None
+            }
+            fn load_account_code_hash(&mut self, _: Address) -> Option<StateLoad<B256>> {
+                None
+            }
+            fn load_account_info_skip_cold_load(
+                &mut self,
+                _: Address,
+                _: bool,
+                _: bool,
+            ) -> Result<AccountInfoLoad<'_>, LoadError> {
+                Err(LoadError::DBError)
+            }
+        }
+
+        // SLOAD tests
+
+        #[test]
+        fn test_sload_zero_public_returns_zero() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::zero_public();
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+
+            sload(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert!(interp.bytecode.instruction_result().is_none());
+            assert_eq!(interp.stack.pop().unwrap(), U256::ZERO);
+        }
+
+        #[test]
+        fn test_sload_nonzero_public_returns_value() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::nonzero_public(42);
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+
+            sload(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert!(interp.bytecode.instruction_result().is_none());
+            assert_eq!(interp.stack.pop().unwrap(), U256::from(42));
+        }
+
+        #[test]
+        fn test_sload_zero_private_halts() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::zero_private();
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+
+            sload(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert_eq!(
+                interp.bytecode.instruction_result(),
+                Some(InstructionResult::FatalExternalError)
+            );
+            assert_eq!(
+                host.halt_reason,
+                Some(SeismicHaltReason::InvalidPrivateStorageAccess)
+            );
+        }
+
+        #[test]
+        fn test_sload_nonzero_private_halts() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::nonzero_private(42);
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+
+            sload(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert_eq!(
+                interp.bytecode.instruction_result(),
+                Some(InstructionResult::FatalExternalError)
+            );
+            assert_eq!(
+                host.halt_reason,
+                Some(SeismicHaltReason::InvalidPrivateStorageAccess)
+            );
+        }
+
+        // CLOAD tests
+
+        #[test]
+        fn test_cload_zero_public_returns_zero() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::zero_public();
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+
+            cload(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert!(interp.bytecode.instruction_result().is_none());
+            assert_eq!(interp.stack.pop().unwrap(), U256::ZERO);
+        }
+
+        #[test]
+        fn test_cload_nonzero_public_returns_value() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::nonzero_public(42);
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+
+            cload(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert!(interp.bytecode.instruction_result().is_none());
+            assert_eq!(interp.stack.pop().unwrap(), U256::from(42));
+        }
+
+        #[test]
+        fn test_cload_zero_private_returns_zero() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::zero_private();
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+
+            cload(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert!(interp.bytecode.instruction_result().is_none());
+            assert_eq!(interp.stack.pop().unwrap(), U256::ZERO);
+        }
+
+        #[test]
+        fn test_cload_nonzero_private_returns_value() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::nonzero_private(42);
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+
+            cload(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert!(interp.bytecode.instruction_result().is_none());
+            assert_eq!(interp.stack.pop().unwrap(), U256::from(42));
+        }
+
+        // SSTORE tests
+
+        #[test]
+        fn test_sstore_zero_public_succeeds() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::zero_public();
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+            let _ = interp.stack.push(U256::from(42));
+
+            sstore(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert!(interp.bytecode.instruction_result().is_none());
+        }
+
+        #[test]
+        fn test_sstore_nonzero_public_succeeds() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::nonzero_public(100);
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+            let _ = interp.stack.push(U256::from(42));
+
+            sstore(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert!(interp.bytecode.instruction_result().is_none());
+        }
+
+        #[test]
+        fn test_sstore_zero_private_halts() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::zero_private();
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+            let _ = interp.stack.push(U256::from(42));
+
+            sstore(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert_eq!(
+                interp.bytecode.instruction_result(),
+                Some(InstructionResult::FatalExternalError)
+            );
+            assert_eq!(
+                host.halt_reason,
+                Some(SeismicHaltReason::InvalidPrivateStorageAccess)
+            );
+        }
+
+        #[test]
+        fn test_sstore_nonzero_private_halts() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::nonzero_private(100);
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+            let _ = interp.stack.push(U256::from(42));
+
+            sstore(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert_eq!(
+                interp.bytecode.instruction_result(),
+                Some(InstructionResult::FatalExternalError)
+            );
+            assert_eq!(
+                host.halt_reason,
+                Some(SeismicHaltReason::InvalidPrivateStorageAccess)
+            );
+        }
+
+        // CSTORE tests
+
+        #[test]
+        fn test_cstore_zero_public_succeeds() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::zero_public();
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+            let _ = interp.stack.push(U256::from(42));
+
+            cstore(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert!(interp.bytecode.instruction_result().is_none());
+        }
+
+        #[test]
+        fn test_cstore_nonzero_public_halts() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::nonzero_public(100);
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+            let _ = interp.stack.push(U256::from(42));
+
+            cstore(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert_eq!(
+                interp.bytecode.instruction_result(),
+                Some(InstructionResult::FatalExternalError)
+            );
+            assert_eq!(
+                host.halt_reason,
+                Some(SeismicHaltReason::InvalidPublicStorageAccess)
+            );
+        }
+
+        #[test]
+        fn test_cstore_zero_private_succeeds() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::zero_private();
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+            let _ = interp.stack.push(U256::from(42));
+
+            cstore(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert!(interp.bytecode.instruction_result().is_none());
+        }
+
+        #[test]
+        fn test_cstore_nonzero_private_succeeds() {
+            let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
+            let mut host = MockStorageHost::nonzero_private(100);
+            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let _ = interp.stack.push(U256::from(0));
+            let _ = interp.stack.push(U256::from(42));
+
+            cstore(InstructionContext {
+                interpreter: &mut interp,
+                host: &mut host,
+            });
+
+            assert!(interp.bytecode.instruction_result().is_none());
+        }
+    }
 }

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -74,7 +74,10 @@ pub fn sload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
 
 /// Implements the CLOAD instruction.
 ///
-/// Loads a word from shielded storage with flat gas cost to prevent information leakage.
+/// Loads a word from storage with flat gas cost to prevent information leakage.
+/// Note that CLOAD is strictly more powerful than SLOAD, as it can access both private and public storage.
+/// SLOAD should however be preferred when accessing public storage, since CLOAD charges constant gas regardless
+/// of access patterns to avoid leaking information about secret values through gas observations.
 pub fn cload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
     context: InstructionContext<'_, H, WIRE>,
 ) {
@@ -90,15 +93,6 @@ pub fn cload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
     let Some(storage) = context.host.sload(target, *index) else {
         return context.interpreter.halt_fatal();
     };
-
-    if !storage.is_private && !storage.data.is_zero() {
-        context.interpreter.halt_fatal();
-        context
-            .host
-            .set_halt_reason(SeismicHaltReason::InvalidPublicStorageAccess);
-        return;
-    }
-
     *index = storage.data;
 }
 


### PR DESCRIPTION
See committed README changes for explanation of new semantics. TLDR is that we are implementing these new semantics, after some audit discussions.

|           | (0, public)  | (x, public) | (0, private) | (x, private) |
| --------- | ------------ | ----------- | ------------ | ------------ |
| SLOAD     | 0            | x           | HALT         | HALT         |
| CLOAD     | 0            | x           | 0            | x            |
| SSTORE(y) | (y, public)  | (y, public) | HALT         | HALT         |
| CSTORE(y) | (y, private) | HALT        | (y, private) | (y, private) |

## Note

Had to update CI semantic tests to point to https://github.com/SeismicSystems/seismic-solidity/pull/130 in order to fix tests. We should change back CI once that PR merges after audit. Added a note in that PR.