### PR TITLE
refactor(seismic-specid)!: cleaner handling of seismic->eth specid

### DIFF
--- a/crates/context/src/journal/test_flagged_storage.rs
+++ b/crates/context/src/journal/test_flagged_storage.rs
@@ -29,7 +29,6 @@ fn setup_journal_with_account(
     status: AccountStatus,
 ) -> JournalInner<JournalEntry> {
     let mut journal = JournalInner::<JournalEntry>::new();
-    journal.spec = SpecId::MERCURY;
     journal.state.insert(address, create_test_account(status));
     journal
 }
@@ -237,7 +236,6 @@ fn _test_account_creation_storage_revert(shielded: bool) {
     let storage_key = U256::from(1);
 
     let mut journal = JournalInner::<JournalEntry>::new();
-    journal.spec = SpecId::MERCURY;
 
     let storage_type = if shielded { "private" } else { "public" };
     let operation_name = if shielded { "CSTORE" } else { "SSTORE" };
@@ -256,7 +254,7 @@ fn _test_account_creation_storage_revert(shielded: bool) {
             caller_address,
             created_address,
             U256::from(1000), // Transfer 1000 from caller to created account
-            SpecId::MERCURY,
+            SpecId::PRAGUE,
         )
         .unwrap();
 

--- a/crates/precompile/src/lib.rs
+++ b/crates/precompile/src/lib.rs
@@ -91,7 +91,6 @@ impl Precompiles {
     /// Returns the precompiles for the given spec.
     pub fn new(spec: PrecompileSpecId) -> &'static Self {
         match spec {
-            PrecompileSpecId::MERCURY => Self::mercury(),
             PrecompileSpecId::HOMESTEAD => Self::homestead(),
             PrecompileSpecId::BYZANTIUM => Self::byzantium(),
             PrecompileSpecId::ISTANBUL => Self::istanbul(),
@@ -100,13 +99,6 @@ impl Precompiles {
             PrecompileSpecId::PRAGUE => Self::prague(),
             PrecompileSpecId::OSAKA => Self::osaka(),
         }
-    }
-
-    /// Returns precompiles for Mercury spec.
-    /// NOTE: uncertain about this, but Christian thinks our precompiles
-    ///       are not registered here; they're nailed in deeper into the EVM
-    pub fn mercury() -> &'static Self {
-        Self::latest()
     }
 
     /// Returns precompiles for Homestead spec.
@@ -410,8 +402,6 @@ pub enum PrecompileSpecId {
     /// * `BLS12_MAP_FP_TO_G1` at address 0x10
     /// * `BLS12_MAP_FP2_TO_G2` at address 0x11
     PRAGUE,
-    /// Seismic's fork of the EVM.
-    MERCURY,
     /// Osaka spec added changes to modexp precompile:
     /// * [`EIP-7823: Set upper bounds for MODEXP`](https://eips.ethereum.org/EIPS/eip-7823).
     /// * [`EIP-7883: ModExp Gas Cost Increase`](https://eips.ethereum.org/EIPS/eip-7883)
@@ -429,7 +419,6 @@ impl PrecompileSpecId {
     pub const fn from_spec_id(spec_id: primitives::hardfork::SpecId) -> Self {
         use primitives::hardfork::SpecId::*;
         match spec_id {
-            MERCURY => Self::MERCURY,
             FRONTIER | FRONTIER_THAWING | HOMESTEAD | DAO_FORK | TANGERINE | SPURIOUS_DRAGON => {
                 Self::HOMESTEAD
             }

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -70,10 +70,8 @@ pub enum SpecId {
     CANCUN,
     /// Prague hard fork
     /// Activated at block 22431084 (Timestamp: 1746612311)
-    PRAGUE,
-    /// Seismic's fork of the EVM.
     #[default]
-    MERCURY,
+    PRAGUE,
     /// Osaka hard fork
     /// Activated at block TBD
     OSAKA,
@@ -98,7 +96,6 @@ impl SpecId {
 
 /// String identifiers for hardforks.
 pub mod name {
-    pub const MERCURY: &str = "Mercury";
     pub const FRONTIER: &str = "Frontier";
     /// String identifier for the Frontier Thawing hardfork
     pub const FRONTIER_THAWING: &str = "Frontier Thawing";
@@ -153,7 +150,6 @@ impl FromStr for SpecId {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            name::MERCURY => Ok(Self::MERCURY),
             name::FRONTIER => Ok(Self::FRONTIER),
             name::FRONTIER_THAWING => Ok(Self::FRONTIER_THAWING),
             name::HOMESTEAD => Ok(Self::HOMESTEAD),
@@ -183,7 +179,6 @@ impl FromStr for SpecId {
 impl From<SpecId> for &'static str {
     fn from(spec_id: SpecId) -> Self {
         match spec_id {
-            SpecId::MERCURY => name::MERCURY,
             SpecId::FRONTIER => name::FRONTIER,
             SpecId::FRONTIER_THAWING => name::FRONTIER_THAWING,
             SpecId::HOMESTEAD => name::HOMESTEAD,

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -261,6 +261,7 @@ mod tests {
         clippy::panic
     )]
 
+    use crate::SeismicSpecId;
     use crate::instructions::seismic_host::SeismicDummyHost;
 
     use super::*;
@@ -294,7 +295,7 @@ mod tests {
 
     #[test]
     fn test_cload_before_mercury() {
-        // SpecId < PRAGUE => Mercury check should fail => NotActivated
+        // SpecId < PRAGUE == Mercury => check should fail => NotActivated
         let bytecode = Bytecode::new_raw(Bytes::from(&[0x60, 0x00, 0x60, 0x00, 0x01][..]));
         let mut host = SeismicDummyHost::new();
         let mut interpreter = build_interpreter(SpecId::LONDON, bytecode);
@@ -313,11 +314,11 @@ mod tests {
 
     #[test]
     fn test_cstore_mercury_or_later() {
-        // SpecId >= PRAGUE => Mercury is "enabled", so it shouldn't fail at the macro check
+        // SpecId >= PRAGUE == Mercury is "enabled", so it shouldn't fail at the macro check
         let mut host = SeismicDummyHost::new();
 
         let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
-        let mut interpreter = build_interpreter(SpecId::PRAGUE, bytecode);
+        let mut interpreter = build_interpreter(SeismicSpecId::MERCURY.into_eth_spec(), bytecode);
         let context = InstructionContext {
             interpreter: &mut interpreter,
             host: &mut host,

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -317,7 +317,7 @@ mod tests {
         let mut host = SeismicDummyHost::new();
 
         let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
-        let mut interpreter = build_interpreter(SpecId::MERCURY, bytecode);
+        let mut interpreter = build_interpreter(SpecId::PRAGUE, bytecode);
         let context = InstructionContext {
             interpreter: &mut interpreter,
             host: &mut host,
@@ -365,7 +365,7 @@ mod tests {
         let mut host = SeismicDummyHost::new();
 
         let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
-        let mut interpreter = build_interpreter(SpecId::MERCURY, bytecode);
+        let mut interpreter = build_interpreter(SpecId::PRAGUE, bytecode);
         let context = InstructionContext {
             interpreter: &mut interpreter,
             host: &mut host,
@@ -588,7 +588,7 @@ mod tests {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
 
             let mut host1 = MockCstoreHost::zero_to_nonzero(true);
-            let mut interp1 = build_interpreter(SpecId::MERCURY, bytecode.clone());
+            let mut interp1 = build_interpreter(SpecId::PRAGUE, bytecode.clone());
             let _ = interp1.stack.push(U256::from(1));
             let _ = interp1.stack.push(U256::from(42));
             let gas_before_1 = interp1.gas.remaining();
@@ -599,7 +599,7 @@ mod tests {
             let gas_used_1 = gas_before_1 - interp1.gas.remaining();
 
             let mut host2 = MockCstoreHost::nonzero_to_nonzero(true);
-            let mut interp2 = build_interpreter(SpecId::MERCURY, bytecode.clone());
+            let mut interp2 = build_interpreter(SpecId::PRAGUE, bytecode.clone());
             let _ = interp2.stack.push(U256::from(1));
             let _ = interp2.stack.push(U256::from(200));
             let gas_before_2 = interp2.gas.remaining();
@@ -621,7 +621,7 @@ mod tests {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
 
             let mut host_cold = MockCstoreHost::zero_to_nonzero(true);
-            let mut interp_cold = build_interpreter(SpecId::MERCURY, bytecode.clone());
+            let mut interp_cold = build_interpreter(SpecId::PRAGUE, bytecode.clone());
             let _ = interp_cold.stack.push(U256::from(1));
             let _ = interp_cold.stack.push(U256::from(42));
             let gas_before_cold = interp_cold.gas.remaining();
@@ -632,7 +632,7 @@ mod tests {
             let gas_cold = gas_before_cold - interp_cold.gas.remaining();
 
             let mut host_warm = MockCstoreHost::zero_to_nonzero(false);
-            let mut interp_warm = build_interpreter(SpecId::MERCURY, bytecode.clone());
+            let mut interp_warm = build_interpreter(SpecId::PRAGUE, bytecode.clone());
             let _ = interp_warm.stack.push(U256::from(1));
             let _ = interp_warm.stack.push(U256::from(42));
             let gas_before_warm = interp_warm.gas.remaining();
@@ -682,7 +682,7 @@ mod tests {
             ];
 
             for (name, mut host) in scenarios {
-                let mut interp = build_interpreter(SpecId::MERCURY, bytecode.clone());
+                let mut interp = build_interpreter(SpecId::PRAGUE, bytecode.clone());
                 let _ = interp.stack.push(U256::from(1));
                 let _ = interp.stack.push(U256::from(42));
                 let gas_before = interp.gas.remaining();
@@ -705,7 +705,7 @@ mod tests {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
 
             let mut host = MockCstoreHost::nonzero_to_zero(true);
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(1));
             let _ = interp.stack.push(U256::ZERO);
 
@@ -964,7 +964,7 @@ mod tests {
         fn test_sload_zero_public_returns_zero() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::zero_public();
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
 
             sload(InstructionContext {
@@ -980,7 +980,7 @@ mod tests {
         fn test_sload_nonzero_public_returns_value() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::nonzero_public(42);
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
 
             sload(InstructionContext {
@@ -996,7 +996,7 @@ mod tests {
         fn test_sload_zero_private_halts() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::zero_private();
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
 
             sload(InstructionContext {
@@ -1018,7 +1018,7 @@ mod tests {
         fn test_sload_nonzero_private_halts() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::nonzero_private(42);
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
 
             sload(InstructionContext {
@@ -1042,7 +1042,7 @@ mod tests {
         fn test_cload_zero_public_returns_zero() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::zero_public();
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
 
             cload(InstructionContext {
@@ -1058,7 +1058,7 @@ mod tests {
         fn test_cload_nonzero_public_returns_value() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::nonzero_public(42);
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
 
             cload(InstructionContext {
@@ -1074,7 +1074,7 @@ mod tests {
         fn test_cload_zero_private_returns_zero() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::zero_private();
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
 
             cload(InstructionContext {
@@ -1090,7 +1090,7 @@ mod tests {
         fn test_cload_nonzero_private_returns_value() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::nonzero_private(42);
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
 
             cload(InstructionContext {
@@ -1108,7 +1108,7 @@ mod tests {
         fn test_sstore_zero_public_succeeds() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::zero_public();
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
             let _ = interp.stack.push(U256::from(42));
 
@@ -1124,7 +1124,7 @@ mod tests {
         fn test_sstore_nonzero_public_succeeds() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::nonzero_public(100);
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
             let _ = interp.stack.push(U256::from(42));
 
@@ -1140,7 +1140,7 @@ mod tests {
         fn test_sstore_zero_private_halts() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::zero_private();
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
             let _ = interp.stack.push(U256::from(42));
 
@@ -1163,7 +1163,7 @@ mod tests {
         fn test_sstore_nonzero_private_halts() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::nonzero_private(100);
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
             let _ = interp.stack.push(U256::from(42));
 
@@ -1188,7 +1188,7 @@ mod tests {
         fn test_cstore_zero_public_succeeds() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::zero_public();
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
             let _ = interp.stack.push(U256::from(42));
 
@@ -1204,7 +1204,7 @@ mod tests {
         fn test_cstore_nonzero_public_halts() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::nonzero_public(100);
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
             let _ = interp.stack.push(U256::from(42));
 
@@ -1227,7 +1227,7 @@ mod tests {
         fn test_cstore_zero_private_succeeds() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::zero_private();
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
             let _ = interp.stack.push(U256::from(42));
 
@@ -1243,7 +1243,7 @@ mod tests {
         fn test_cstore_nonzero_private_succeeds() {
             let bytecode = Bytecode::new_raw(Bytes::from(&[0x00][..]));
             let mut host = MockStorageHost::nonzero_private(100);
-            let mut interp = build_interpreter(SpecId::MERCURY, bytecode);
+            let mut interp = build_interpreter(SpecId::PRAGUE, bytecode);
             let _ = interp.stack.push(U256::from(0));
             let _ = interp.stack.push(U256::from(42));
 

--- a/crates/seismic/src/instructions/macros.rs
+++ b/crates/seismic/src/instructions/macros.rs
@@ -1,4 +1,14 @@
-/// Check if the `SeismicSPEC` is enabled, and fail the instruction if it is not.
+/// Check if a [`SeismicSpecId`] is enabled, and halt the instruction if it is not.
+///
+/// This works by converting the SeismicSpecId to its corresponding SpecId
+/// (e.g., MERCURY -> PRAGUE) and checking against the interpreter's runtime spec.
+/// This is a pragmatic approach: the interpreter only knows about Ethereum SpecIds,
+/// while SeismicSpecId lives at the EVM context/handler layer (via `Cfg<Spec = SeismicSpecId>`).
+///
+/// If Seismic ever has multiple forks mapping to different Ethereum specs, this still works.
+/// If two Seismic forks map to the *same* Ethereum spec, this approach would be insufficient
+/// and we'd need to go through the host to access `ctx.cfg().spec()` directly (which is how
+/// Optimism gates their fork-specific logic in handlers).
 #[macro_export]
 macro_rules! check {
     ($interpreter:expr, $min:ident) => {

--- a/crates/seismic/src/spec.rs
+++ b/crates/seismic/src/spec.rs
@@ -14,7 +14,7 @@ impl SeismicSpecId {
     /// Converts the [`SeismicSpecId`] into a [`SpecId`].
     pub const fn into_eth_spec(self) -> SpecId {
         match self {
-            Self::MERCURY => SpecId::MERCURY,
+            Self::MERCURY => SpecId::PRAGUE,
         }
     }
 
@@ -74,7 +74,6 @@ mod tests {
                 (SpecId::SHANGHAI, true),
                 (SpecId::CANCUN, true),
                 (SpecId::PRAGUE, true),
-                (SpecId::MERCURY, true),
                 (SpecId::OSAKA, false),
                 (SpecId::AMSTERDAM, false),
             ],


### PR DESCRIPTION
Removes the MERCURY specid from the upstream enum, and keeps our specids completely separate. This is done by following op's pattern and using SeismicSpecId.into_eth_spec() to map between our specIDs and ethereum's.

This thus reduces our fork size.