### PR TITLE
chore(confidential_storage): remove cload/cstore notion from journal

### DIFF
--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -96,23 +96,6 @@ pub trait Host {
         self.sstore_skip_cold_load(address, key, value, false).ok()
     }
 
-    /// Cstore, for storing shielded state
-    fn cstore(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        value: StorageValue,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError>;
-
-    /// Cload, for loading shielded state
-    fn cload(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, LoadError>;
-
     /// Sload with optional fetch from database. Return none if the value is cold or if there is db error.
     fn sload_skip_cold_load(
         &mut self,
@@ -127,10 +110,10 @@ pub trait Host {
     }
 
     /// Tstore, calls `ContextTr::journal_mut().tstore(address, key, value)`
-    fn tstore(&mut self, address: Address, key: StorageKey, value: StorageValue);
+    fn tstore(&mut self, address: Address, key: StorageKey, value: U256);
 
     /// Tload, calls `ContextTr::journal_mut().tload(address, key)`
-    fn tload(&mut self, address: Address, key: StorageKey) -> StorageValue;
+    fn tload(&mut self, address: Address, key: StorageKey) -> U256;
 
     /// Main function to load account info.
     ///
@@ -168,7 +151,6 @@ pub trait Host {
                 is_empty: account.is_empty,
             },
             account.is_cold,
-            false,
         );
 
         // load delegate code if account is EIP-7702
@@ -287,29 +269,10 @@ impl Host for DummyHost {
 
     fn log(&mut self, _log: Log) {}
 
-    fn tstore(&mut self, _address: Address, _key: StorageKey, _value: StorageValue) {}
+    fn tstore(&mut self, _address: Address, _key: StorageKey, _value: U256) {}
 
-    fn tload(&mut self, _address: Address, _key: StorageKey) -> StorageValue {
-        StorageValue::ZERO
-    }
-
-    fn cload(
-        &mut self,
-        _address: Address,
-        _key: StorageKey,
-        _skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, LoadError> {
-        Err(LoadError::DBError)
-    }
-
-    fn cstore(
-        &mut self,
-        _address: Address,
-        _key: StorageKey,
-        _value: StorageValue,
-        _skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError> {
-        Err(LoadError::DBError)
+    fn tload(&mut self, _address: Address, _key: StorageKey) -> U256 {
+        U256::ZERO
     }
 
     fn load_account_info_skip_cold_load(

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -42,16 +42,6 @@ pub trait JournalTr {
             .map_err(JournalLoadError::unwrap_db_error)
     }
 
-    /// Returns the private storage value from Journal state.
-    ///
-    /// Loads the storage from database if not found in Journal state.
-    fn cload(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        _skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, <Self::Database as Database>::Error>;
-
     /// Loads the storage value from Journal state.
     fn sload_skip_cold_load(
         &mut self,
@@ -71,15 +61,6 @@ pub trait JournalTr {
         self.sstore_skip_cold_load(address, key, value, false)
             .map_err(JournalLoadError::unwrap_db_error)
     }
-
-    /// Stores the storage value in Journal state.
-    fn cstore(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        value: StorageValue,
-        _skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, <Self::Database as Database>::Error>;
 
     /// Stores the storage value in Journal state.
     fn sstore_skip_cold_load(
@@ -202,7 +183,7 @@ pub trait JournalTr {
         // SAFETY: Safe to unwrap as load_code will insert code if it is empty.
         let code = a.info.code.as_ref().unwrap().original_bytes();
 
-        Ok(StateLoad::new(code, a.is_cold, false))
+        Ok(StateLoad::new(code, a.is_cold))
     }
 
     /// Gets code hash of account.
@@ -212,10 +193,10 @@ pub trait JournalTr {
     ) -> Result<StateLoad<B256>, <Self::Database as Database>::Error> {
         let acc = self.load_account_code(address)?;
         if acc.is_empty() {
-            return Ok(StateLoad::new(B256::ZERO, acc.is_cold, false));
+            return Ok(StateLoad::new(B256::ZERO, acc.is_cold));
         }
         let hash = acc.info.code_hash;
-        Ok(StateLoad::new(hash, acc.is_cold, false))
+        Ok(StateLoad::new(hash, acc.is_cold))
     }
 
     /// Called at the end of the transaction to clean all residue data from journal.
@@ -366,8 +347,6 @@ pub struct StateLoad<T> {
     pub data: T,
     /// Is account is cold loaded
     pub is_cold: bool,
-    /// True if slot was tagged as private.
-    pub is_private: bool,
 }
 
 impl<T> Deref for StateLoad<T> {
@@ -386,12 +365,8 @@ impl<T> DerefMut for StateLoad<T> {
 
 impl<T> StateLoad<T> {
     /// Returns a new [`StateLoad`] with the given data and cold load status.
-    pub fn new(data: T, is_cold: bool, is_private: bool) -> Self {
-        Self {
-            data,
-            is_cold,
-            is_private,
-        }
+    pub fn new(data: T, is_cold: bool) -> Self {
+        Self { data, is_cold }
     }
 
     /// Maps the data of the [`StateLoad`] to a new value.
@@ -401,7 +376,7 @@ impl<T> StateLoad<T> {
     where
         F: FnOnce(T) -> B,
     {
-        StateLoad::new(f(self.data), self.is_cold, self.is_private)
+        StateLoad::new(f(self.data), self.is_cold)
     }
 }
 
@@ -444,7 +419,7 @@ impl<'a> AccountInfoLoad<'a> {
     where
         F: FnOnce(Cow<'a, AccountInfo>) -> O,
     {
-        StateLoad::new(f(self.account), self.is_cold, false)
+        StateLoad::new(f(self.account), self.is_cold)
     }
 }
 

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -532,36 +532,13 @@ impl<
     /* Journal */
 
     /// Gets the transient storage value of `address` at `index`.
-    fn tload(&mut self, address: Address, index: StorageKey) -> StorageValue {
+    fn tload(&mut self, address: Address, index: StorageKey) -> U256 {
         self.journal_mut().tload(address, index)
     }
 
     /// Sets the transient storage value of `address` at `index`.
-    fn tstore(&mut self, address: Address, index: StorageKey, value: StorageValue) {
+    fn tstore(&mut self, address: Address, index: StorageKey, value: U256) {
         self.journal_mut().tstore(address, index, value)
-    }
-
-    fn cload(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, LoadError> {
-        self.journal_mut()
-            .cload(address, key, skip_cold_load)
-            .map_err(|_e| LoadError::DBError)
-    }
-
-    fn cstore(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        value: StorageValue,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError> {
-        self.journal_mut()
-            .cstore(address, key, value, skip_cold_load)
-            .map_err(|_e| LoadError::DBError)
     }
 
     /// Emits a log owned by `address` with given `LogData`.

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -20,7 +20,10 @@ use context_interface::{
 };
 use core::ops::{Deref, DerefMut};
 use database_interface::Database;
-use primitives::{hardfork::SpecId, Address, HashSet, Log, StorageKey, StorageValue, B256, U256};
+use primitives::{
+    hardfork::SpecId, Address, HashSet, Log, StorageKey, StorageValue, TransientStorageValue, B256,
+    U256,
+};
 use state::{Account, EvmState};
 use std::vec::Vec;
 
@@ -108,29 +111,6 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         &mut self.database
     }
 
-    fn cload(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        _skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, <Self::Database as Database>::Error> {
-        self.inner
-            .cload(&mut self.database, address, key, false)
-            .map_err(JournalLoadError::unwrap_db_error)
-    }
-
-    fn cstore(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        value: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, <Self::Database as Database>::Error> {
-        self.inner
-            .cstore(&mut self.database, address, key, value, skip_cold_load)
-            .map_err(JournalLoadError::unwrap_db_error)
-    }
-
     fn sload(
         &mut self,
         address: Address,
@@ -145,18 +125,18 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         &mut self,
         address: Address,
         key: StorageKey,
-        value: U256,
+        value: StorageValue,
     ) -> Result<StateLoad<SStoreResult>, <Self::Database as Database>::Error> {
         self.inner
             .sstore(&mut self.database, address, key, value, false)
             .map_err(JournalLoadError::unwrap_db_error)
     }
 
-    fn tload(&mut self, address: Address, key: StorageKey) -> U256 {
+    fn tload(&mut self, address: Address, key: StorageKey) -> TransientStorageValue {
         self.inner.tload(address, key)
     }
 
-    fn tstore(&mut self, address: Address, key: StorageKey, value: U256) {
+    fn tstore(&mut self, address: Address, key: StorageKey, value: TransientStorageValue) {
         self.inner.tstore(address, key, value)
     }
 

--- a/crates/context/src/journal/entry.rs
+++ b/crates/context/src/journal/entry.rs
@@ -6,7 +6,7 @@
 //! or removal of the storage slot. Check [`JournalEntryTr`] for more details.
 use primitives::alloy_primitives::FlaggedStorage;
 
-use primitives::{Address, StorageKey, StorageValue, KECCAK_EMPTY, PRECOMPILE3, U256};
+use primitives::{Address, StorageKey, TransientStorageValue, KECCAK_EMPTY, PRECOMPILE3, U256};
 use state::{EvmState, TransientStorage};
 
 /// Trait for tracking and reverting state changes in the EVM.
@@ -55,7 +55,7 @@ pub trait JournalEntryTr {
     fn transient_storage_changed(
         address: Address,
         key: StorageKey,
-        had_value: StorageValue,
+        had_value: TransientStorageValue,
     ) -> Self;
 
     /// Creates a journal entry for when an account's code is modified
@@ -203,7 +203,7 @@ pub enum JournalEntry {
         /// Key of transient storage slot that is changed.
         key: StorageKey,
         /// Previous value of transient storage slot.
-        had_value: StorageValue,
+        had_value: TransientStorageValue,
         /// Address of account that had its transient storage changed.
         address: Address,
     },
@@ -224,7 +224,7 @@ impl JournalEntryTr for JournalEntry {
         address: Address,
         target: Address,
         destroyed_status: SelfdestructionRevertStatus,
-        had_balance: StorageValue,
+        had_balance: U256,
     ) -> Self {
         JournalEntry::AccountDestroyed {
             address,
@@ -275,7 +275,7 @@ impl JournalEntryTr for JournalEntry {
     fn transient_storage_changed(
         address: Address,
         key: StorageKey,
-        had_value: StorageValue,
+        had_value: TransientStorageValue,
     ) -> Self {
         JournalEntry::TransientStorageChange {
             address,

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -9,7 +9,7 @@ use context_interface::{
 };
 use core::mem;
 use database_interface::Database;
-use primitives::alloy_primitives::FlaggedStorage;
+use primitives::TransientStorageValue;
 use primitives::{
     hardfork::SpecId::{self, *},
     hash_map::Entry,
@@ -65,29 +65,6 @@ impl<ENTRY: JournalEntryTr> Default for JournalInner<ENTRY> {
 }
 
 impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
-    /// Loads the private storage value from Journal state.
-    pub fn cload<DB: Database>(
-        &mut self,
-        db: &mut DB,
-        address: Address,
-        key: StorageKey,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, JournalLoadError<DB::Error>> {
-        self.load_inner(db, address, key, skip_cold_load, true)
-    }
-
-    /// Stores the private storage value in Journal state.
-    pub fn cstore<DB: Database>(
-        &mut self,
-        db: &mut DB,
-        address: Address,
-        key: StorageKey,
-        value: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, JournalLoadError<DB::Error>> {
-        self.store(db, address, key, value, skip_cold_load, true)
-    }
-
     /// Creates new [`JournalInner`].
     ///
     /// `warm_preloaded_addresses` is used to determine if address is considered warm loaded.
@@ -579,7 +556,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                     == SelfdestructionRevertStatus::RepeatedSelfdestruction,
             },
             is_cold,
-            is_private: false,
         })
     }
 
@@ -620,7 +596,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                 is_empty,
             },
             account.is_cold,
-            false,
         );
 
         // load delegate code if account is EIP-7702
@@ -690,7 +665,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                 StateLoad {
                     data: account,
                     is_cold,
-                    is_private: false,
                 }
             }
             Entry::Vacant(vac) => {
@@ -710,7 +684,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                 StateLoad {
                     data: vac.insert(account),
                     is_cold,
-                    is_private: false,
                 }
             }
         };
@@ -740,7 +713,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                 address,
                 storage_key,
                 false,
-                false,
             )?;
         }
         Ok(load)
@@ -752,13 +724,12 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     ///
     /// Panics if the account is not present in the state.
     #[inline]
-    fn load_inner<DB: Database>(
+    pub fn sload<DB: Database>(
         &mut self,
         db: &mut DB,
         address: Address,
         key: StorageKey,
         skip_cold_load: bool,
-        default_privacy: bool,
     ) -> Result<StateLoad<StorageValue>, JournalLoadError<DB::Error>> {
         // assume acc is warm
         let account = self.state.get_mut(&address).unwrap();
@@ -771,32 +742,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             address,
             key,
             skip_cold_load,
-            default_privacy,
         )
-    }
-
-    /// Loads public storage slot
-    pub fn sload<DB: Database>(
-        &mut self,
-        db: &mut DB,
-        address: Address,
-        key: StorageKey,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<StorageValue>, JournalLoadError<DB::Error>> {
-        self.load_inner(db, address, key, skip_cold_load, false)
-    }
-
-    /// Stores public storage value
-    #[inline]
-    pub fn sstore<DB: Database>(
-        &mut self,
-        db: &mut DB,
-        address: Address,
-        key: StorageKey,
-        value: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, JournalLoadError<DB::Error>> {
-        self.store(db, address, key, value, skip_cold_load, false)
     }
 
     /// Stores storage slot.
@@ -805,14 +751,13 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     ///
     /// **Note**: Account should already be present in our state.
     #[inline]
-    pub fn store<DB: Database>(
+    pub fn sstore<DB: Database>(
         &mut self,
         db: &mut DB,
         address: Address,
         key: StorageKey,
         new: StorageValue,
         skip_cold_load: bool,
-        is_private: bool,
     ) -> Result<StateLoad<SStoreResult>, JournalLoadError<DB::Error>> {
         // assume that acc exists and load the slot.
         let present = self.sload(db, address, key, skip_cold_load)?;
@@ -822,31 +767,28 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         let slot = acc.storage.get_mut(&key).unwrap();
 
         // new value is same as present, we don't need to do anything
-        let present_value = FlaggedStorage::new(present.data, present.is_private);
-        if present_value == FlaggedStorage::new(new, is_private) {
+        if present.data == new {
             return Ok(StateLoad::new(
                 SStoreResult {
                     original_value: slot.original_value(),
-                    present_value,
-                    new_value: FlaggedStorage::new(new, is_private),
+                    present_value: present.data,
+                    new_value: new,
                 },
                 present.is_cold,
-                is_private,
             ));
         }
 
         self.journal
-            .push(ENTRY::storage_changed(address, key, present_value));
+            .push(ENTRY::storage_changed(address, key, present.data));
         // insert value into present state.
-        slot.present_value = FlaggedStorage::new(new, is_private);
+        slot.present_value = new;
         Ok(StateLoad::new(
             SStoreResult {
                 original_value: slot.original_value(),
-                present_value,
-                new_value: FlaggedStorage::new(new, is_private),
+                present_value: present.data,
+                new_value: new,
             },
             present.is_cold,
-            is_private,
         ))
     }
 
@@ -854,7 +796,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     ///
     /// EIP-1153: Transient storage opcodes
     #[inline]
-    pub fn tload(&mut self, address: Address, key: StorageKey) -> U256 {
+    pub fn tload(&mut self, address: Address, key: StorageKey) -> TransientStorageValue {
         self.transient_storage
             .get(&(address, key))
             .copied()
@@ -868,7 +810,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     ///
     /// EIP-1153: Transient storage opcodes
     #[inline]
-    pub fn tstore(&mut self, address: Address, key: StorageKey, new: U256) {
+    pub fn tstore(&mut self, address: Address, key: StorageKey, new: TransientStorageValue) {
         let had_value = if new.is_zero() {
             // if new values is zero, remove entry from transient storage.
             // if previous values was some insert it inside journal.
@@ -914,35 +856,32 @@ pub fn sload_with_account<DB: Database, ENTRY: JournalEntryTr>(
     address: Address,
     key: StorageKey,
     skip_cold_load: bool,
-    default_privacy: bool,
 ) -> Result<StateLoad<StorageValue>, JournalLoadError<DB::Error>> {
-    // only if account is created in this tx we can assume that storage is empty.
     let is_newly_created = account.is_created();
-    let (value, is_cold, is_private) = match account.storage.entry(key) {
+    let (value, is_cold) = match account.storage.entry(key) {
         Entry::Occupied(occ) => {
             let slot = occ.into_mut();
+            // skip load if account is cold.
             let is_cold = slot.is_cold_transaction_id(transaction_id);
             if skip_cold_load && is_cold {
                 return Err(JournalLoadError::ColdLoadSkipped);
             }
-            let is_private = slot.present_value().is_private;
-            (slot.present_value.value, is_cold, is_private)
+            // TODO(samlaf): figure out how to deal with warming txs when cloading.
+            (slot.present_value, is_cold)
         }
         Entry::Vacant(vac) => {
-            // if storage was cleared, we don't need to ping db.
             if skip_cold_load {
                 return Err(JournalLoadError::ColdLoadSkipped);
             }
+            // if storage was cleared, we don't need to ping db.
             let value = if is_newly_created {
-                FlaggedStorage::ZERO.set_visibility(default_privacy)
+                StorageValue::ZERO
             } else {
-                let v = db.storage(address, key)?;
-                v
+                db.storage(address, key)?
             };
-
             vac.insert(EvmStorageSlot::new(value, transaction_id));
 
-            (value.value, true, value.is_private)
+            (value, true)
         }
     };
 
@@ -951,5 +890,5 @@ pub fn sload_with_account<DB: Database, ENTRY: JournalEntryTr>(
         journal.push(ENTRY::storage_warmed(address, key));
     }
 
-    Ok(StateLoad::new(value, is_cold, is_private))
+    Ok(StateLoad::new(value, is_cold))
 }

--- a/crates/context/src/journal/test_flagged_storage.rs
+++ b/crates/context/src/journal/test_flagged_storage.rs
@@ -1,8 +1,9 @@
 use super::entry::JournalEntry;
 use super::inner::JournalInner;
+use context_interface::context::{SStoreResult, StateLoad};
 use database::InMemoryDB;
 use database_interface::Database;
-use primitives::{hardfork::SpecId, Address, FlaggedStorage, U256};
+use primitives::{hardfork::SpecId, Address, FlaggedStorage, StorageValue, U256};
 use state::{Account, AccountInfo, AccountStatus, EvmStorage};
 
 // =============================================================================
@@ -46,18 +47,20 @@ fn verify_storage_state(
 ) {
     let result = journal.sload(db, address, key, false).unwrap();
     assert_eq!(
-        result.data, expected_value,
+        result.data.value, expected_value,
         "{}: Storage value mismatch. Expected {}, got {}",
-        context, expected_value, result.data
+        context, expected_value, result.data.value
     );
     assert_eq!(
-        result.is_private, expected_private,
+        result.data.is_private, expected_private,
         "{}: Privacy flag mismatch. Expected {}, got {}",
-        context, expected_private, result.is_private
+        context, expected_private, result.data.is_private
     );
 }
 
 // Helper function to store data using appropriate operation based on shielded parameter
+// When shielded=true, stores as private (like CSTORE opcode)
+// When shielded=false, stores as public (like SSTORE opcode)
 fn store_value(
     shielded: bool,
     journal: &mut JournalInner<JournalEntry>,
@@ -65,27 +68,23 @@ fn store_value(
     address: Address,
     key: U256,
     value: U256,
-) -> context_interface::context::StateLoad<context_interface::context::SStoreResult> {
-    if shielded {
-        journal.cstore(db, address, key, value, false).unwrap()
-    } else {
-        journal.sstore(db, address, key, value, false).unwrap()
-    }
+) -> StateLoad<SStoreResult> {
+    let storage_value = StorageValue::new(value, shielded);
+    journal.sstore(db, address, key, storage_value, false).unwrap()
 }
 
-// Helper function to load data using appropriate operation based on shielded parameter
+// Helper function to load data from storage
+// The shielded parameter is kept for API compatibility but sload is used for all cases
+// (at the journal level, there's no difference - the privacy flag is in the returned StorageValue)
+#[allow(unused_variables)]
 fn load_value(
     shielded: bool,
     journal: &mut JournalInner<JournalEntry>,
     db: &mut InMemoryDB,
     address: Address,
     key: U256,
-) -> context_interface::context::StateLoad<U256> {
-    if shielded {
-        journal.cload(db, address, key, false).unwrap()
-    } else {
-        journal.sload(db, address, key, false).unwrap()
-    }
+) -> StateLoad<StorageValue> {
+    journal.sload(db, address, key, false).unwrap()
 }
 
 // Helper function to verify account status
@@ -164,7 +163,7 @@ fn _test_storage_simple_revert(shielded: bool) {
         U256::from(42),
     );
     assert_eq!(
-        store_result.is_private, shielded,
+        store_result.data.new_value.is_private, shielded,
         "{} operation must mark storage as {}",
         operation_name, storage_type
     );
@@ -174,21 +173,16 @@ fn _test_storage_simple_revert(shielded: bool) {
         "{} must store correct value",
         operation_name
     );
-    assert_eq!(
-        store_result.data.new_value.is_private, shielded,
-        "{} must mark new value as {}",
-        operation_name, storage_type
-    );
 
     // Verify storage was stored with correct value using consistent load operation
     let before_revert = load_value(shielded, &mut journal, &mut db, address, storage_key);
     assert_eq!(
-        before_revert.data,
+        before_revert.data.value,
         U256::from(42),
         "Storage must contain the stored value before revert"
     );
     assert_eq!(
-        before_revert.is_private, shielded,
+        before_revert.data.is_private, shielded,
         "Storage must be marked {} before revert",
         storage_type
     );
@@ -210,7 +204,7 @@ fn _test_storage_simple_revert(shielded: bool) {
     // Verify state after revert - should be back to original (zero/empty)
     let after_revert = load_value(shielded, &mut journal, &mut db, address, storage_key);
     assert_eq!(
-        after_revert.data,
+        after_revert.data.value,
         U256::ZERO,
         "Storage value must be zero after reverting {} storage write",
         storage_type
@@ -218,12 +212,12 @@ fn _test_storage_simple_revert(shielded: bool) {
 
     if shielded {
         assert!(
-            !after_revert.is_private,
+            !after_revert.data.is_private,
             "BUGGY: Storage must be public (not private) after revert to empty state"
         );
     } else {
         assert!(
-            !after_revert.is_private,
+            !after_revert.data.is_private,
             "Storage must remain public after revert to empty state"
         );
     }
@@ -284,7 +278,7 @@ fn _test_account_creation_storage_revert(shielded: bool) {
         U256::from(99),
     );
     assert_eq!(
-        store_result.is_private, shielded,
+        store_result.data.new_value.is_private, shielded,
         "{} in new account must mark storage as {}",
         operation_name, storage_type
     );
@@ -298,12 +292,12 @@ fn _test_account_creation_storage_revert(shielded: bool) {
         storage_key,
     );
     assert_eq!(
-        read_result.data,
+        read_result.data.value,
         U256::from(99),
         "Storage must contain the stored value"
     );
     assert_eq!(
-        read_result.is_private, shielded,
+        read_result.data.is_private, shielded,
         "Storage must be marked {} after {}",
         storage_type, operation_name
     );
@@ -329,12 +323,12 @@ fn _test_account_creation_storage_revert(shielded: bool) {
             storage_key,
         );
         assert_eq!(
-            read_after_revert.data,
+            read_after_revert.data.value,
             U256::ZERO,
             "Storage must be zero after account creation revert"
         );
         assert!(
-            !read_after_revert.is_private,
+            !read_after_revert.data.is_private,
             "Storage must be public after account creation revert"
         );
     }
@@ -391,7 +385,7 @@ fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
         U256::from(10),
     );
     assert_eq!(
-        initial_store.is_private, shielded,
+        initial_store.data.new_value.is_private, shielded,
         "Level 0 {} must mark storage as {}",
         operation_name, storage_type
     );
@@ -422,7 +416,7 @@ fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
         U256::from(20),
     ); // Modify existing
     assert_eq!(
-        modify_store.is_private, shielded,
+        modify_store.data.new_value.is_private, shielded,
         "Level 1 key1 {} must maintain {} flag",
         operation_name, storage_type
     );
@@ -442,7 +436,7 @@ fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
         U256::from(30),
     ); // New key
     assert_eq!(
-        new_store.is_private, shielded,
+        new_store.data.new_value.is_private, shielded,
         "Level 1 key2 {} must mark storage as {}",
         operation_name, storage_type
     );
@@ -483,7 +477,7 @@ fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
         U256::from(40),
     ); // Modify again
     assert_eq!(
-        modify_again.is_private, shielded,
+        modify_again.data.new_value.is_private, shielded,
         "Level 2 {} must maintain {} flag",
         operation_name, storage_type
     );
@@ -570,19 +564,19 @@ fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
     // Check key2 after complete revert - behavior differs between private and public
     let key2_after_revert = load_value(shielded, &mut journal, &mut db, address, key2);
     assert_eq!(
-        key2_after_revert.data,
+        key2_after_revert.data.value,
         U256::ZERO,
         "key2 must revert to zero after level 1 revert"
     );
 
     if shielded {
         assert!(
-            !key2_after_revert.is_private,
+            !key2_after_revert.data.is_private,
             "BUGGY: key2 must be public (empty) after level 1 revert for private storage"
         );
     } else {
         assert!(
-            !key2_after_revert.is_private,
+            !key2_after_revert.data.is_private,
             "key2 must be public (empty) after level 1 revert for public storage"
         );
     }
@@ -697,7 +691,7 @@ fn test_mixed_storage_revert() {
         U256::from(100),
     );
     assert!(
-        !initial_public_store.is_private,
+        !initial_public_store.data.new_value.is_private,
         "SSTORE operation must mark storage as public"
     );
     assert_eq!(
@@ -731,7 +725,7 @@ fn test_mixed_storage_revert() {
         U256::from(200),
     );
     assert!(
-        private_store.is_private,
+        private_store.data.new_value.is_private,
         "CSTORE operation must mark storage as private"
     );
     assert_eq!(
@@ -750,7 +744,7 @@ fn test_mixed_storage_revert() {
         U256::from(300),
     );
     assert!(
-        !public_modify.is_private,
+        !public_modify.data.new_value.is_private,
         "SSTORE operation must keep storage public"
     );
     assert_eq!(
@@ -769,21 +763,21 @@ fn test_mixed_storage_revert() {
     let private_read = load_value(true, &mut journal, &mut db, address, private_key);
     let public_read = load_value(false, &mut journal, &mut db, address, public_key);
     assert_eq!(
-        private_read.data,
+        private_read.data.value,
         U256::from(200),
         "Private storage must contain correct value before revert"
     );
     assert!(
-        private_read.is_private,
+        private_read.data.is_private,
         "Private storage must be marked private before revert"
     );
     assert_eq!(
-        public_read.data,
+        public_read.data.value,
         U256::from(300),
         "Public storage must contain correct value before revert"
     );
     assert!(
-        !public_read.is_private,
+        !public_read.data.is_private,
         "Public storage must be marked public before revert"
     );
 
@@ -802,21 +796,21 @@ fn test_mixed_storage_revert() {
     let public_after = load_value(false, &mut journal, &mut db, address, public_key);
 
     assert_eq!(
-        private_after.data,
+        private_after.data.value,
         U256::ZERO,
         "Private storage value must be zero after revert"
     );
     assert!(
-        !private_after.is_private,
+        !private_after.data.is_private,
         "BUGGY: Reverted private storage must be public (empty)"
     );
     assert_eq!(
-        public_after.data,
+        public_after.data.value,
         U256::from(100),
         "Public storage value must be reverted to original"
     );
     assert!(
-        !public_after.is_private,
+        !public_after.data.is_private,
         "Public storage must remain public after revert"
     );
 

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -9,7 +9,9 @@ use crate::{
 };
 use context_interface::host::LoadError;
 use core::cmp::min;
-use primitives::{hardfork::SpecId::*, Bytes, Log, LogData, B256, BLOCK_HASH_HISTORY, U256};
+use primitives::{
+    hardfork::SpecId::*, Bytes, Log, LogData, StorageValue, B256, BLOCK_HASH_HISTORY, U256,
+};
 
 use crate::InstructionContext;
 
@@ -245,7 +247,7 @@ pub fn sload<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionConte
                     gas!(context.interpreter, COLD_SLOAD_COST_ADDITIONAL);
                 }
 
-                *index = storage.data;
+                *index = storage.data.value;
             }
             Err(LoadError::ColdLoadSkipped) => context.interpreter.halt_oog(),
             Err(LoadError::DBError) => context.interpreter.halt_fatal(),
@@ -254,7 +256,7 @@ pub fn sload<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionConte
         let Some(storage) = context.host.sload(target, *index) else {
             return context.interpreter.halt_fatal();
         };
-        *index = storage.data;
+        *index = storage.data.value;
     };
 }
 
@@ -290,16 +292,22 @@ pub fn sstore<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionCont
 
     let state_load = if spec_id.is_enabled_in(BERLIN) {
         let skip_cold = context.interpreter.gas.remaining() < COLD_SLOAD_COST_ADDITIONAL;
-        let res = context
-            .host
-            .sstore_skip_cold_load(target, index, value, skip_cold);
+        let res = context.host.sstore_skip_cold_load(
+            target,
+            index,
+            StorageValue::new_from_value(value),
+            skip_cold,
+        );
         match res {
             Ok(load) => load,
             Err(LoadError::ColdLoadSkipped) => return context.interpreter.halt_oog(),
             Err(LoadError::DBError) => return context.interpreter.halt_fatal(),
         }
     } else {
-        let Some(load) = context.host.sstore(target, index, value) else {
+        let Some(load) = context
+            .host
+            .sstore(target, index, StorageValue::new_from_value(value))
+        else {
             return context.interpreter.halt_fatal();
         };
         load

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -43,7 +43,11 @@ pub type StorageKey = U256;
 
 /// Type alias for EVM storage values (256-bit unsigned integers).
 /// Used to store data values in smart contract storage slots.
-pub type StorageValue = U256;
+pub type StorageValue = FlaggedStorage;
+
+/// Type alias for EIP-1153 transient storage values (256-bit unsigned integers).
+/// Used for temporary storage that does not persist between transactions.
+pub type TransientStorageValue = U256;
 
 /// Optimize short address access.
 pub const SHORT_ADDRESS_CAP: usize = 300;

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -1,5 +1,6 @@
 use crate::{check, SeismicHaltReason, SeismicHost};
 use revm::primitives::hardfork::SpecId::*;
+use revm::primitives::StorageValue;
 use revm::{
     context::host::LoadError,
     interpreter::{
@@ -53,7 +54,7 @@ pub fn sload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
                     return;
                 }
 
-                *index = storage.data;
+                *index = storage.data.value;
             }
             Err(LoadError::ColdLoadSkipped) => context.interpreter.halt_oog(),
             Err(LoadError::DBError) => context.interpreter.halt_fatal(),
@@ -69,7 +70,7 @@ pub fn sload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
                 .set_halt_reason(SeismicHaltReason::InvalidPrivateStorageAccess);
             return;
         }
-        *index = storage.data;
+        *index = storage.data.value;
     };
 }
 
@@ -94,7 +95,7 @@ pub fn cload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
     let Some(storage) = context.host.sload(target, *index) else {
         return context.interpreter.halt_fatal();
     };
-    *index = storage.data;
+    *index = storage.data.value;
 }
 
 /// Implements the SSTORE instruction.
@@ -132,16 +133,22 @@ pub fn sstore<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
 
     let state_load = if spec_id.is_enabled_in(BERLIN) {
         let skip_cold = context.interpreter.gas.remaining() < COLD_SLOAD_COST_ADDITIONAL;
-        let res = context
-            .host
-            .sstore_skip_cold_load(target, index, value, skip_cold);
+        let res = context.host.sstore_skip_cold_load(
+            target,
+            index,
+            StorageValue::new(value, false),
+            skip_cold,
+        );
         match res {
             Ok(load) => load,
             Err(LoadError::ColdLoadSkipped) => return context.interpreter.halt_oog(),
             Err(LoadError::DBError) => return context.interpreter.halt_fatal(),
         }
     } else {
-        let Some(load) = context.host.sstore(target, index, value) else {
+        let Some(load) = context
+            .host
+            .sstore(target, index, StorageValue::new(value, false))
+        else {
             return context.interpreter.halt_fatal();
         };
         load
@@ -214,7 +221,10 @@ pub fn cstore<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
         + COLD_SLOAD_COST_ADDITIONAL;
     gas!(context.interpreter, flat_gas);
 
-    let result = context.host.cstore(target, index, value, false);
+    let result =
+        context
+            .host
+            .sstore_skip_cold_load(target, index, StorageValue::private(value), false);
     match result {
         Ok(state_load) => {
             // Privacy check: CSTORE cannot overwrite non-zero public slots
@@ -521,10 +531,15 @@ mod tests {
             fn tload(&mut self, _: Address, _: U256) -> U256 {
                 U256::ZERO
             }
-            fn sstore(&mut self, _: Address, _: U256, _: U256) -> Option<StateLoad<SStoreResult>> {
+            fn sstore(
+                &mut self,
+                _: Address,
+                _: U256,
+                _: StorageValue,
+            ) -> Option<StateLoad<SStoreResult>> {
                 None
             }
-            fn sload(&mut self, _: Address, _: U256) -> Option<StateLoad<U256>> {
+            fn sload(&mut self, _: Address, _: U256) -> Option<StateLoad<StorageValue>> {
                 None
             }
             fn balance(&mut self, _: Address) -> Option<StateLoad<U256>> {
@@ -551,7 +566,7 @@ mod tests {
                 &mut self,
                 _: Address,
                 _: U256,
-                _: U256,
+                _: StorageValue,
                 _: bool,
             ) -> Result<StateLoad<SStoreResult>, LoadError> {
                 Err(LoadError::DBError)
@@ -561,24 +576,7 @@ mod tests {
                 _: Address,
                 _: U256,
                 _: bool,
-            ) -> Result<StateLoad<U256>, LoadError> {
-                Err(LoadError::DBError)
-            }
-            fn cstore(
-                &mut self,
-                _: Address,
-                _: U256,
-                _: U256,
-                _: bool,
-            ) -> Result<StateLoad<SStoreResult>, LoadError> {
-                Ok(StateLoad::new(self.sstore_result.clone(), false, true))
-            }
-            fn cload(
-                &mut self,
-                _: Address,
-                _: U256,
-                _: bool,
-            ) -> Result<StateLoad<U256>, LoadError> {
+            ) -> Result<StateLoad<StorageValue>, LoadError> {
                 Err(LoadError::DBError)
             }
         }
@@ -849,12 +847,8 @@ mod tests {
                 U256::ZERO
             }
 
-            fn sload(&mut self, _: Address, _: U256) -> Option<StateLoad<U256>> {
-                Some(StateLoad::new(
-                    self.storage_state.value,
-                    false,
-                    self.storage_state.is_private,
-                ))
+            fn sload(&mut self, _: Address, _: U256) -> Option<StateLoad<StorageValue>> {
+                Some(StateLoad::new(self.storage_state, false))
             }
 
             fn sload_skip_cold_load(
@@ -862,27 +856,22 @@ mod tests {
                 _: Address,
                 _: U256,
                 _: bool,
-            ) -> Result<StateLoad<U256>, LoadError> {
-                Ok(StateLoad::new(
-                    self.storage_state.value,
-                    false,
-                    self.storage_state.is_private,
-                ))
+            ) -> Result<StateLoad<StorageValue>, LoadError> {
+                Ok(StateLoad::new(self.storage_state, false))
             }
 
             fn sstore(
                 &mut self,
                 _: Address,
                 _: U256,
-                new_value: U256,
+                new_value: StorageValue,
             ) -> Option<StateLoad<SStoreResult>> {
                 Some(StateLoad::new(
                     SStoreResult {
                         original_value: self.storage_state,
                         present_value: self.storage_state,
-                        new_value: FlaggedStorage::new(new_value, false),
+                        new_value: new_value,
                     },
-                    false,
                     false,
                 ))
             }
@@ -891,48 +880,16 @@ mod tests {
                 &mut self,
                 _: Address,
                 _: U256,
-                new_value: U256,
+                new_value: StorageValue,
                 _: bool,
             ) -> Result<StateLoad<SStoreResult>, LoadError> {
                 Ok(StateLoad::new(
                     SStoreResult {
                         original_value: self.storage_state,
                         present_value: self.storage_state,
-                        new_value: FlaggedStorage::new(new_value, false),
+                        new_value: new_value,
                     },
                     false,
-                    false,
-                ))
-            }
-
-            fn cstore(
-                &mut self,
-                _: Address,
-                _: U256,
-                new_value: U256,
-                _: bool,
-            ) -> Result<StateLoad<SStoreResult>, LoadError> {
-                Ok(StateLoad::new(
-                    SStoreResult {
-                        original_value: self.storage_state,
-                        present_value: self.storage_state,
-                        new_value: FlaggedStorage::new(new_value, true),
-                    },
-                    false,
-                    true,
-                ))
-            }
-
-            fn cload(
-                &mut self,
-                _: Address,
-                _: U256,
-                _: bool,
-            ) -> Result<StateLoad<U256>, LoadError> {
-                Ok(StateLoad::new(
-                    self.storage_state.value,
-                    false,
-                    self.storage_state.is_private,
                 ))
             }
 

--- a/crates/seismic/src/instructions/seismic_host.rs
+++ b/crates/seismic/src/instructions/seismic_host.rs
@@ -133,35 +133,16 @@ impl Host for SeismicDummyHost {
         self.dummy_host.log(_log)
     }
 
-    fn cstore(
-        &mut self,
-        address: Address,
-        key: U256,
-        value: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError> {
-        self.dummy_host.cstore(address, key, value, skip_cold_load)
-    }
-
-    fn cload(
-        &mut self,
-        address: Address,
-        key: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, LoadError> {
-        self.dummy_host.cload(address, key, skip_cold_load)
-    }
-
     fn sstore(
         &mut self,
         address: Address,
         key: U256,
-        value: U256,
+        value: StorageValue,
     ) -> Option<StateLoad<SStoreResult>> {
         self.dummy_host.sstore(address, key, value)
     }
 
-    fn sload(&mut self, address: Address, key: U256) -> Option<StateLoad<U256>> {
+    fn sload(&mut self, address: Address, key: U256) -> Option<StateLoad<StorageValue>> {
         self.dummy_host.sload(address, key)
     }
 

--- a/crates/state/src/types.rs
+++ b/crates/state/src/types.rs
@@ -1,11 +1,11 @@
 use super::{Account, EvmStorageSlot};
-use primitives::{Address, HashMap, StorageKey, StorageValue};
+use primitives::{Address, HashMap, StorageKey, U256};
 
 /// EVM State is a mapping from addresses to accounts.
 pub type EvmState = HashMap<Address, Account>;
 
 /// Structure used for EIP-1153 transient storage
-pub type TransientStorage = HashMap<(Address, StorageKey), StorageValue>;
+pub type TransientStorage = HashMap<(Address, StorageKey), U256>;
 
 /// An account's Storage is a mapping from 256-bit integer keys to [EvmStorageSlot]s.
 pub type EvmStorage = HashMap<StorageKey, EvmStorageSlot>;

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -7,29 +7,15 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use revm::{
-    context::{
-        journaled_state::{AccountInfoLoad, JournalLoadError},
-        result::InvalidTransaction,
-        BlockEnv, Cfg, CfgEnv, ContextTr, Evm, LocalContext, TxEnv,
-    },
-    context_interface::{
-        journaled_state::{AccountLoad, JournalCheckpoint, TransferError},
-        result::EVMError,
-        Block, JournalTr, Transaction,
-    },
-    database::InMemoryDB,
-    handler::{
-        instructions::{EthInstructions, InstructionProvider},
-        EthPrecompiles, PrecompileProvider,
-    },
-    inspector::{inspectors::TracerEip3155, JournalExt},
-    interpreter::{
-        interpreter::EthInterpreter, CallInputs, CallOutcome, InterpreterResult, SStoreResult,
-        SelfDestructResult, StateLoad,
-    },
-    primitives::{hardfork::SpecId, Address, HashSet, Log, StorageKey, StorageValue, B256, U256},
-    state::{Account, Bytecode, EvmState},
-    Context, Database, DatabaseCommit, InspectEvm, Inspector, Journal, JournalEntry,
+    Context, Database, DatabaseCommit, InspectEvm, Inspector, Journal, JournalEntry, context::{
+        BlockEnv, Cfg, CfgEnv, ContextTr, Evm, LocalContext, TxEnv, journaled_state::{AccountInfoLoad, JournalLoadError}, result::InvalidTransaction
+    }, context_interface::{
+        Block, JournalTr, Transaction, journaled_state::{AccountLoad, JournalCheckpoint, TransferError}, result::EVMError
+    }, database::InMemoryDB, handler::{
+        EthPrecompiles, PrecompileProvider, instructions::{EthInstructions, InstructionProvider}
+    }, inspector::{JournalExt, inspectors::TracerEip3155}, interpreter::{
+        CallInputs, CallOutcome, InterpreterResult, SStoreResult, SelfDestructResult, StateLoad, interpreter::EthInterpreter
+    }, primitives::{Address, B256, HashSet, Log, StorageKey, StorageValue, TransientStorageValue, U256, hardfork::SpecId}, state::{Account, Bytecode, EvmState}
 };
 use std::{convert::Infallible, fmt::Debug};
 
@@ -110,11 +96,11 @@ impl JournalTr for Backend {
         self.journaled_state.sstore(address, key, value)
     }
 
-    fn tload(&mut self, address: Address, key: StorageKey) -> StorageValue {
+    fn tload(&mut self, address: Address, key: StorageKey) -> TransientStorageValue {
         self.journaled_state.tload(address, key)
     }
 
-    fn tstore(&mut self, address: Address, key: StorageKey, value: StorageValue) {
+    fn tstore(&mut self, address: Address, key: StorageKey, value: TransientStorageValue) {
         self.journaled_state.tstore(address, key, value)
     }
 

--- a/examples/erc20_gas/src/main.rs
+++ b/examples/erc20_gas/src/main.rs
@@ -100,7 +100,8 @@ where
     let sender_balance = context
         .journal_mut()
         .sload(TOKEN, sender_balance_slot)?
-        .data;
+        .data
+        .value;
 
     if sender_balance < amount {
         return Err(ERROR::from(


### PR DESCRIPTION
This is an attempt at a cleanup. Still WIP.

Only higher level evm instruction level understands the shielded semantics. The journal is just a passthrough like storage.