### PR TITLE
refactor(timestampms): move to seismic crate

### DIFF
--- a/crates/bytecode/src/opcode.rs
+++ b/crates/bytecode/src/opcode.rs
@@ -466,9 +466,6 @@ opcodes! {
     0x49 => BLOBHASH     => stack_io(1, 1);
     0x4A => BLOBBASEFEE  => stack_io(0, 1);
 
-    // Modification: Added TIMESTAMPMS opcode
-    0x4B => TIMESTAMPMS => stack_io(0, 1);
-
     // 0x4B
     // 0x4C
     // 0x4D
@@ -723,7 +720,7 @@ mod tests {
         for _ in OPCODE_INFO.into_iter().flatten() {
             opcode_num += 1;
         }
-        assert_eq!(opcode_num, 151);
+        assert_eq!(opcode_num, 150);
     }
 
     #[test]

--- a/crates/interpreter/src/instructions.rs
+++ b/crates/interpreter/src/instructions.rs
@@ -144,7 +144,6 @@ const fn instruction_table_impl<WIRE: InterpreterTypes, H: Host>() -> [Instructi
     table[BLOCKHASH as usize] = Instruction::new(host::blockhash, 20);
     table[COINBASE as usize] = Instruction::new(block_info::coinbase, 2);
     table[TIMESTAMP as usize] = Instruction::new(block_info::timestamp, 2);
-    table[TIMESTAMPMS as usize] = Instruction::new(block_info::timestamp_milliseconds, 2);
     table[NUMBER as usize] = Instruction::new(block_info::block_number, 2);
     table[DIFFICULTY as usize] = Instruction::new(block_info::difficulty, 2);
     table[GASLIMIT as usize] = Instruction::new(block_info::gaslimit, 2);

--- a/crates/interpreter/src/instructions/block_info.rs
+++ b/crates/interpreter/src/instructions/block_info.rs
@@ -48,28 +48,6 @@ pub fn timestamp<WIRE: InterpreterTypes, H: Host + ?Sized>(
     }
 }
 
-/// Implements the TIMESTAMP_MS instruction.
-///
-/// Pushes the current block's timestamp in milliseconds onto the stack.
-pub fn timestamp_milliseconds<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    context: InstructionContext<'_, H, WIRE>,
-) {
-    //gas!(context.interpreter, gas::BASE);
-
-    #[cfg(feature = "timestamp-in-seconds")]
-    {
-        // Host returns seconds, convert to milliseconds for reth compatibility
-        let timestamp_ms = context.host.timestamp() * U256::from(1000);
-        push!(context.interpreter, timestamp_ms);
-    }
-
-    #[cfg(not(feature = "timestamp-in-seconds"))]
-    {
-        // Host returns milliseconds, use as is
-        push!(context.interpreter, context.host.timestamp());
-    }
-}
-
 /// Implements the NUMBER instruction.
 ///
 /// Pushes the current block number onto the stack.

--- a/crates/seismic/src/instructions.rs
+++ b/crates/seismic/src/instructions.rs
@@ -1,3 +1,4 @@
+pub mod block_info;
 pub mod confidential_storage;
 pub mod instruction_provider;
 pub mod seismic_host;

--- a/crates/seismic/src/instructions/block_info.rs
+++ b/crates/seismic/src/instructions/block_info.rs
@@ -1,0 +1,32 @@
+use revm::interpreter::{
+    interpreter_types::{InterpreterTypes, StackTr},
+    push, Host, Instruction, InstructionContext,
+};
+
+/// Implements the TIMESTAMP_MS instruction.
+///
+/// Pushes the current block's timestamp in milliseconds onto the stack.
+pub fn timestamp_milliseconds<WIRE: InterpreterTypes, H: Host + ?Sized>(
+    context: InstructionContext<'_, H, WIRE>,
+) {
+    //gas!(context.interpreter, gas::BASE);
+
+    #[cfg(feature = "timestamp-in-seconds")]
+    {
+        use revm::primitives::U256;
+        // Host returns seconds, convert to milliseconds for reth compatibility
+        let timestamp_ms = context.host.timestamp() * U256::from(1000);
+        push!(context.interpreter, timestamp_ms);
+    }
+
+    #[cfg(not(feature = "timestamp-in-seconds"))]
+    {
+        // Host returns milliseconds, use as is
+        push!(context.interpreter, context.host.timestamp());
+    }
+}
+
+pub fn timestampms_instruction<WIRE: InterpreterTypes, H: Host + ?Sized>() -> Instruction<WIRE, H>
+{
+    Instruction::new(timestamp_milliseconds, 2)
+}

--- a/crates/seismic/src/instructions/instruction_provider.rs
+++ b/crates/seismic/src/instructions/instruction_provider.rs
@@ -9,14 +9,18 @@ use revm::{
 use std::boxed::Box;
 
 use crate::{
-    instructions::confidential_storage::{
-        cload_instruction, cstore_instruction, seismic_sload_instruction,
-        seismic_sstore_instruction,
+    instructions::{
+        block_info::timestampms_instruction,
+        confidential_storage::{
+            cload_instruction, cstore_instruction, seismic_sload_instruction,
+            seismic_sstore_instruction,
+        },
     },
     SeismicHost,
 };
 
-/// Custom opcodes for CLOAD and CSTORE
+/// Custom opcodes
+pub const TIMESTAMPMS: u8 = 0x4B;
 pub const CLOAD: u8 = 0xB0;
 pub const CSTORE: u8 = 0xB1;
 
@@ -41,6 +45,7 @@ where
     pub fn new_mainnet() -> Self {
         let mut table = instruction_table::<WIRE, HOST>();
 
+        table[TIMESTAMPMS as usize] = timestampms_instruction();
         // NOTE: static_gas is 0 because gas is dynamic for these
         table[CLOAD as usize] = cload_instruction();
         table[CSTORE as usize] = cstore_instruction();
@@ -211,7 +216,8 @@ mod tests {
 
         // Verify all standard opcodes remain unchanged (except our custom ones)
         for i in 0..256 {
-            if i != CLOAD as usize
+            if i != TIMESTAMPMS as usize
+                && i != CLOAD as usize
                 && i != CSTORE as usize
                 && i != SLOAD as usize
                 && i != SSTORE as usize


### PR DESCRIPTION
Another small PR part of refactoring to minimize our forks and maintain as much code as we can in seismic related crates (which we plan to eventually bring into our monorepo).