### PR TITLE
refactor!(storage): make StorageValue generic/associated-type

### DIFF
--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -5,7 +5,8 @@ use clap::Parser;
 use context::ContextTr;
 use context_interface::block::BlobExcessGasAndPrice;
 use database::states::bundle_state::BundleRetention;
-use database::{EmptyDB, State};
+use database::State;
+use seismic_revm::SeismicEmptyDB;
 use inspector::inspectors::TracerEip3155;
 use primitives::{hardfork::SpecId, hex, Address, HashMap, U256};
 use revm::handler::EvmTr;
@@ -298,7 +299,7 @@ struct DebugInfo {
 impl DebugInfo {
     /// Capture current state from the State database
     fn capture_committed_state(
-        state: &State<EmptyDB>,
+        state: &State<SeismicEmptyDB, revm::state::FlaggedStorage>,
     ) -> HashMap<Address, (AccountInfo, HashMap<U256, FlaggedStorage>)> {
         let mut committed_state = HashMap::new();
 
@@ -319,7 +320,7 @@ impl DebugInfo {
 
 /// Validate post state against expected values
 fn validate_post_state(
-    state: &mut State<EmptyDB>,
+    state: &mut State<SeismicEmptyDB, revm::state::FlaggedStorage>,
     expected_post_state: &BTreeMap<Address, Account>,
     debug_info: &DebugInfo,
     print_env_on_error: bool,
@@ -437,7 +438,7 @@ fn validate_post_state(
 /// Print comprehensive error information including environment and state comparison
 fn print_error_with_state(
     debug_info: &DebugInfo,
-    current_state: &State<EmptyDB>,
+    current_state: &State<SeismicEmptyDB, revm::state::FlaggedStorage>,
     expected_post_state: Option<&BTreeMap<Address, Account>>,
 ) {
     eprintln!("\n========== TEST EXECUTION ERROR ==========");
@@ -650,7 +651,7 @@ fn execute_blockchain_test(
     }
 
     // Create database with initial state
-    let mut state = State::builder().build();
+    let mut state = database::StateBuilder::new_with_database(SeismicEmptyDB::default()).build();
 
     // Capture pre-state for debug info
     let mut pre_state_debug = HashMap::new();

--- a/bins/revme/src/cmd/blockchaintest/post_block.rs
+++ b/bins/revme/src/cmd/blockchaintest/post_block.rs
@@ -1,6 +1,6 @@
 use context::{Block, ContextTr};
 use database::State;
-use primitives::{hardfork::SpecId, ONE_ETHER, ONE_GWEI};
+use primitives::{hardfork::SpecId, StorageValueTr, ONE_ETHER, ONE_GWEI};
 use revm::{handler::EvmTr, Database, SystemCallCommitEvm};
 use statetest_types::blockchain::Withdrawal;
 
@@ -15,8 +15,9 @@ use statetest_types::blockchain::Withdrawal;
 pub fn post_block_transition<
     'a,
     DB: Database + 'a,
+    SV: StorageValueTr,
     EVM: SystemCallCommitEvm<Error: core::fmt::Debug>
-        + EvmTr<Context: ContextTr<Db = &'a mut State<DB>>>,
+        + EvmTr<Context: ContextTr<Db = &'a mut State<DB, SV>>>,
 >(
     evm: &mut EVM,
     block: impl Block,

--- a/bins/revme/src/cmd/blockchaintest/pre_block.rs
+++ b/bins/revme/src/cmd/blockchaintest/pre_block.rs
@@ -2,7 +2,7 @@
 
 use context::{Block, ContextTr};
 use database::State;
-use primitives::{address, hardfork::SpecId, Address, B256};
+use primitives::{address, hardfork::SpecId, Address, StorageValueTr, B256};
 use revm::{handler::EvmTr, Database, SystemCallCommitEvm};
 
 /// Pre block state transition
@@ -13,8 +13,9 @@ use revm::{handler::EvmTr, Database, SystemCallCommitEvm};
 pub fn pre_block_transition<
     'a,
     DB: Database + 'a,
+    SV: StorageValueTr,
     EVM: SystemCallCommitEvm<Error: core::fmt::Debug>
-        + EvmTr<Context: ContextTr<Db = &'a mut State<DB>>>,
+        + EvmTr<Context: ContextTr<Db = &'a mut State<DB, SV>>>,
 >(
     evm: &mut EVM,
     spec: SpecId,

--- a/bins/revme/src/cmd/semantics.rs
+++ b/bins/revme/src/cmd/semantics.rs
@@ -1,9 +1,9 @@
 use cargo_metadata::MetadataCommand;
 use evm_handler::{EvmConfig, EvmExecutor};
-use revm::{
-    database::{CacheDB, EmptyDB},
-    primitives::U256,
-};
+use revm::{database::CacheDB, primitives::U256};
+use seismic_revm::SeismicInMemoryDB;
+/// CacheDB using FlaggedStorage, compatible with both mainnet and Seismic EVM handlers.
+type FlaggedCacheDB = SeismicInMemoryDB;
 
 use log::{error, info, LevelFilter};
 use rayon::prelude::*;
@@ -272,8 +272,8 @@ impl Cmd {
         }
     }
 
-    fn prepare_database(&self, config: &EvmConfig) -> Result<CacheDB<EmptyDB>, Errors> {
-        let mut db = CacheDB::new(EmptyDB::default());
+    fn prepare_database(&self, config: &EvmConfig) -> Result<FlaggedCacheDB, Errors> {
+        let mut db = CacheDB::new(seismic_revm::SeismicEmptyDB::default());
         let account_info = AccountInfo {
             balance: U256::MAX,
             nonce: Default::default(),

--- a/bins/revme/src/cmd/semantics/evm_handler.rs
+++ b/bins/revme/src/cmd/semantics/evm_handler.rs
@@ -2,11 +2,14 @@ use context::result::{ExecutionResult, Output};
 use log::{debug, error};
 use primitives::hex::FromHex;
 use revm::{
-    database::{CacheDB, EmptyDB},
     inspector::inspectors::TracerEip3155,
     primitives::{Address, Bytes, FixedBytes, Log, TxKind, U256},
     Context, DatabaseCommit, DatabaseRef, ExecuteEvm, InspectEvm, MainBuilder, MainContext,
 };
+use seismic_revm::SeismicInMemoryDB;
+
+/// CacheDB using FlaggedStorage, compatible with both mainnet and Seismic EVM handlers.
+type FlaggedCacheDB = SeismicInMemoryDB;
 use seismic_revm::{DefaultSeismicContext, SeismicBuilder};
 use std::str::FromStr;
 
@@ -97,14 +100,14 @@ impl EvmConfig {
 }
 
 pub(crate) struct EvmExecutor {
-    db: CacheDB<EmptyDB>,
+    db: FlaggedCacheDB,
     pub config: EvmConfig,
     evm_version: EVMVersion,
     libraries: Vec<Address>,
 }
 
 impl EvmExecutor {
-    pub(crate) fn new(db: CacheDB<EmptyDB>, config: EvmConfig, evm_version: EVMVersion) -> Self {
+    pub(crate) fn new(db: FlaggedCacheDB, config: EvmConfig, evm_version: EVMVersion) -> Self {
         Self {
             db,
             config,

--- a/bins/revme/src/cmd/semantics/utils.rs
+++ b/bins/revme/src/cmd/semantics/utils.rs
@@ -1,7 +1,10 @@
 use context::result::{ExecutionResult, HaltReason, ResultAndState};
 use log::error;
 use primitives::HashMap;
-use revm::database::{CacheDB, EmptyDB};
+use seismic_revm::SeismicInMemoryDB;
+
+/// CacheDB using FlaggedStorage, compatible with both mainnet and Seismic EVM handlers.
+type FlaggedCacheDB = SeismicInMemoryDB;
 use revm::primitives::{Address, Bytes, FixedBytes, Log, LogData, U256};
 use seismic_revm::SeismicHaltReason;
 
@@ -308,7 +311,7 @@ pub(crate) fn verify_emitted_events(
 }
 
 pub(crate) fn verify_expected_balances(
-    mut db: CacheDB<EmptyDB>,
+    mut db: FlaggedCacheDB,
     expected: &HashMap<Address, U256>,
     deployed_contract_address: Address,
 ) -> Result<(), Errors> {
@@ -333,7 +336,7 @@ pub(crate) fn verify_expected_balances(
 }
 
 pub(crate) fn verify_storage_empty(
-    mut db: CacheDB<EmptyDB>,
+    mut db: FlaggedCacheDB,
     contract_address: Address,
     expected_empty: bool,
 ) -> Result<(), Errors> {
@@ -361,7 +364,7 @@ pub(crate) fn bytes_to_fixed(bytes: Bytes) -> FixedBytes<32> {
     fixed.into()
 }
 
-pub fn mainnet_to_seismic(raw: ResultAndState<HaltReason>) -> ResultAndState<SeismicHaltReason> {
+pub fn mainnet_to_seismic<S>(raw: ResultAndState<HaltReason, S>) -> ResultAndState<SeismicHaltReason, S> {
     let ResultAndState { result, state } = raw;
     let result = match result {
         ExecutionResult::Success {

--- a/bins/revme/src/cmd/statetest/merkle_trie.rs
+++ b/bins/revme/src/cmd/statetest/merkle_trie.rs
@@ -2,10 +2,12 @@ use std::convert::Infallible;
 
 use alloy_rlp::{RlpEncodable, RlpMaxEncodedLen};
 use context::result::{EVMError, ExecutionResult, InvalidTransaction};
-use database::{EmptyDB, PlainAccount, State};
+use database::{PlainAccount, State};
+use seismic_revm::SeismicEmptyDB;
 use hash_db::Hasher;
 use plain_hasher::PlainHasher;
 use revm::primitives::{keccak256, Address, Log, B256, U256};
+use state::FlaggedStorage;
 use seismic_revm::SeismicHaltReason as HaltReason;
 use triehash::sec_trie_root;
 
@@ -16,7 +18,7 @@ pub struct TestValidationResult {
 
 pub fn compute_test_roots(
     exec_result: &Result<ExecutionResult<HaltReason>, EVMError<Infallible, InvalidTransaction>>,
-    db: &State<EmptyDB>,
+    db: &State<SeismicEmptyDB, revm::state::FlaggedStorage>,
 ) -> TestValidationResult {
     TestValidationResult {
         logs_root: log_rlp_hash(exec_result.as_ref().map(|r| r.logs()).unwrap_or_default()),
@@ -31,7 +33,7 @@ pub fn log_rlp_hash(logs: &[Log]) -> B256 {
 }
 
 pub fn state_merkle_trie_root<'a>(
-    accounts: impl IntoIterator<Item = (Address, &'a PlainAccount)>,
+    accounts: impl IntoIterator<Item = (Address, &'a PlainAccount<FlaggedStorage>)>,
 ) -> B256 {
     trie_root(accounts.into_iter().map(|(address, acc)| {
         (
@@ -50,7 +52,7 @@ struct TrieAccount {
 }
 
 impl TrieAccount {
-    fn new(acc: &PlainAccount) -> Self {
+    fn new(acc: &PlainAccount<FlaggedStorage>) -> Self {
         Self {
             nonce: acc.info.nonce,
             balance: acc.info.balance,

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -11,13 +11,12 @@ use revm::{
         result::{EVMError, ExecutionResult, InvalidTransaction},
         Cfg,
     },
-    database_interface::EmptyDB,
     primitives::{Bytes, B256},
     Context, ExecuteCommitEvm,
 };
 use seismic_revm::{
-    DefaultSeismicContext, SeismicBuilder, SeismicHaltReason, SeismicHaltReason as HaltReason,
-    SeismicSpecId as SpecId, SeismicTransaction,
+    DefaultSeismicContext, SeismicBuilder, SeismicEmptyDB, SeismicHaltReason,
+    SeismicHaltReason as HaltReason, SeismicSpecId as SpecId, SeismicTransaction,
 };
 use serde_json::json;
 use statetest_types::{SpecName, Test, TestSuite, TestUnit};
@@ -134,7 +133,7 @@ struct TestExecutionContext<'a> {
     cfg: &'a CfgEnv<SpecId>,
     block: &'a BlockEnv,
     tx: &'a SeismicTransaction<TxEnv>,
-    cache_state: &'a database::CacheState,
+    cache_state: &'a database::CacheState<state::FlaggedStorage>,
     elapsed: &'a Arc<Mutex<Duration>>,
     trace: bool,
     print_json_outcome: bool,
@@ -148,7 +147,7 @@ struct DebugContext<'a> {
     cfg: &'a CfgEnv<SpecId>,
     block: &'a BlockEnv,
     tx: &'a SeismicTransaction<TxEnv>,
-    cache_state: &'a database::CacheState,
+    cache_state: &'a database::CacheState<state::FlaggedStorage>,
     error: &'a TestErrorKind,
 }
 
@@ -227,7 +226,7 @@ fn check_evm_execution(
         ExecutionResult<SeismicHaltReason>,
         EVMError<Infallible, InvalidTransaction>,
     >,
-    db: &mut State<EmptyDB>,
+    db: &mut State<SeismicEmptyDB, state::FlaggedStorage>,
     spec: SpecId,
     print_json_outcome: bool,
 ) -> Result<(), TestErrorKind> {
@@ -421,7 +420,7 @@ fn execute_single_test(ctx: TestExecutionContext) -> Result<(), TestErrorKind> {
     /*
     cache.set_state_clear_flag(ctx.cfg.spec.is_enabled_in(SpecId::SPURIOUS_DRAGON));
     */
-    let mut state = database::State::builder()
+    let mut state = database::StateBuilder::new_with_database(SeismicEmptyDB::default())
         .with_cached_prestate(cache)
         .with_bundle_update()
         .build();
@@ -471,7 +470,7 @@ fn debug_failed_test(ctx: DebugContext) {
     /*
     cache.set_state_clear_flag(ctx.cfg.spec.is_enabled_in(SpecId::SPURIOUS_DRAGON));
     */
-    let mut state = database::State::builder()
+    let mut state = database::StateBuilder::new_with_database(SeismicEmptyDB::default())
         .with_cached_prestate(cache)
         .with_bundle_update()
         .build();

--- a/crates/context/interface/src/context.rs
+++ b/crates/context/interface/src/context.rs
@@ -4,7 +4,7 @@ use crate::{
     result::FromStringError, Block, Cfg, Database, Host, JournalTr, LocalContextTr, Transaction,
 };
 use auto_impl::auto_impl;
-use primitives::FlaggedStorage;
+use primitives::{StorageValueTr, U256};
 use std::string::String;
 
 /// Trait that defines the context of the EVM execution.
@@ -104,50 +104,50 @@ impl<DbError> From<DbError> for ContextError<DbError> {
 /// Represents the result of an `sstore` operation.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct SStoreResult {
+pub struct SStoreResult<SV: StorageValueTr = U256> {
     /// Value of the storage when it is first read
-    pub original_value: FlaggedStorage,
+    pub original_value: SV,
     /// Current value of the storage
-    pub present_value: FlaggedStorage,
+    pub present_value: SV,
     /// New value that is set
-    pub new_value: FlaggedStorage,
+    pub new_value: SV,
 }
 
-impl SStoreResult {
+impl<SV: StorageValueTr> SStoreResult<SV> {
     /// Returns `true` if the new value is equal to the present value.
     #[inline]
-    pub const fn is_new_eq_present(&self) -> bool {
-        self.new_value.const_eq(&self.present_value)
+    pub fn is_new_eq_present(&self) -> bool {
+        self.new_value == self.present_value
     }
 
     /// Returns `true` if the original value is equal to the present value.
     #[inline]
-    pub const fn is_original_eq_present(&self) -> bool {
-        self.original_value.const_eq(&self.present_value)
+    pub fn is_original_eq_present(&self) -> bool {
+        self.original_value == self.present_value
     }
 
     /// Returns `true` if the original value is equal to the new value.
     #[inline]
-    pub const fn is_original_eq_new(&self) -> bool {
-        self.original_value.const_eq(&self.new_value)
+    pub fn is_original_eq_new(&self) -> bool {
+        self.original_value == self.new_value
     }
 
     /// Returns `true` if the original value is zero.
     #[inline]
-    pub const fn is_original_zero(&self) -> bool {
-        self.original_value.const_is_zero()
+    pub fn is_original_zero(&self) -> bool {
+        self.original_value.is_zero()
     }
 
     /// Returns `true` if the present value is zero.
     #[inline]
-    pub const fn is_present_zero(&self) -> bool {
-        self.present_value.const_is_zero()
+    pub fn is_present_zero(&self) -> bool {
+        self.present_value.is_zero()
     }
 
     /// Returns `true` if the new value is zero.
     #[inline]
-    pub const fn is_new_zero(&self) -> bool {
-        self.new_value.const_is_zero()
+    pub fn is_new_zero(&self) -> bool {
+        self.new_value.is_zero()
     }
 }
 
@@ -171,4 +171,20 @@ pub trait ContextSetters: ContextTr {
     fn set_tx(&mut self, tx: Self::Tx);
     /// Set the block
     fn set_block(&mut self, block: Self::Block);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sstore_result_u256() {
+        let result = SStoreResult::<U256> {
+            original_value: U256::ZERO,
+            present_value: U256::ZERO,
+            new_value: U256::from(1),
+        };
+        assert!(!result.is_new_eq_present());
+        assert!(result.is_original_zero());
+    }
 }

--- a/crates/context/interface/src/host.rs
+++ b/crates/context/interface/src/host.rs
@@ -5,7 +5,9 @@ use crate::{
     journaled_state::{AccountInfoLoad, AccountLoad},
 };
 use auto_impl::auto_impl;
-use primitives::{Address, Bytes, Log, StorageKey, StorageValue, B256, U256};
+use primitives::{
+    Address, Bytes, Log, StorageKey, StorageValueTr, TransientStorageValue, B256, U256,
+};
 use state::Bytecode;
 
 /// Error that can happen when loading account info.
@@ -25,6 +27,9 @@ pub enum LoadError {
 /// There are few groups of functions which are Block, Transaction, Config, Database and Journal functions.
 #[auto_impl(&mut, Box)]
 pub trait Host {
+    /// The type of storage values this host works with.
+    type StorageValue: StorageValueTr;
+
     /* Block */
 
     /// Block basefee, calls ContextTr::block().basefee()
@@ -82,36 +87,19 @@ pub trait Host {
         &mut self,
         address: Address,
         key: StorageKey,
-        value: StorageValue,
+        value: Self::StorageValue,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError>;
+    ) -> Result<StateLoad<SStoreResult<Self::StorageValue>>, LoadError>;
 
     /// Sstore, calls `ContextTr::journal_mut().sstore(address, key, value)`
     fn sstore(
         &mut self,
         address: Address,
         key: StorageKey,
-        value: StorageValue,
-    ) -> Option<StateLoad<SStoreResult>> {
+        value: Self::StorageValue,
+    ) -> Option<StateLoad<SStoreResult<Self::StorageValue>>> {
         self.sstore_skip_cold_load(address, key, value, false).ok()
     }
-
-    /// Cstore, for storing shielded state
-    fn cstore(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        value: StorageValue,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError>;
-
-    /// Cload, for loading shielded state
-    fn cload(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, LoadError>;
 
     /// Sload with optional fetch from database. Return none if the value is cold or if there is db error.
     fn sload_skip_cold_load(
@@ -119,18 +107,22 @@ pub trait Host {
         address: Address,
         key: StorageKey,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<StorageValue>, LoadError>;
+    ) -> Result<StateLoad<Self::StorageValue>, LoadError>;
 
     /// Sload, calls `ContextTr::journal_mut().sload(address, key)`
-    fn sload(&mut self, address: Address, key: StorageKey) -> Option<StateLoad<StorageValue>> {
+    fn sload(
+        &mut self,
+        address: Address,
+        key: StorageKey,
+    ) -> Option<StateLoad<Self::StorageValue>> {
         self.sload_skip_cold_load(address, key, false).ok()
     }
 
     /// Tstore, calls `ContextTr::journal_mut().tstore(address, key, value)`
-    fn tstore(&mut self, address: Address, key: StorageKey, value: StorageValue);
+    fn tstore(&mut self, address: Address, key: StorageKey, value: TransientStorageValue);
 
     /// Tload, calls `ContextTr::journal_mut().tload(address, key)`
-    fn tload(&mut self, address: Address, key: StorageKey) -> StorageValue;
+    fn tload(&mut self, address: Address, key: StorageKey) -> TransientStorageValue;
 
     /// Main function to load account info.
     ///
@@ -168,7 +160,6 @@ pub trait Host {
                 is_empty: account.is_empty,
             },
             account.is_cold,
-            false,
         );
 
         // load delegate code if account is EIP-7702
@@ -221,6 +212,8 @@ pub trait Host {
 pub struct DummyHost;
 
 impl Host for DummyHost {
+    type StorageValue = U256;
+
     fn basefee(&self) -> U256 {
         U256::ZERO
     }
@@ -287,29 +280,10 @@ impl Host for DummyHost {
 
     fn log(&mut self, _log: Log) {}
 
-    fn tstore(&mut self, _address: Address, _key: StorageKey, _value: StorageValue) {}
+    fn tstore(&mut self, _address: Address, _key: StorageKey, _value: TransientStorageValue) {}
 
-    fn tload(&mut self, _address: Address, _key: StorageKey) -> StorageValue {
-        StorageValue::ZERO
-    }
-
-    fn cload(
-        &mut self,
-        _address: Address,
-        _key: StorageKey,
-        _skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, LoadError> {
-        Err(LoadError::DBError)
-    }
-
-    fn cstore(
-        &mut self,
-        _address: Address,
-        _key: StorageKey,
-        _value: StorageValue,
-        _skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError> {
-        Err(LoadError::DBError)
+    fn tload(&mut self, _address: Address, _key: StorageKey) -> TransientStorageValue {
+        TransientStorageValue::ZERO
     }
 
     fn load_account_info_skip_cold_load(
@@ -325,9 +299,9 @@ impl Host for DummyHost {
         &mut self,
         _address: Address,
         _key: StorageKey,
-        _value: StorageValue,
+        _value: Self::StorageValue,
         _skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError> {
+    ) -> Result<StateLoad<SStoreResult<Self::StorageValue>>, LoadError> {
         Err(LoadError::DBError)
     }
 
@@ -336,7 +310,7 @@ impl Host for DummyHost {
         _address: Address,
         _key: StorageKey,
         _skip_cold_load: bool,
-    ) -> Result<StateLoad<StorageValue>, LoadError> {
+    ) -> Result<StateLoad<Self::StorageValue>, LoadError> {
         Err(LoadError::DBError)
     }
 }

--- a/crates/context/interface/src/journaled_state.rs
+++ b/crates/context/interface/src/journaled_state.rs
@@ -5,9 +5,7 @@ use crate::{
 };
 use core::ops::{Deref, DerefMut};
 use database_interface::Database;
-use primitives::{
-    hardfork::SpecId, Address, Bytes, HashSet, Log, StorageKey, StorageValue, B256, U256,
-};
+use primitives::{hardfork::SpecId, Address, Bytes, HashSet, Log, StorageKey, B256, U256};
 use state::{Account, AccountInfo, Bytecode};
 use std::{borrow::Cow, vec::Vec};
 
@@ -36,59 +34,43 @@ pub trait JournalTr {
         &mut self,
         address: Address,
         key: StorageKey,
-    ) -> Result<StateLoad<StorageValue>, <Self::Database as Database>::Error> {
+    ) -> Result<StateLoad<<Self::Database as Database>::StorageValue>, <Self::Database as Database>::Error> {
         // unwrapping is safe as we only can get DBError
         self.sload_skip_cold_load(address, key, false)
             .map_err(JournalLoadError::unwrap_db_error)
     }
 
-    /// Returns the private storage value from Journal state.
-    ///
-    /// Loads the storage from database if not found in Journal state.
-    fn cload(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        _skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, <Self::Database as Database>::Error>;
-
     /// Loads the storage value from Journal state.
+    #[allow(clippy::type_complexity)]
     fn sload_skip_cold_load(
         &mut self,
         _address: Address,
         _key: StorageKey,
         _skip_cold_load: bool,
-    ) -> Result<StateLoad<StorageValue>, JournalLoadError<<Self::Database as Database>::Error>>;
+    ) -> Result<StateLoad<<Self::Database as Database>::StorageValue>, JournalLoadError<<Self::Database as Database>::Error>>;
 
     /// Stores the storage value in Journal state.
+    #[allow(clippy::type_complexity)]
     fn sstore(
         &mut self,
         address: Address,
         key: StorageKey,
-        value: StorageValue,
-    ) -> Result<StateLoad<SStoreResult>, <Self::Database as Database>::Error> {
+        value: <Self::Database as Database>::StorageValue,
+    ) -> Result<StateLoad<SStoreResult<<Self::Database as Database>::StorageValue>>, <Self::Database as Database>::Error> {
         // unwrapping is safe as we only can get DBError
         self.sstore_skip_cold_load(address, key, value, false)
             .map_err(JournalLoadError::unwrap_db_error)
     }
 
     /// Stores the storage value in Journal state.
-    fn cstore(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        value: StorageValue,
-        _skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, <Self::Database as Database>::Error>;
-
-    /// Stores the storage value in Journal state.
+    #[allow(clippy::type_complexity)]
     fn sstore_skip_cold_load(
         &mut self,
         _address: Address,
         _key: StorageKey,
-        _value: StorageValue,
+        _value: <Self::Database as Database>::StorageValue,
         _skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, JournalLoadError<<Self::Database as Database>::Error>>;
+    ) -> Result<StateLoad<SStoreResult<<Self::Database as Database>::StorageValue>>, JournalLoadError<<Self::Database as Database>::Error>>;
 
     /// Loads transient storage value.
     fn tload(&mut self, address: Address, key: StorageKey) -> U256;
@@ -166,13 +148,13 @@ pub trait JournalTr {
     fn load_account(
         &mut self,
         address: Address,
-    ) -> Result<StateLoad<&mut Account>, <Self::Database as Database>::Error>;
+    ) -> Result<StateLoad<&mut Account<<Self::Database as Database>::StorageValue>>, <Self::Database as Database>::Error>;
 
     /// Loads the account code.
     fn load_account_code(
         &mut self,
         address: Address,
-    ) -> Result<StateLoad<&mut Account>, <Self::Database as Database>::Error>;
+    ) -> Result<StateLoad<&mut Account<<Self::Database as Database>::StorageValue>>, <Self::Database as Database>::Error>;
 
     /// Loads the account delegated.
     fn load_account_delegated(
@@ -202,7 +184,7 @@ pub trait JournalTr {
         // SAFETY: Safe to unwrap as load_code will insert code if it is empty.
         let code = a.info.code.as_ref().unwrap().original_bytes();
 
-        Ok(StateLoad::new(code, a.is_cold, false))
+        Ok(StateLoad::new(code, a.is_cold))
     }
 
     /// Gets code hash of account.
@@ -212,10 +194,10 @@ pub trait JournalTr {
     ) -> Result<StateLoad<B256>, <Self::Database as Database>::Error> {
         let acc = self.load_account_code(address)?;
         if acc.is_empty() {
-            return Ok(StateLoad::new(B256::ZERO, acc.is_cold, false));
+            return Ok(StateLoad::new(B256::ZERO, acc.is_cold));
         }
         let hash = acc.info.code_hash;
-        Ok(StateLoad::new(hash, acc.is_cold, false))
+        Ok(StateLoad::new(hash, acc.is_cold))
     }
 
     /// Called at the end of the transaction to clean all residue data from journal.
@@ -366,8 +348,6 @@ pub struct StateLoad<T> {
     pub data: T,
     /// Is account is cold loaded
     pub is_cold: bool,
-    /// True if slot was tagged as private.
-    pub is_private: bool,
 }
 
 impl<T> Deref for StateLoad<T> {
@@ -386,12 +366,8 @@ impl<T> DerefMut for StateLoad<T> {
 
 impl<T> StateLoad<T> {
     /// Returns a new [`StateLoad`] with the given data and cold load status.
-    pub fn new(data: T, is_cold: bool, is_private: bool) -> Self {
-        Self {
-            data,
-            is_cold,
-            is_private,
-        }
+    pub fn new(data: T, is_cold: bool) -> Self {
+        Self { data, is_cold }
     }
 
     /// Maps the data of the [`StateLoad`] to a new value.
@@ -401,7 +377,7 @@ impl<T> StateLoad<T> {
     where
         F: FnOnce(T) -> B,
     {
-        StateLoad::new(f(self.data), self.is_cold, self.is_private)
+        StateLoad::new(f(self.data), self.is_cold)
     }
 }
 
@@ -444,7 +420,7 @@ impl<'a> AccountInfoLoad<'a> {
     where
         F: FnOnce(Cow<'a, AccountInfo>) -> O,
     {
-        StateLoad::new(f(self.account), self.is_cold, false)
+        StateLoad::new(f(self.account), self.is_cold)
     }
 }
 

--- a/crates/context/src/context.rs
+++ b/crates/context/src/context.rs
@@ -1,5 +1,7 @@
 //! This module contains [`Context`] struct and implements [`ContextTr`] trait for it.
-use crate::{block::BlockEnv, cfg::CfgEnv, journal::Journal, tx::TxEnv, LocalContext};
+use crate::{
+    block::BlockEnv, cfg::CfgEnv, entry::JournalEntry, journal::Journal, tx::TxEnv, LocalContext,
+};
 use context_interface::{
     context::{ContextError, ContextSetters, SStoreResult, SelfDestructResult, StateLoad},
     host::LoadError,
@@ -8,7 +10,7 @@ use context_interface::{
 };
 use database_interface::{Database, DatabaseRef, EmptyDB, WrapDatabaseRef};
 use derive_where::derive_where;
-use primitives::{hardfork::SpecId, Address, Log, StorageKey, StorageValue, B256, U256};
+use primitives::{hardfork::SpecId, Address, Log, StorageKey, TransientStorageValue, B256, U256};
 
 /// EVM context contains data that EVM needs for execution.
 #[derive_where(Clone, Debug; BLOCK, CFG, CHAIN, TX, DB, JOURNAL, <DB as Database>::Error, LOCAL)]
@@ -208,11 +210,13 @@ where
 
     /// Creates a new context with a new database type.
     ///
-    /// This will create a new [`Journal`] object.
+    /// This will create a new [`Journal`] object with a [`JournalEntry`] that
+    /// matches the database's [`StorageValue`](Database::StorageValue) type.
     pub fn with_db<ODB: Database>(
         self,
         db: ODB,
-    ) -> Context<BLOCK, TX, CFG, ODB, Journal<ODB>, CHAIN, LOCAL> {
+    ) -> Context<BLOCK, TX, CFG, ODB, Journal<ODB, JournalEntry<ODB::StorageValue>>, CHAIN, LOCAL>
+    {
         let spec = self.cfg.spec().into();
         let mut journaled_state = Journal::new(db);
         journaled_state.set_spec_id(spec);
@@ -231,8 +235,15 @@ where
     pub fn with_ref_db<ODB: DatabaseRef>(
         self,
         db: ODB,
-    ) -> Context<BLOCK, TX, CFG, WrapDatabaseRef<ODB>, Journal<WrapDatabaseRef<ODB>>, CHAIN, LOCAL>
-    {
+    ) -> Context<
+        BLOCK,
+        TX,
+        CFG,
+        WrapDatabaseRef<ODB>,
+        Journal<WrapDatabaseRef<ODB>, JournalEntry<ODB::StorageValue>>,
+        CHAIN,
+        LOCAL,
+    > {
         let spec = self.cfg.spec().into();
         let mut journaled_state = Journal::new(WrapDatabaseRef(db));
         journaled_state.set_spec_id(spec);
@@ -453,6 +464,8 @@ impl<
         LOCAL: LocalContextTr,
     > Host for Context<BLOCK, TX, CFG, DB, JOURNAL, CHAIN, LOCAL>
 {
+    type StorageValue = <DB as Database>::StorageValue;
+
     /* Block */
 
     fn basefee(&self) -> U256 {
@@ -532,36 +545,13 @@ impl<
     /* Journal */
 
     /// Gets the transient storage value of `address` at `index`.
-    fn tload(&mut self, address: Address, index: StorageKey) -> StorageValue {
+    fn tload(&mut self, address: Address, index: StorageKey) -> TransientStorageValue {
         self.journal_mut().tload(address, index)
     }
 
     /// Sets the transient storage value of `address` at `index`.
-    fn tstore(&mut self, address: Address, index: StorageKey, value: StorageValue) {
+    fn tstore(&mut self, address: Address, index: StorageKey, value: TransientStorageValue) {
         self.journal_mut().tstore(address, index, value)
-    }
-
-    fn cload(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, LoadError> {
-        self.journal_mut()
-            .cload(address, key, skip_cold_load)
-            .map_err(|_e| LoadError::DBError)
-    }
-
-    fn cstore(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        value: StorageValue,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError> {
-        self.journal_mut()
-            .cstore(address, key, value, skip_cold_load)
-            .map_err(|_e| LoadError::DBError)
     }
 
     /// Emits a log owned by `address` with given `LogData`.
@@ -587,9 +577,9 @@ impl<
         &mut self,
         address: Address,
         key: StorageKey,
-        value: StorageValue,
+        value: <DB as Database>::StorageValue,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError> {
+    ) -> Result<StateLoad<SStoreResult<<DB as Database>::StorageValue>>, LoadError> {
         self.journal_mut()
             .sstore_skip_cold_load(address, key, value, skip_cold_load)
             .map_err(|e| {
@@ -606,7 +596,7 @@ impl<
         address: Address,
         key: StorageKey,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<StorageValue>, LoadError> {
+    ) -> Result<StateLoad<<DB as Database>::StorageValue>, LoadError> {
         self.journal_mut()
             .sload_skip_cold_load(address, key, skip_cold_load)
             .map_err(|e| {

--- a/crates/context/src/journal.rs
+++ b/crates/context/src/journal.rs
@@ -20,7 +20,7 @@ use context_interface::{
 };
 use core::ops::{Deref, DerefMut};
 use database_interface::Database;
-use primitives::{hardfork::SpecId, Address, HashSet, Log, StorageKey, StorageValue, B256, U256};
+use primitives::{hardfork::SpecId, Address, HashSet, Log, StorageKey, B256, U256};
 use state::{Account, EvmState};
 use std::vec::Vec;
 
@@ -31,6 +31,10 @@ use std::vec::Vec;
 /// The journal contains every state change that happens within that call, making it possible to revert changes made in a specific call.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound = "DB: serde::Serialize + serde::de::DeserializeOwned, ENTRY: serde::Serialize + serde::de::DeserializeOwned, ENTRY::StorageValue: serde::Serialize + serde::de::DeserializeOwned")
+)]
 pub struct Journal<DB, ENTRY = JournalEntry>
 where
     ENTRY: JournalEntryTr,
@@ -89,9 +93,11 @@ impl<DB, ENTRY: JournalEntryTr + Clone> Journal<DB, ENTRY> {
     }
 }
 
-impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
+impl<DB: Database, ENTRY: JournalEntryTr<StorageValue = DB::StorageValue>> JournalTr
+    for Journal<DB, ENTRY>
+{
     type Database = DB;
-    type State = EvmState;
+    type State = EvmState<DB::StorageValue>;
 
     fn new(database: DB) -> Journal<DB, ENTRY> {
         Self {
@@ -108,34 +114,11 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         &mut self.database
     }
 
-    fn cload(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        _skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, <Self::Database as Database>::Error> {
-        self.inner
-            .cload(&mut self.database, address, key, false)
-            .map_err(JournalLoadError::unwrap_db_error)
-    }
-
-    fn cstore(
-        &mut self,
-        address: Address,
-        key: StorageKey,
-        value: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, <Self::Database as Database>::Error> {
-        self.inner
-            .cstore(&mut self.database, address, key, value, skip_cold_load)
-            .map_err(JournalLoadError::unwrap_db_error)
-    }
-
     fn sload(
         &mut self,
         address: Address,
         key: StorageKey,
-    ) -> Result<StateLoad<StorageValue>, <Self::Database as Database>::Error> {
+    ) -> Result<StateLoad<<DB as Database>::StorageValue>, <Self::Database as Database>::Error> {
         self.inner
             .sload(&mut self.database, address, key, false)
             .map_err(JournalLoadError::unwrap_db_error)
@@ -145,8 +128,8 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         &mut self,
         address: Address,
         key: StorageKey,
-        value: U256,
-    ) -> Result<StateLoad<SStoreResult>, <Self::Database as Database>::Error> {
+        value: <DB as Database>::StorageValue,
+    ) -> Result<StateLoad<SStoreResult<<DB as Database>::StorageValue>>, <Self::Database as Database>::Error> {
         self.inner
             .sstore(&mut self.database, address, key, value, false)
             .map_err(JournalLoadError::unwrap_db_error)
@@ -254,7 +237,7 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
     }
 
     #[inline]
-    fn load_account(&mut self, address: Address) -> Result<StateLoad<&mut Account>, DB::Error> {
+    fn load_account(&mut self, address: Address) -> Result<StateLoad<&mut Account<DB::StorageValue>>, DB::Error> {
         self.inner.load_account(&mut self.database, address)
     }
 
@@ -262,7 +245,7 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
     fn load_account_code(
         &mut self,
         address: Address,
-    ) -> Result<StateLoad<&mut Account>, DB::Error> {
+    ) -> Result<StateLoad<&mut Account<DB::StorageValue>>, DB::Error> {
         self.inner.load_code(&mut self.database, address)
     }
 
@@ -334,7 +317,7 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         address: Address,
         key: StorageKey,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<StorageValue>, JournalLoadError<<Self::Database as Database>::Error>>
+    ) -> Result<StateLoad<<DB as Database>::StorageValue>, JournalLoadError<<Self::Database as Database>::Error>>
     {
         self.inner
             .sload(&mut self.database, address, key, skip_cold_load)
@@ -344,9 +327,9 @@ impl<DB: Database, ENTRY: JournalEntryTr> JournalTr for Journal<DB, ENTRY> {
         &mut self,
         address: Address,
         key: StorageKey,
-        value: StorageValue,
+        value: <DB as Database>::StorageValue,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, JournalLoadError<<Self::Database as Database>::Error>>
+    ) -> Result<StateLoad<SStoreResult<<DB as Database>::StorageValue>>, JournalLoadError<<Self::Database as Database>::Error>>
     {
         self.inner
             .sstore(&mut self.database, address, key, value, skip_cold_load)

--- a/crates/context/src/journal/entry.rs
+++ b/crates/context/src/journal/entry.rs
@@ -4,14 +4,14 @@
 //!
 //! They are created when there is change to the state from loading (making it warm), changes to the balance,
 //! or removal of the storage slot. Check [`JournalEntryTr`] for more details.
-use primitives::alloy_primitives::FlaggedStorage;
-
-use primitives::{Address, StorageKey, StorageValue, KECCAK_EMPTY, PRECOMPILE3, U256};
+use primitives::{Address, StorageKey, StorageValue, StorageValueTr, KECCAK_EMPTY, PRECOMPILE3, U256};
 use state::{EvmState, TransientStorage};
 
 /// Trait for tracking and reverting state changes in the EVM.
 /// Journal entry contains information about state changes that can be reverted.
 pub trait JournalEntryTr {
+    /// The storage value type used by this journal entry.
+    type StorageValue: StorageValueTr;
     /// Creates a journal entry for when an account is accessed and marked as "warm" for gas metering
     fn account_warmed(address: Address) -> Self;
 
@@ -44,7 +44,7 @@ pub trait JournalEntryTr {
 
     /// Creates a journal entry for when a storage slot is modified
     /// Records the previous value for reverting
-    fn storage_changed(address: Address, key: U256, had_value: FlaggedStorage) -> Self;
+    fn storage_changed(address: Address, key: U256, had_value: Self::StorageValue) -> Self;
 
     /// Creates a journal entry for when a storage slot is accessed and marked as "warm" for gas metering
     /// This is called with SLOAD opcode.
@@ -82,7 +82,7 @@ pub trait JournalEntryTr {
     /// ```
     fn revert(
         self,
-        state: &mut EvmState,
+        state: &mut EvmState<Self::StorageValue>,
         transient_storage: Option<&mut TransientStorage>,
         is_spurious_dragon_enabled: bool,
     );
@@ -109,7 +109,7 @@ pub enum SelfdestructionRevertStatus {
 /// Journal entries that are used to track changes to the state and are used to revert it.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum JournalEntry {
+pub enum JournalEntry<SV: StorageValueTr = U256> {
     /// Used to mark account that is warm inside EVM in regard to EIP-2929 AccessList.
     /// Action: We will add Account to state.
     /// Revert: we will remove account from state.
@@ -183,7 +183,7 @@ pub enum JournalEntry {
         /// Key of storage slot that is changed.
         key: StorageKey,
         /// Previous value of storage slot.
-        had_value: FlaggedStorage,
+        had_value: SV,
         /// Address of account that had its storage changed.
         address: Address,
     },
@@ -215,7 +215,9 @@ pub enum JournalEntry {
         address: Address,
     },
 }
-impl JournalEntryTr for JournalEntry {
+impl<SV: StorageValueTr> JournalEntryTr for JournalEntry<SV> {
+    type StorageValue = SV;
+
     fn account_warmed(address: Address) -> Self {
         JournalEntry::AccountWarmed { address }
     }
@@ -256,7 +258,7 @@ impl JournalEntryTr for JournalEntry {
         }
     }
 
-    fn storage_changed(address: Address, key: U256, had_value: FlaggedStorage) -> Self {
+    fn storage_changed(address: Address, key: U256, had_value: SV) -> Self {
         JournalEntry::StorageChanged {
             address,
             key,
@@ -290,7 +292,7 @@ impl JournalEntryTr for JournalEntry {
 
     fn revert(
         self,
-        state: &mut EvmState,
+        state: &mut EvmState<SV>,
         transient_storage: Option<&mut TransientStorage>,
         is_spurious_dragon_enabled: bool,
     ) {

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -9,11 +9,10 @@ use context_interface::{
 };
 use core::mem;
 use database_interface::Database;
-use primitives::alloy_primitives::FlaggedStorage;
 use primitives::{
     hardfork::SpecId::{self, *},
     hash_map::Entry,
-    Address, HashMap, Log, StorageKey, StorageValue, B256, KECCAK_EMPTY, U256,
+    Address, HashMap, Log, StorageKey, StorageValueTr, B256, KECCAK_EMPTY, U256,
 };
 use state::{Account, EvmState, EvmStorageSlot, TransientStorage};
 use std::vec::Vec;
@@ -22,9 +21,13 @@ use std::vec::Vec;
 /// Spec Id is a essential information for the Journal.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct JournalInner<ENTRY> {
+#[cfg_attr(
+    feature = "serde",
+    serde(bound = "ENTRY: serde::Serialize + serde::de::DeserializeOwned, ENTRY::StorageValue: serde::Serialize + serde::de::DeserializeOwned")
+)]
+pub struct JournalInner<ENTRY: JournalEntryTr> {
     /// The current state
-    pub state: EvmState,
+    pub state: EvmState<ENTRY::StorageValue>,
     /// Transient storage that is discarded after every transaction.
     ///
     /// See [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153).
@@ -65,29 +68,6 @@ impl<ENTRY: JournalEntryTr> Default for JournalInner<ENTRY> {
 }
 
 impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
-    /// Loads the private storage value from Journal state.
-    pub fn cload<DB: Database>(
-        &mut self,
-        db: &mut DB,
-        address: Address,
-        key: StorageKey,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, JournalLoadError<DB::Error>> {
-        self.load_inner(db, address, key, skip_cold_load, true)
-    }
-
-    /// Stores the private storage value in Journal state.
-    pub fn cstore<DB: Database>(
-        &mut self,
-        db: &mut DB,
-        address: Address,
-        key: StorageKey,
-        value: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, JournalLoadError<DB::Error>> {
-        self.store(db, address, key, value, skip_cold_load, true)
-    }
-
     /// Creates new [`JournalInner`].
     ///
     /// `warm_preloaded_addresses` is used to determine if address is considered warm loaded.
@@ -179,7 +159,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     /// Note: Precompile addresses and spec are preserved and initial state of
     /// warm_preloaded_addresses will contain precompiles addresses.
     #[inline]
-    pub fn finalize(&mut self) -> EvmState {
+    pub fn finalize(&mut self) -> EvmState<ENTRY::StorageValue> {
         // Clears all field from JournalInner. Doing it this way to avoid
         // missing any field.
         let Self {
@@ -212,7 +192,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
     /// Return reference to state.
     #[inline]
-    pub fn state(&mut self) -> &mut EvmState {
+    pub fn state(&mut self) -> &mut EvmState<ENTRY::StorageValue> {
         &mut self.state
     }
 
@@ -234,7 +214,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
     /// Mark account as touched.
     #[inline]
-    fn touch_account(journal: &mut Vec<ENTRY>, address: Address, account: &mut Account) {
+    fn touch_account(journal: &mut Vec<ENTRY>, address: Address, account: &mut Account<ENTRY::StorageValue>) {
         if !account.is_touched() {
             journal.push(ENTRY::account_touched(address));
             account.mark_touch();
@@ -249,7 +229,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     ///
     /// Panics if the account has not been loaded and is missing from the state set.
     #[inline]
-    pub fn account(&self, address: Address) -> &Account {
+    pub fn account(&self, address: Address) -> &Account<ENTRY::StorageValue> {
         self.state
             .get(&address)
             .expect("Account expected to be loaded") // Always assume that acc is already loaded
@@ -311,7 +291,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     ///
     /// Mark account as touched.
     #[inline]
-    pub fn balance_incr<DB: Database>(
+    pub fn balance_incr<DB: Database<StorageValue = ENTRY::StorageValue>>(
         &mut self,
         db: &mut DB,
         address: Address,
@@ -341,7 +321,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 
     /// Transfers balance from two accounts. Returns error if sender balance is not enough.
     #[inline]
-    pub fn transfer<DB: Database>(
+    pub fn transfer<DB: Database<StorageValue = ENTRY::StorageValue>>(
         &mut self,
         db: &mut DB,
         from: Address,
@@ -512,7 +492,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     ///  * <https://github.com/ethereum/go-ethereum/blob/141cd425310b503c5678e674a8c3872cf46b7086/core/state/statedb.go#L449>
     ///  * <https://eips.ethereum.org/EIPS/eip-6780>
     #[inline]
-    pub fn selfdestruct<DB: Database>(
+    pub fn selfdestruct<DB: Database<StorageValue = ENTRY::StorageValue>>(
         &mut self,
         db: &mut DB,
         address: Address,
@@ -579,17 +559,16 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                     == SelfdestructionRevertStatus::RepeatedSelfdestruction,
             },
             is_cold,
-            is_private: false,
         })
     }
 
     /// Loads account into memory. return if it is cold or warm accessed
     #[inline]
-    pub fn load_account<DB: Database>(
+    pub fn load_account<DB: Database<StorageValue = ENTRY::StorageValue>>(
         &mut self,
         db: &mut DB,
         address: Address,
-    ) -> Result<StateLoad<&mut Account>, DB::Error> {
+    ) -> Result<StateLoad<&mut Account<ENTRY::StorageValue>>, DB::Error> {
         self.load_account_optional(db, address, false, [], false)
             .map_err(JournalLoadError::unwrap_db_error)
     }
@@ -602,7 +581,7 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     /// Returns information about the account (If it is empty or cold loaded) and if present the information
     /// about the delegated account (If it is cold loaded).
     #[inline]
-    pub fn load_account_delegated<DB: Database>(
+    pub fn load_account_delegated<DB: Database<StorageValue = ENTRY::StorageValue>>(
         &mut self,
         db: &mut DB,
         address: Address,
@@ -620,7 +599,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                 is_empty,
             },
             account.is_cold,
-            false,
         );
 
         // load delegate code if account is EIP-7702
@@ -640,25 +618,25 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     /// In case of EIP-7702 delegated account will not be loaded,
     /// [`Self::load_account_delegated`] should be used instead.
     #[inline]
-    pub fn load_code<DB: Database>(
+    pub fn load_code<DB: Database<StorageValue = ENTRY::StorageValue>>(
         &mut self,
         db: &mut DB,
         address: Address,
-    ) -> Result<StateLoad<&mut Account>, DB::Error> {
+    ) -> Result<StateLoad<&mut Account<ENTRY::StorageValue>>, DB::Error> {
         self.load_account_optional(db, address, true, [], false)
             .map_err(JournalLoadError::unwrap_db_error)
     }
 
     /// Loads account. If account is already loaded it will be marked as warm.
     #[inline(never)]
-    pub fn load_account_optional<DB: Database>(
+    pub fn load_account_optional<DB: Database<StorageValue = ENTRY::StorageValue>>(
         &mut self,
         db: &mut DB,
         address: Address,
         load_code: bool,
         storage_keys: impl IntoIterator<Item = StorageKey>,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<&mut Account>, JournalLoadError<DB::Error>> {
+    ) -> Result<StateLoad<&mut Account<ENTRY::StorageValue>>, JournalLoadError<DB::Error>> {
         let load = match self.state.entry(address) {
             Entry::Occupied(entry) => {
                 let account = entry.into_mut();
@@ -690,7 +668,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                 StateLoad {
                     data: account,
                     is_cold,
-                    is_private: false,
                 }
             }
             Entry::Vacant(vac) => {
@@ -710,7 +687,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                 StateLoad {
                     data: vac.insert(account),
                     is_cold,
-                    is_private: false,
                 }
             }
         };
@@ -740,7 +716,6 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
                 address,
                 storage_key,
                 false,
-                false,
             )?;
         }
         Ok(load)
@@ -752,14 +727,16 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
     ///
     /// Panics if the account is not present in the state.
     #[inline]
-    fn load_inner<DB: Database>(
+    /// Loads storage slot value.
+    ///
+    /// Returns the storage value.
+    pub fn sload<DB: Database<StorageValue = ENTRY::StorageValue>>(
         &mut self,
         db: &mut DB,
         address: Address,
         key: StorageKey,
         skip_cold_load: bool,
-        default_privacy: bool,
-    ) -> Result<StateLoad<StorageValue>, JournalLoadError<DB::Error>> {
+    ) -> Result<StateLoad<ENTRY::StorageValue>, JournalLoadError<DB::Error>> {
         // assume acc is warm
         let account = self.state.get_mut(&address).unwrap();
         // only if account is created in this tx we can assume that storage is empty.
@@ -771,49 +748,23 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
             address,
             key,
             skip_cold_load,
-            default_privacy,
         )
     }
 
-    /// Loads public storage slot
-    pub fn sload<DB: Database>(
-        &mut self,
-        db: &mut DB,
-        address: Address,
-        key: StorageKey,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<StorageValue>, JournalLoadError<DB::Error>> {
-        self.load_inner(db, address, key, skip_cold_load, false)
-    }
-
-    /// Stores public storage value
-    #[inline]
-    pub fn sstore<DB: Database>(
-        &mut self,
-        db: &mut DB,
-        address: Address,
-        key: StorageKey,
-        value: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, JournalLoadError<DB::Error>> {
-        self.store(db, address, key, value, skip_cold_load, false)
-    }
-
-    /// Stores storage slot.
+    /// Stores storage slot value.
     ///
     /// And returns (original,present,new) slot value.
     ///
     /// **Note**: Account should already be present in our state.
     #[inline]
-    pub fn store<DB: Database>(
+    pub fn sstore<DB: Database<StorageValue = ENTRY::StorageValue>>(
         &mut self,
         db: &mut DB,
         address: Address,
         key: StorageKey,
-        new: StorageValue,
+        new_value: ENTRY::StorageValue,
         skip_cold_load: bool,
-        is_private: bool,
-    ) -> Result<StateLoad<SStoreResult>, JournalLoadError<DB::Error>> {
+    ) -> Result<StateLoad<SStoreResult<ENTRY::StorageValue>>, JournalLoadError<DB::Error>> {
         // assume that acc exists and load the slot.
         let present = self.sload(db, address, key, skip_cold_load)?;
         let acc = self.state.get_mut(&address).unwrap();
@@ -821,32 +772,30 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
         // if there is no original value in dirty return present value, that is our original.
         let slot = acc.storage.get_mut(&key).unwrap();
 
+        let present_value = present.data;
         // new value is same as present, we don't need to do anything
-        let present_value = FlaggedStorage::new(present.data, present.is_private);
-        if present_value == FlaggedStorage::new(new, is_private) {
+        if present_value == new_value {
             return Ok(StateLoad::new(
                 SStoreResult {
                     original_value: slot.original_value(),
                     present_value,
-                    new_value: FlaggedStorage::new(new, is_private),
+                    new_value,
                 },
                 present.is_cold,
-                is_private,
             ));
         }
 
         self.journal
             .push(ENTRY::storage_changed(address, key, present_value));
         // insert value into present state.
-        slot.present_value = FlaggedStorage::new(new, is_private);
+        slot.present_value = new_value;
         Ok(StateLoad::new(
             SStoreResult {
                 original_value: slot.original_value(),
                 present_value,
-                new_value: FlaggedStorage::new(new, is_private),
+                new_value,
             },
             present.is_cold,
-            is_private,
         ))
     }
 
@@ -905,28 +854,28 @@ impl<ENTRY: JournalEntryTr> JournalInner<ENTRY> {
 }
 
 /// Loads storage slot with account.
+///
+/// For newly created accounts, storage defaults to SV::ZERO.
 #[inline]
-pub fn sload_with_account<DB: Database, ENTRY: JournalEntryTr>(
-    account: &mut Account,
+pub fn sload_with_account<SV: StorageValueTr, DB: Database<StorageValue = SV>, ENTRY: JournalEntryTr<StorageValue = SV>>(
+    account: &mut Account<SV>,
     db: &mut DB,
     journal: &mut Vec<ENTRY>,
     transaction_id: usize,
     address: Address,
     key: StorageKey,
     skip_cold_load: bool,
-    default_privacy: bool,
-) -> Result<StateLoad<StorageValue>, JournalLoadError<DB::Error>> {
+) -> Result<StateLoad<SV>, JournalLoadError<DB::Error>> {
     // only if account is created in this tx we can assume that storage is empty.
     let is_newly_created = account.is_created();
-    let (value, is_cold, is_private) = match account.storage.entry(key) {
+    let (value, is_cold) = match account.storage.entry(key) {
         Entry::Occupied(occ) => {
             let slot = occ.into_mut();
             let is_cold = slot.is_cold_transaction_id(transaction_id);
             if skip_cold_load && is_cold {
                 return Err(JournalLoadError::ColdLoadSkipped);
             }
-            let is_private = slot.present_value().is_private;
-            (slot.present_value.value, is_cold, is_private)
+            (slot.present_value, is_cold)
         }
         Entry::Vacant(vac) => {
             // if storage was cleared, we don't need to ping db.
@@ -934,15 +883,14 @@ pub fn sload_with_account<DB: Database, ENTRY: JournalEntryTr>(
                 return Err(JournalLoadError::ColdLoadSkipped);
             }
             let value = if is_newly_created {
-                FlaggedStorage::ZERO.set_visibility(default_privacy)
+                SV::ZERO
             } else {
-                let v = db.storage(address, key)?;
-                v
+                db.storage(address, key)?
             };
 
             vac.insert(EvmStorageSlot::new(value, transaction_id));
 
-            (value.value, true, value.is_private)
+            (value, true)
         }
     };
 
@@ -951,5 +899,5 @@ pub fn sload_with_account<DB: Database, ENTRY: JournalEntryTr>(
         journal.push(ENTRY::storage_warmed(address, key));
     }
 
-    Ok(StateLoad::new(value, is_cold, is_private))
+    Ok(StateLoad::new(value, is_cold))
 }

--- a/crates/context/src/journal/test_flagged_storage.rs
+++ b/crates/context/src/journal/test_flagged_storage.rs
@@ -1,16 +1,20 @@
 use super::entry::JournalEntry;
 use super::inner::JournalInner;
-use database::InMemoryDB;
-use database_interface::Database;
+use core::convert::Infallible;
+use database::CacheDB;
+use database_interface::{Database, EmptyDBTyped};
 use primitives::{hardfork::SpecId, Address, FlaggedStorage, U256};
 use state::{Account, AccountInfo, AccountStatus, EvmStorage};
+
+/// InMemoryDB with FlaggedStorage for these tests.
+type FlaggedInMemoryDB = CacheDB<EmptyDBTyped<Infallible, FlaggedStorage>, FlaggedStorage>;
 
 // =============================================================================
 // HELPER FUNCTIONS
 // =============================================================================
 
 // Helper function to create test accounts with different statuses
-fn create_test_account(status: AccountStatus) -> Account {
+fn create_test_account(status: AccountStatus) -> Account<FlaggedStorage> {
     Account {
         info: AccountInfo {
             nonce: 1,
@@ -27,16 +31,16 @@ fn create_test_account(status: AccountStatus) -> Account {
 fn setup_journal_with_account(
     address: Address,
     status: AccountStatus,
-) -> JournalInner<JournalEntry> {
-    let mut journal = JournalInner::<JournalEntry>::new();
+) -> JournalInner<JournalEntry<FlaggedStorage>> {
+    let mut journal = JournalInner::<JournalEntry<FlaggedStorage>>::new();
     journal.state.insert(address, create_test_account(status));
     journal
 }
 
 // Helper function to verify storage state with detailed assertions
 fn verify_storage_state(
-    journal: &mut JournalInner<JournalEntry>,
-    db: &mut InMemoryDB,
+    journal: &mut JournalInner<JournalEntry<FlaggedStorage>>,
+    db: &mut FlaggedInMemoryDB,
     address: Address,
     key: U256,
     expected_value: U256,
@@ -45,51 +49,52 @@ fn verify_storage_state(
 ) {
     let result = journal.sload(db, address, key, false).unwrap();
     assert_eq!(
-        result.data, expected_value,
+        result.data.value, expected_value,
         "{}: Storage value mismatch. Expected {}, got {}",
-        context, expected_value, result.data
+        context, expected_value, result.data.value
     );
     assert_eq!(
-        result.is_private, expected_private,
+        result.data.is_private, expected_private,
         "{}: Privacy flag mismatch. Expected {}, got {}",
-        context, expected_private, result.is_private
+        context, expected_private, result.data.is_private
     );
 }
 
 // Helper function to store data using appropriate operation based on shielded parameter
 fn store_value(
     shielded: bool,
-    journal: &mut JournalInner<JournalEntry>,
-    db: &mut InMemoryDB,
+    journal: &mut JournalInner<JournalEntry<FlaggedStorage>>,
+    db: &mut FlaggedInMemoryDB,
     address: Address,
     key: U256,
     value: U256,
-) -> context_interface::context::StateLoad<context_interface::context::SStoreResult> {
+) -> context_interface::context::StateLoad<context_interface::context::SStoreResult<primitives::FlaggedStorage>> {
     if shielded {
-        journal.cstore(db, address, key, value, false).unwrap()
+        journal
+            .sstore(db, address, key, FlaggedStorage::new(value, true), false)
+            .unwrap()
     } else {
-        journal.sstore(db, address, key, value, false).unwrap()
+        journal
+            .sstore(db, address, key, FlaggedStorage::new(value, false), false)
+            .unwrap()
     }
 }
 
 // Helper function to load data using appropriate operation based on shielded parameter
 fn load_value(
-    shielded: bool,
-    journal: &mut JournalInner<JournalEntry>,
-    db: &mut InMemoryDB,
+    _shielded: bool,
+    journal: &mut JournalInner<JournalEntry<FlaggedStorage>>,
+    db: &mut FlaggedInMemoryDB,
     address: Address,
     key: U256,
-) -> context_interface::context::StateLoad<U256> {
-    if shielded {
-        journal.cload(db, address, key, false).unwrap()
-    } else {
-        journal.sload(db, address, key, false).unwrap()
-    }
+) -> context_interface::context::StateLoad<FlaggedStorage> {
+    // Both cload and sload are now unified into sload which returns FlaggedStorage
+    journal.sload(db, address, key, false).unwrap()
 }
 
 // Helper function to verify account status
 fn verify_account_status(
-    journal: &JournalInner<JournalEntry>,
+    journal: &JournalInner<JournalEntry<FlaggedStorage>>,
     address: Address,
     expected_created: bool,
     context: &str,
@@ -129,7 +134,7 @@ fn verify_account_status(
 
 // Implementation of simple revert test for both private and public storage
 fn _test_storage_simple_revert(shielded: bool) {
-    let mut db = InMemoryDB::default();
+    let mut db = FlaggedInMemoryDB::default();
     let address = Address::from_slice(&[0x1; 20]);
     let storage_key = U256::from(1);
 
@@ -163,7 +168,7 @@ fn _test_storage_simple_revert(shielded: bool) {
         U256::from(42),
     );
     assert_eq!(
-        store_result.is_private, shielded,
+        store_result.data.new_value.is_private, shielded,
         "{} operation must mark storage as {}",
         operation_name, storage_type
     );
@@ -182,12 +187,12 @@ fn _test_storage_simple_revert(shielded: bool) {
     // Verify storage was stored with correct value using consistent load operation
     let before_revert = load_value(shielded, &mut journal, &mut db, address, storage_key);
     assert_eq!(
-        before_revert.data,
+        before_revert.data.value,
         U256::from(42),
         "Storage must contain the stored value before revert"
     );
     assert_eq!(
-        before_revert.is_private, shielded,
+        before_revert.data.is_private, shielded,
         "Storage must be marked {} before revert",
         storage_type
     );
@@ -209,7 +214,7 @@ fn _test_storage_simple_revert(shielded: bool) {
     // Verify state after revert - should be back to original (zero/empty)
     let after_revert = load_value(shielded, &mut journal, &mut db, address, storage_key);
     assert_eq!(
-        after_revert.data,
+        after_revert.data.value,
         U256::ZERO,
         "Storage value must be zero after reverting {} storage write",
         storage_type
@@ -217,12 +222,12 @@ fn _test_storage_simple_revert(shielded: bool) {
 
     if shielded {
         assert!(
-            !after_revert.is_private,
+            !after_revert.data.is_private,
             "BUGGY: Storage must be public (not private) after revert to empty state"
         );
     } else {
         assert!(
-            !after_revert.is_private,
+            !after_revert.data.is_private,
             "Storage must remain public after revert to empty state"
         );
     }
@@ -230,12 +235,12 @@ fn _test_storage_simple_revert(shielded: bool) {
 
 // Implementation of account creation with storage followed by revert
 fn _test_account_creation_storage_revert(shielded: bool) {
-    let mut db = InMemoryDB::default();
+    let mut db = FlaggedInMemoryDB::default();
     let caller_address = Address::from_slice(&[0x1; 20]);
     let created_address = Address::from_slice(&[0x3; 20]);
     let storage_key = U256::from(1);
 
-    let mut journal = JournalInner::<JournalEntry>::new();
+    let mut journal = JournalInner::<JournalEntry<FlaggedStorage>>::new();
 
     let storage_type = if shielded { "private" } else { "public" };
     let operation_name = if shielded { "CSTORE" } else { "SSTORE" };
@@ -282,7 +287,7 @@ fn _test_account_creation_storage_revert(shielded: bool) {
         U256::from(99),
     );
     assert_eq!(
-        store_result.is_private, shielded,
+        store_result.data.new_value.is_private, shielded,
         "{} in new account must mark storage as {}",
         operation_name, storage_type
     );
@@ -296,12 +301,12 @@ fn _test_account_creation_storage_revert(shielded: bool) {
         storage_key,
     );
     assert_eq!(
-        read_result.data,
+        read_result.data.value,
         U256::from(99),
         "Storage must contain the stored value"
     );
     assert_eq!(
-        read_result.is_private, shielded,
+        read_result.data.is_private, shielded,
         "Storage must be marked {} after {}",
         storage_type, operation_name
     );
@@ -327,12 +332,12 @@ fn _test_account_creation_storage_revert(shielded: bool) {
             storage_key,
         );
         assert_eq!(
-            read_after_revert.data,
+            read_after_revert.data.value,
             U256::ZERO,
             "Storage must be zero after account creation revert"
         );
         assert!(
-            !read_after_revert.is_private,
+            !read_after_revert.data.is_private,
             "Storage must be public after account creation revert"
         );
     }
@@ -348,7 +353,7 @@ fn _test_account_creation_storage_revert(shielded: bool) {
 
 // Implementation of nested checkpoint reverts with storage
 fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
-    let mut db = InMemoryDB::default();
+    let mut db = FlaggedInMemoryDB::default();
     let address = Address::from_slice(&[0x4; 20]);
     let key1 = U256::from(1);
     let key2 = U256::from(2);
@@ -389,7 +394,7 @@ fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
         U256::from(10),
     );
     assert_eq!(
-        initial_store.is_private, shielded,
+        initial_store.data.new_value.is_private, shielded,
         "Level 0 {} must mark storage as {}",
         operation_name, storage_type
     );
@@ -420,7 +425,7 @@ fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
         U256::from(20),
     ); // Modify existing
     assert_eq!(
-        modify_store.is_private, shielded,
+        modify_store.data.new_value.is_private, shielded,
         "Level 1 key1 {} must maintain {} flag",
         operation_name, storage_type
     );
@@ -440,7 +445,7 @@ fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
         U256::from(30),
     ); // New key
     assert_eq!(
-        new_store.is_private, shielded,
+        new_store.data.new_value.is_private, shielded,
         "Level 1 key2 {} must mark storage as {}",
         operation_name, storage_type
     );
@@ -481,7 +486,7 @@ fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
         U256::from(40),
     ); // Modify again
     assert_eq!(
-        modify_again.is_private, shielded,
+        modify_again.data.new_value.is_private, shielded,
         "Level 2 {} must maintain {} flag",
         operation_name, storage_type
     );
@@ -568,19 +573,19 @@ fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
     // Check key2 after complete revert - behavior differs between private and public
     let key2_after_revert = load_value(shielded, &mut journal, &mut db, address, key2);
     assert_eq!(
-        key2_after_revert.data,
+        key2_after_revert.data.value,
         U256::ZERO,
         "key2 must revert to zero after level 1 revert"
     );
 
     if shielded {
         assert!(
-            !key2_after_revert.is_private,
+            !key2_after_revert.data.is_private,
             "BUGGY: key2 must be public (empty) after level 1 revert for private storage"
         );
     } else {
         assert!(
-            !key2_after_revert.is_private,
+            !key2_after_revert.data.is_private,
             "key2 must be public (empty) after level 1 revert for public storage"
         );
     }
@@ -593,7 +598,7 @@ fn _test_nested_checkpoint_storage_reverts(shielded: bool) {
 /// Test that demonstrates the database correctly preserves privacy flags
 #[test]
 fn test_database_privacy_flag_preservation() {
-    let mut db = InMemoryDB::default();
+    let mut db = FlaggedInMemoryDB::default();
     let address = Address::from_slice(&[0x2; 20]);
     let storage_key = U256::from(1);
 
@@ -658,7 +663,7 @@ fn test_database_privacy_flag_preservation() {
 /// Test mixed private/public storage reverts to ensure privacy flags are handled correctly
 #[test]
 fn test_mixed_storage_revert() {
-    let mut db = InMemoryDB::default();
+    let mut db = FlaggedInMemoryDB::default();
     let address = Address::from_slice(&[0x2; 20]);
     let private_key = U256::from(1);
     let public_key = U256::from(2);
@@ -695,7 +700,7 @@ fn test_mixed_storage_revert() {
         U256::from(100),
     );
     assert!(
-        !initial_public_store.is_private,
+        !initial_public_store.data.new_value.is_private,
         "SSTORE operation must mark storage as public"
     );
     assert_eq!(
@@ -729,7 +734,7 @@ fn test_mixed_storage_revert() {
         U256::from(200),
     );
     assert!(
-        private_store.is_private,
+        private_store.data.new_value.is_private,
         "CSTORE operation must mark storage as private"
     );
     assert_eq!(
@@ -748,7 +753,7 @@ fn test_mixed_storage_revert() {
         U256::from(300),
     );
     assert!(
-        !public_modify.is_private,
+        !public_modify.data.new_value.is_private,
         "SSTORE operation must keep storage public"
     );
     assert_eq!(
@@ -767,21 +772,21 @@ fn test_mixed_storage_revert() {
     let private_read = load_value(true, &mut journal, &mut db, address, private_key);
     let public_read = load_value(false, &mut journal, &mut db, address, public_key);
     assert_eq!(
-        private_read.data,
+        private_read.data.value,
         U256::from(200),
         "Private storage must contain correct value before revert"
     );
     assert!(
-        private_read.is_private,
+        private_read.data.is_private,
         "Private storage must be marked private before revert"
     );
     assert_eq!(
-        public_read.data,
+        public_read.data.value,
         U256::from(300),
         "Public storage must contain correct value before revert"
     );
     assert!(
-        !public_read.is_private,
+        !public_read.data.is_private,
         "Public storage must be marked public before revert"
     );
 
@@ -800,7 +805,7 @@ fn test_mixed_storage_revert() {
     let public_after = load_value(false, &mut journal, &mut db, address, public_key);
 
     assert_eq!(
-        private_after.data,
+        private_after.data.value,
         U256::ZERO,
         "Private storage value must be zero after revert"
     );
@@ -809,7 +814,7 @@ fn test_mixed_storage_revert() {
         "BUGGY: Reverted private storage must be public (empty)"
     );
     assert_eq!(
-        public_after.data,
+        public_after.data.value,
         U256::from(100),
         "Public storage value must be reverted to original"
     );

--- a/crates/database/interface/src/async_db.rs
+++ b/crates/database/interface/src/async_db.rs
@@ -1,8 +1,7 @@
 //! Async database interface.
 use crate::{DBErrorMarker, Database, DatabaseRef};
 use core::{error::Error, future::Future};
-use primitives::alloy_primitives::FlaggedStorage;
-use primitives::{Address, StorageKey, B256};
+use primitives::{Address, StorageKey, StorageValueTr, B256};
 use state::{AccountInfo, Bytecode};
 use tokio::runtime::{Handle, Runtime};
 
@@ -14,6 +13,9 @@ use tokio::runtime::{Handle, Runtime};
 pub trait DatabaseAsync {
     /// The database error type
     type Error: Send + DBErrorMarker + Error;
+
+    /// The storage value type.
+    type StorageValue: StorageValueTr + Send;
 
     /// Gets basic account information.
     fn basic_async(
@@ -32,7 +34,7 @@ pub trait DatabaseAsync {
         &mut self,
         address: Address,
         index: StorageKey,
-    ) -> impl Future<Output = Result<FlaggedStorage, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Self::StorageValue, Self::Error>> + Send;
 
     /// Gets block hash by block number.
     fn block_hash_async(
@@ -49,6 +51,9 @@ pub trait DatabaseAsync {
 pub trait DatabaseAsyncRef {
     /// The database error type
     type Error: Send + DBErrorMarker + Error;
+
+    /// The storage value type.
+    type StorageValue: StorageValueTr + Send;
 
     /// Gets basic account information.
     fn basic_async_ref(
@@ -67,7 +72,7 @@ pub trait DatabaseAsyncRef {
         &self,
         address: Address,
         index: StorageKey,
-    ) -> impl Future<Output = Result<FlaggedStorage, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Self::StorageValue, Self::Error>> + Send;
 
     /// Gets block hash by block number.
     fn block_hash_async_ref(
@@ -122,6 +127,7 @@ impl<T> WrapDatabaseAsync<T> {
 
 impl<T: DatabaseAsync> Database for WrapDatabaseAsync<T> {
     type Error = T::Error;
+    type StorageValue = T::StorageValue;
 
     #[inline]
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -138,7 +144,7 @@ impl<T: DatabaseAsync> Database for WrapDatabaseAsync<T> {
         &mut self,
         address: Address,
         index: StorageKey,
-    ) -> Result<FlaggedStorage, Self::Error> {
+    ) -> Result<T::StorageValue, Self::Error> {
         self.rt.block_on(self.db.storage_async(address, index))
     }
 
@@ -150,6 +156,7 @@ impl<T: DatabaseAsync> Database for WrapDatabaseAsync<T> {
 
 impl<T: DatabaseAsyncRef> DatabaseRef for WrapDatabaseAsync<T> {
     type Error = T::Error;
+    type StorageValue = T::StorageValue;
 
     #[inline]
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -166,7 +173,7 @@ impl<T: DatabaseAsyncRef> DatabaseRef for WrapDatabaseAsync<T> {
         &self,
         address: Address,
         index: StorageKey,
-    ) -> Result<FlaggedStorage, Self::Error> {
+    ) -> Result<T::StorageValue, Self::Error> {
         self.rt.block_on(self.db.storage_async_ref(address, index))
     }
 

--- a/crates/database/interface/src/either.rs
+++ b/crates/database/interface/src/either.rs
@@ -2,15 +2,16 @@
 
 use crate::{Database, DatabaseCommit, DatabaseRef};
 use either::Either;
-use primitives::{Address, HashMap, StorageKey, B256};
+use primitives::{Address, HashMap, StorageKey, StorageValueTr, B256};
 use state::{Account, AccountInfo, Bytecode};
 
 impl<L, R> Database for Either<L, R>
 where
     L: Database,
-    R: Database<Error = L::Error>,
+    R: Database<Error = L::Error, StorageValue = L::StorageValue>,
 {
     type Error = L::Error;
+    type StorageValue = L::StorageValue;
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         match self {
@@ -30,7 +31,7 @@ where
         &mut self,
         address: Address,
         index: StorageKey,
-    ) -> Result<state::FlaggedStorage, Self::Error> {
+    ) -> Result<Self::StorageValue, Self::Error> {
         match self {
             Self::Left(db) => db.storage(address, index),
             Self::Right(db) => db.storage(address, index),
@@ -45,12 +46,12 @@ where
     }
 }
 
-impl<L, R> DatabaseCommit for Either<L, R>
+impl<L, R, SV: StorageValueTr> DatabaseCommit<SV> for Either<L, R>
 where
-    L: DatabaseCommit,
-    R: DatabaseCommit,
+    L: DatabaseCommit<SV>,
+    R: DatabaseCommit<SV>,
 {
-    fn commit(&mut self, changes: HashMap<Address, Account>) {
+    fn commit(&mut self, changes: HashMap<Address, Account<SV>>) {
         match self {
             Self::Left(db) => db.commit(changes),
             Self::Right(db) => db.commit(changes),
@@ -61,9 +62,10 @@ where
 impl<L, R> DatabaseRef for Either<L, R>
 where
     L: DatabaseRef,
-    R: DatabaseRef<Error = L::Error>,
+    R: DatabaseRef<Error = L::Error, StorageValue = L::StorageValue>,
 {
     type Error = L::Error;
+    type StorageValue = L::StorageValue;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         match self {
@@ -83,7 +85,7 @@ where
         &self,
         address: Address,
         index: StorageKey,
-    ) -> Result<state::FlaggedStorage, Self::Error> {
+    ) -> Result<Self::StorageValue, Self::Error> {
         match self {
             Self::Left(db) => db.storage_ref(address, index),
             Self::Right(db) => db.storage_ref(address, index),

--- a/crates/database/interface/src/empty_db.rs
+++ b/crates/database/interface/src/empty_db.rs
@@ -2,51 +2,53 @@
 use crate::{DBErrorMarker, Database, DatabaseRef};
 use core::error::Error;
 use core::{convert::Infallible, fmt, marker::PhantomData};
-use primitives::{keccak256, Address, FlaggedStorage, B256, U256};
+use primitives::{keccak256, Address, StorageValueTr, B256, U256};
 use state::{AccountInfo, Bytecode};
 use std::string::ToString;
 
-/// An empty database that always returns default values when queried
+/// An empty database that always returns default values when queried.
+/// Uses `U256` as the default storage value type.
 pub type EmptyDB = EmptyDBTyped<Infallible>;
 
 /// An empty database that always returns default values when queried
 ///
-/// This is generic over a type which is used as the database error type.
+/// This is generic over a type which is used as the database error type,
+/// and a storage value type (defaults to `U256`).
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct EmptyDBTyped<E> {
-    _phantom: PhantomData<E>,
+pub struct EmptyDBTyped<E, SV: StorageValueTr = U256> {
+    _phantom: PhantomData<(E, SV)>,
 }
 
-// Don't derive traits, because the type parameter is unused.
-impl<E> Clone for EmptyDBTyped<E> {
+// Don't derive traits, because the type parameters are unused.
+impl<E, SV: StorageValueTr> Clone for EmptyDBTyped<E, SV> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<E> Copy for EmptyDBTyped<E> {}
+impl<E, SV: StorageValueTr> Copy for EmptyDBTyped<E, SV> {}
 
-impl<E> Default for EmptyDBTyped<E> {
+impl<E, SV: StorageValueTr> Default for EmptyDBTyped<E, SV> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<E> fmt::Debug for EmptyDBTyped<E> {
+impl<E, SV: StorageValueTr> fmt::Debug for EmptyDBTyped<E, SV> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EmptyDB").finish_non_exhaustive()
     }
 }
 
-impl<E> PartialEq for EmptyDBTyped<E> {
+impl<E, SV: StorageValueTr> PartialEq for EmptyDBTyped<E, SV> {
     fn eq(&self, _: &Self) -> bool {
         true
     }
 }
 
-impl<E> Eq for EmptyDBTyped<E> {}
+impl<E, SV: StorageValueTr> Eq for EmptyDBTyped<E, SV> {}
 
-impl<E> EmptyDBTyped<E> {
+impl<E, SV: StorageValueTr> EmptyDBTyped<E, SV> {
     /// Create a new empty database.
     pub fn new() -> Self {
         Self {
@@ -55,8 +57,9 @@ impl<E> EmptyDBTyped<E> {
     }
 }
 
-impl<E: DBErrorMarker + Error> Database for EmptyDBTyped<E> {
+impl<E: DBErrorMarker + Error, SV: StorageValueTr> Database for EmptyDBTyped<E, SV> {
     type Error = E;
+    type StorageValue = SV;
 
     #[inline]
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -69,7 +72,11 @@ impl<E: DBErrorMarker + Error> Database for EmptyDBTyped<E> {
     }
 
     #[inline]
-    fn storage(&mut self, address: Address, index: U256) -> Result<FlaggedStorage, Self::Error> {
+    fn storage(
+        &mut self,
+        address: Address,
+        index: U256,
+    ) -> Result<Self::StorageValue, Self::Error> {
         <Self as DatabaseRef>::storage_ref(self, address, index)
     }
 
@@ -79,8 +86,9 @@ impl<E: DBErrorMarker + Error> Database for EmptyDBTyped<E> {
     }
 }
 
-impl<E: DBErrorMarker + Error> DatabaseRef for EmptyDBTyped<E> {
+impl<E: DBErrorMarker + Error, SV: StorageValueTr> DatabaseRef for EmptyDBTyped<E, SV> {
     type Error = E;
+    type StorageValue = SV;
 
     #[inline]
     fn basic_ref(&self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -93,8 +101,12 @@ impl<E: DBErrorMarker + Error> DatabaseRef for EmptyDBTyped<E> {
     }
 
     #[inline]
-    fn storage_ref(&self, _address: Address, _index: U256) -> Result<FlaggedStorage, Self::Error> {
-        Ok(FlaggedStorage::default())
+    fn storage_ref(
+        &self,
+        _address: Address,
+        _index: U256,
+    ) -> Result<Self::StorageValue, Self::Error> {
+        Ok(SV::ZERO)
     }
 
     #[inline]

--- a/crates/database/interface/src/lib.rs
+++ b/crates/database/interface/src/lib.rs
@@ -9,9 +9,9 @@ use core::convert::Infallible;
 
 use auto_impl::auto_impl;
 use core::error::Error;
-use primitives::FlaggedStorage;
-use primitives::{address, Address, HashMap, StorageKey, B256, U256};
+use primitives::{address, Address, HashMap, StorageKey, StorageValueTr, B256, U256};
 use state::{Account, AccountInfo, Bytecode};
+
 use std::string::String;
 
 /// Address with all `0xff..ff` in it. Used for testing.
@@ -52,6 +52,9 @@ pub trait Database {
     /// The database error type.
     type Error: DBErrorMarker + Error;
 
+    /// The storage value type. Upstream uses `U256`, Seismic uses `FlaggedStorage`.
+    type StorageValue: StorageValueTr;
+
     /// Gets basic account information.
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
 
@@ -59,7 +62,8 @@ pub trait Database {
     fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error>;
 
     /// Get storage value of address at index.
-    fn storage(&mut self, address: Address, index: U256) -> Result<FlaggedStorage, Self::Error>;
+    fn storage(&mut self, address: Address, index: U256)
+        -> Result<Self::StorageValue, Self::Error>;
 
     /// Gets block hash by block number.
     fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error>;
@@ -67,9 +71,9 @@ pub trait Database {
 
 /// EVM database commit interface.
 #[auto_impl(&mut, Box)]
-pub trait DatabaseCommit {
+pub trait DatabaseCommit<SV: StorageValueTr = U256> {
     /// Commit changes to the database.
-    fn commit(&mut self, changes: HashMap<Address, Account>);
+    fn commit(&mut self, changes: HashMap<Address, Account<SV>>);
 }
 
 /// EVM database interface.
@@ -83,6 +87,9 @@ pub trait DatabaseRef {
     /// The database error type.
     type Error: DBErrorMarker + Error;
 
+    /// The storage value type. Upstream uses `U256`, Seismic uses `FlaggedStorage`.
+    type StorageValue: StorageValueTr;
+
     /// Gets basic account information.
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error>;
 
@@ -90,7 +97,8 @@ pub trait DatabaseRef {
     fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error>;
 
     /// Get storage value of address at index.
-    fn storage_ref(&self, address: Address, index: U256) -> Result<FlaggedStorage, Self::Error>;
+    fn storage_ref(&self, address: Address, index: U256)
+        -> Result<Self::StorageValue, Self::Error>;
 
     /// Gets block hash by block number.
     fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error>;
@@ -109,6 +117,7 @@ impl<F: DatabaseRef> From<F> for WrapDatabaseRef<F> {
 
 impl<T: DatabaseRef> Database for WrapDatabaseRef<T> {
     type Error = T::Error;
+    type StorageValue = T::StorageValue;
 
     #[inline]
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -121,7 +130,11 @@ impl<T: DatabaseRef> Database for WrapDatabaseRef<T> {
     }
 
     #[inline]
-    fn storage(&mut self, address: Address, index: U256) -> Result<FlaggedStorage, Self::Error> {
+    fn storage(
+        &mut self,
+        address: Address,
+        index: U256,
+    ) -> Result<Self::StorageValue, Self::Error> {
         self.0.storage_ref(address, index)
     }
 
@@ -131,15 +144,16 @@ impl<T: DatabaseRef> Database for WrapDatabaseRef<T> {
     }
 }
 
-impl<T: DatabaseRef + DatabaseCommit> DatabaseCommit for WrapDatabaseRef<T> {
+impl<T: DatabaseRef + DatabaseCommit<SV>, SV: StorageValueTr> DatabaseCommit<SV> for WrapDatabaseRef<T> {
     #[inline]
-    fn commit(&mut self, changes: HashMap<Address, Account>) {
+    fn commit(&mut self, changes: HashMap<Address, Account<SV>>) {
         self.0.commit(changes)
     }
 }
 
 impl<T: DatabaseRef> DatabaseRef for WrapDatabaseRef<T> {
     type Error = T::Error;
+    type StorageValue = T::StorageValue;
 
     #[inline]
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
@@ -156,7 +170,7 @@ impl<T: DatabaseRef> DatabaseRef for WrapDatabaseRef<T> {
         &self,
         address: Address,
         index: StorageKey,
-    ) -> Result<state::FlaggedStorage, Self::Error> {
+    ) -> Result<Self::StorageValue, Self::Error> {
         self.0.storage_ref(address, index)
     }
 

--- a/crates/database/src/alloydb.rs
+++ b/crates/database/src/alloydb.rs
@@ -8,7 +8,6 @@ use alloy_provider::{
 use alloy_transport::TransportError;
 use core::error::Error;
 use database_interface::{async_db::DatabaseAsyncRef, DBErrorMarker};
-use primitives::alloy_primitives::FlaggedStorage;
 use primitives::{Address, B256, U256};
 use state::{AccountInfo, Bytecode};
 use std::fmt::Display;
@@ -63,6 +62,7 @@ impl<N: Network, P: Provider<N>> AlloyDB<N, P> {
 
 impl<N: Network, P: Provider<N>> DatabaseAsyncRef for AlloyDB<N, P> {
     type Error = DBTransportError;
+    type StorageValue = U256;
 
     async fn basic_async_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         let nonce = self
@@ -107,13 +107,12 @@ impl<N: Network, P: Provider<N>> DatabaseAsyncRef for AlloyDB<N, P> {
         &self,
         address: Address,
         index: U256,
-    ) -> Result<FlaggedStorage, Self::Error> {
+    ) -> Result<U256, Self::Error> {
         Ok(self
             .provider
             .get_storage_at(address, index)
             .block_id(self.block_number)
-            .await?
-            .into())
+            .await?)
     }
 }
 

--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -3,7 +3,7 @@ use database_interface::{
     Database, DatabaseCommit, DatabaseRef, EmptyDB, BENCH_CALLER, BENCH_CALLER_BALANCE,
     BENCH_TARGET, BENCH_TARGET_BALANCE,
 };
-use primitives::{hash_map::Entry, Address, HashMap, Log, B256, KECCAK_EMPTY, U256};
+use primitives::{hash_map::Entry, Address, HashMap, Log, StorageKey, StorageValueTr, B256, KECCAK_EMPTY, U256};
 use state::{Account, AccountInfo, Bytecode};
 use std::vec::Vec;
 
@@ -17,10 +17,10 @@ pub type InMemoryDB = CacheDB<EmptyDB>;
 /// The [DbAccount] holds the code hash of the contract, which is used to look up the contract in the `contracts` map.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Cache {
+pub struct Cache<SV: StorageValueTr = U256> {
     /// Account info where None means it is not existing. Not existing state is needed for Pre TANGERINE forks.
     /// `code` is always `None`, and bytecode can be found in `contracts`.
-    pub accounts: HashMap<Address, DbAccount>,
+    pub accounts: HashMap<Address, DbAccount<SV>>,
     /// Tracks all contracts by their code hash.
     pub contracts: HashMap<B256, Bytecode>,
     /// All logs that were committed via [DatabaseCommit::commit].
@@ -29,7 +29,7 @@ pub struct Cache {
     pub block_hashes: HashMap<U256, B256>,
 }
 
-impl Default for Cache {
+impl<SV: StorageValueTr> Default for Cache<SV> {
     fn default() -> Self {
         let mut contracts = HashMap::default();
         contracts.insert(KECCAK_EMPTY, Bytecode::default());
@@ -49,22 +49,22 @@ impl Default for Cache {
 /// This implementation wraps a [DatabaseRef] that is used to load data ([AccountInfo]).
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct CacheDB<ExtDB> {
+pub struct CacheDB<ExtDB, SV: StorageValueTr = U256> {
     /// The cache that stores all state changes.
-    pub cache: Cache,
+    pub cache: Cache<SV>,
     /// The underlying database ([DatabaseRef]) that is used to load data.
     ///
     /// Note: This is read-only, data is never written to this database.
     pub db: ExtDB,
 }
 
-impl<ExtDB: Default> Default for CacheDB<ExtDB> {
+impl<ExtDB: Default, SV: StorageValueTr> Default for CacheDB<ExtDB, SV> {
     fn default() -> Self {
         Self::new(ExtDB::default())
     }
 }
 
-impl<ExtDb> CacheDB<CacheDB<ExtDb>> {
+impl<ExtDb, SV: StorageValueTr> CacheDB<CacheDB<ExtDb, SV>, SV> {
     /// Flattens a nested cache by applying the outer cache to the inner cache.
     ///
     /// The behavior is as follows:
@@ -72,7 +72,7 @@ impl<ExtDb> CacheDB<CacheDB<ExtDb>> {
     /// - Contracts are overridden with outer contracts
     /// - Logs are appended
     /// - Block hashes are overridden with outer block hashes
-    pub fn flatten(self) -> CacheDB<ExtDb> {
+    pub fn flatten(self) -> CacheDB<ExtDb, SV> {
         let CacheDB {
             cache:
                 Cache {
@@ -92,12 +92,12 @@ impl<ExtDb> CacheDB<CacheDB<ExtDb>> {
     }
 
     /// Discards the outer cache and return the inner cache.
-    pub fn discard_outer(self) -> CacheDB<ExtDb> {
+    pub fn discard_outer(self) -> CacheDB<ExtDb, SV> {
         self.db
     }
 }
 
-impl<ExtDB> CacheDB<ExtDB> {
+impl<ExtDB, SV: StorageValueTr> CacheDB<ExtDB, SV> {
     /// Creates a new cache with the given external database.
     pub fn new(db: ExtDB) -> Self {
         Self {
@@ -139,16 +139,16 @@ impl<ExtDB> CacheDB<ExtDB> {
     }
 
     /// Wraps the cache in a [CacheDB], creating a nested cache.
-    pub fn nest(self) -> CacheDB<Self> {
+    pub fn nest(self) -> CacheDB<Self, SV> {
         CacheDB::new(self)
     }
 }
 
-impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
+impl<ExtDB: DatabaseRef, SV: StorageValueTr> CacheDB<ExtDB, SV> {
     /// Returns the account for the given address.
     ///
     /// If the account was not found in the cache, it will be loaded from the underlying database.
-    pub fn load_account(&mut self, address: Address) -> Result<&mut DbAccount, ExtDB::Error> {
+    pub fn load_account(&mut self, address: Address) -> Result<&mut DbAccount<SV>, ExtDB::Error> {
         let db = &self.db;
         match self.cache.accounts.entry(address) {
             Entry::Occupied(entry) => Ok(entry.into_mut()),
@@ -167,8 +167,8 @@ impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
     pub fn insert_account_storage(
         &mut self,
         address: Address,
-        slot: U256,
-        value: state::FlaggedStorage,
+        slot: StorageKey,
+        value: SV,
     ) -> Result<(), ExtDB::Error> {
         let account = self.load_account(address)?;
         account.storage.insert(slot, value);
@@ -179,7 +179,7 @@ impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
     pub fn replace_account_storage(
         &mut self,
         address: Address,
-        storage: HashMap<U256, state::FlaggedStorage>,
+        storage: HashMap<U256, SV>,
     ) -> Result<(), ExtDB::Error> {
         let account = self.load_account(address)?;
         account.account_state = AccountState::StorageCleared;
@@ -188,8 +188,8 @@ impl<ExtDB: DatabaseRef> CacheDB<ExtDB> {
     }
 }
 
-impl<ExtDB> DatabaseCommit for CacheDB<ExtDB> {
-    fn commit(&mut self, changes: HashMap<Address, Account>) {
+impl<ExtDB, SV: StorageValueTr> DatabaseCommit<SV> for CacheDB<ExtDB, SV> {
+    fn commit(&mut self, changes: HashMap<Address, Account<SV>>) {
         for (address, mut account) in changes {
             if !account.is_touched() {
                 continue;
@@ -226,8 +226,9 @@ impl<ExtDB> DatabaseCommit for CacheDB<ExtDB> {
     }
 }
 
-impl<ExtDB: DatabaseRef> Database for CacheDB<ExtDB> {
+impl<ExtDB: DatabaseRef<StorageValue = SV>, SV: StorageValueTr> Database for CacheDB<ExtDB, SV> {
     type Error = ExtDB::Error;
+    type StorageValue = SV;
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         let basic = match self.cache.accounts.entry(address) {
@@ -262,7 +263,7 @@ impl<ExtDB: DatabaseRef> Database for CacheDB<ExtDB> {
         &mut self,
         address: Address,
         index: U256,
-    ) -> Result<state::FlaggedStorage, Self::Error> {
+    ) -> Result<Self::StorageValue, Self::Error> {
         match self.cache.accounts.entry(address) {
             Entry::Occupied(mut acc_entry) => {
                 let acc_entry = acc_entry.get_mut();
@@ -273,7 +274,7 @@ impl<ExtDB: DatabaseRef> Database for CacheDB<ExtDB> {
                             acc_entry.account_state,
                             AccountState::StorageCleared | AccountState::NotExisting
                         ) {
-                            Ok(state::FlaggedStorage::default())
+                            Ok(SV::ZERO)
                         } else {
                             let slot = self.db.storage_ref(address, index)?;
                             entry.insert(slot);
@@ -287,11 +288,11 @@ impl<ExtDB: DatabaseRef> Database for CacheDB<ExtDB> {
                 let info = self.db.basic_ref(address)?;
                 let (account, value) = if info.is_some() {
                     let value = self.db.storage_ref(address, index)?;
-                    let mut account: DbAccount = info.into();
+                    let mut account: DbAccount<SV> = info.into();
                     account.storage.insert(index, value);
                     (account, value)
                 } else {
-                    (info.into(), state::FlaggedStorage::default())
+                    (info.into(), SV::ZERO)
                 };
                 acc_entry.insert(account);
                 Ok(value)
@@ -311,8 +312,9 @@ impl<ExtDB: DatabaseRef> Database for CacheDB<ExtDB> {
     }
 }
 
-impl<ExtDB: DatabaseRef> DatabaseRef for CacheDB<ExtDB> {
+impl<ExtDB: DatabaseRef<StorageValue = SV>, SV: StorageValueTr> DatabaseRef for CacheDB<ExtDB, SV> {
     type Error = ExtDB::Error;
+    type StorageValue = SV;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         match self.cache.accounts.get(&address) {
@@ -332,7 +334,7 @@ impl<ExtDB: DatabaseRef> DatabaseRef for CacheDB<ExtDB> {
         &self,
         address: Address,
         index: U256,
-    ) -> Result<state::FlaggedStorage, Self::Error> {
+    ) -> Result<Self::StorageValue, Self::Error> {
         match self.cache.accounts.get(&address) {
             Some(acc_entry) => match acc_entry.storage.get(&index) {
                 Some(entry) => Ok(*entry),
@@ -341,7 +343,7 @@ impl<ExtDB: DatabaseRef> DatabaseRef for CacheDB<ExtDB> {
                         acc_entry.account_state,
                         AccountState::StorageCleared | AccountState::NotExisting
                     ) {
-                        Ok(state::FlaggedStorage::ZERO)
+                        Ok(SV::ZERO)
                     } else {
                         self.db.storage_ref(address, index)
                     }
@@ -362,16 +364,16 @@ impl<ExtDB: DatabaseRef> DatabaseRef for CacheDB<ExtDB> {
 /// Database account representation.
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct DbAccount {
+pub struct DbAccount<SV: StorageValueTr = U256> {
     /// Basic account information.
     pub info: AccountInfo,
     /// If account is selfdestructed or newly created, storage will be cleared.
     pub account_state: AccountState,
     /// storage slots
-    pub storage: HashMap<U256, state::FlaggedStorage>,
+    pub storage: HashMap<U256, SV>,
 }
 
-impl DbAccount {
+impl<SV: StorageValueTr> DbAccount<SV> {
     /// Creates a new non-existing account.
     pub fn new_not_existing() -> Self {
         Self {
@@ -402,13 +404,13 @@ impl DbAccount {
     }
 }
 
-impl From<Option<AccountInfo>> for DbAccount {
+impl<SV: StorageValueTr> From<Option<AccountInfo>> for DbAccount<SV> {
     fn from(from: Option<AccountInfo>) -> Self {
         from.map(Self::from).unwrap_or_else(Self::new_not_existing)
     }
 }
 
-impl From<AccountInfo> for DbAccount {
+impl<SV: StorageValueTr> From<AccountInfo> for DbAccount<SV> {
     fn from(info: AccountInfo) -> Self {
         Self {
             info,
@@ -458,6 +460,7 @@ impl BenchmarkDB {
 
 impl Database for BenchmarkDB {
     type Error = Infallible;
+    type StorageValue = U256;
     /// Get basic account information.
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         if address == BENCH_TARGET {
@@ -489,8 +492,8 @@ impl Database for BenchmarkDB {
         &mut self,
         _address: Address,
         _index: U256,
-    ) -> Result<state::FlaggedStorage, Self::Error> {
-        Ok(state::FlaggedStorage::default())
+    ) -> Result<Self::StorageValue, Self::Error> {
+        Ok(U256::ZERO)
     }
 
     // History related
@@ -518,10 +521,7 @@ mod tests {
             },
         );
 
-        let (key, value) = (
-            U256::from(123),
-            state::FlaggedStorage::from(U256::from(456)),
-        );
+        let (key, value) = (U256::from(123), U256::from(456));
         let mut new_state = CacheDB::new(init_state);
         new_state
             .insert_account_storage(account, key, value)
@@ -544,14 +544,8 @@ mod tests {
             },
         );
 
-        let (key0, value0) = (
-            U256::from(123),
-            state::FlaggedStorage::from(U256::from(456)),
-        );
-        let (key1, value1) = (
-            U256::from(789),
-            state::FlaggedStorage::from(U256::from(999)),
-        );
+        let (key0, value0) = (U256::from(123), U256::from(456));
+        let (key1, value1) = (U256::from(789), U256::from(999));
         init_state
             .insert_account_storage(account, key0, value0)
             .unwrap();
@@ -562,10 +556,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);
-        assert_eq!(
-            new_state.storage(account, key0),
-            Ok(state::FlaggedStorage::ZERO)
-        );
+        assert_eq!(new_state.storage(account, key0), Ok(U256::ZERO));
         assert_eq!(new_state.storage(account, key1), Ok(value1));
     }
 
@@ -574,7 +565,7 @@ mod tests {
     fn test_serialize_deserialize_cachedb() {
         let account = Address::with_last_byte(69);
         let nonce = 420;
-        let mut init_state = CacheDB::new(EmptyDB::default());
+        let mut init_state: CacheDB<EmptyDB> = CacheDB::new(EmptyDB::default());
         init_state.insert_account_info(
             account,
             AccountInfo {
@@ -597,69 +588,5 @@ mod tests {
                 .nonce,
             nonce
         );
-    }
-
-    #[test]
-    fn test_insert_account_storage_private() {
-        let account = Address::with_last_byte(42);
-        let nonce = 42;
-        let mut init_state = CacheDB::new(EmptyDB::default());
-        init_state.insert_account_info(
-            account,
-            AccountInfo {
-                nonce,
-                ..Default::default()
-            },
-        );
-
-        let (key, value) = (
-            U256::from(123),
-            state::FlaggedStorage::from(U256::from(456)).mark_private(),
-        );
-        let mut new_state = CacheDB::new(init_state);
-        new_state
-            .insert_account_storage(account, key, value)
-            .unwrap();
-
-        assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);
-        assert_eq!(new_state.storage(account, key), Ok(value));
-    }
-
-    #[test]
-    fn test_replace_account_storage_private() {
-        let account = Address::with_last_byte(42);
-        let nonce = 42;
-        let mut init_state = CacheDB::new(EmptyDB::default());
-        init_state.insert_account_info(
-            account,
-            AccountInfo {
-                nonce,
-                ..Default::default()
-            },
-        );
-
-        let (key0, value0) = (
-            U256::from(123),
-            state::FlaggedStorage::from(U256::from(456)).mark_private(),
-        );
-        let (key1, value1) = (
-            U256::from(789),
-            state::FlaggedStorage::from(U256::from(999)).mark_private(),
-        );
-        init_state
-            .insert_account_storage(account, key0, value0)
-            .unwrap();
-
-        let mut new_state = CacheDB::new(init_state);
-        new_state
-            .replace_account_storage(account, [(key1, value1)].into())
-            .unwrap();
-
-        assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);
-        assert_eq!(
-            new_state.storage(account, key0),
-            Ok(state::FlaggedStorage::ZERO)
-        );
-        assert_eq!(new_state.storage(account, key1), Ok(value1));
     }
 }

--- a/crates/database/src/states/bundle_account.rs
+++ b/crates/database/src/states/bundle_account.rs
@@ -2,8 +2,7 @@ use super::{
     reverts::AccountInfoRevert, AccountRevert, AccountStatus, RevertToSlot, StorageSlot,
     StorageWithOriginalValues, TransitionAccount,
 };
-use primitives::alloy_primitives::FlaggedStorage;
-use primitives::{HashMap, StorageKey, U256};
+use primitives::{HashMap, StorageKey, StorageValueTr, U256};
 use state::AccountInfo;
 
 /// Account information focused on creating of database changesets
@@ -18,7 +17,8 @@ use state::AccountInfo;
 /// On selfdestruct storage original value is ignored.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BundleAccount {
+#[cfg_attr(feature = "serde", serde(bound = "SV: serde::Serialize + serde::de::DeserializeOwned"))]
+pub struct BundleAccount<SV: StorageValueTr = U256> {
     /// Current account information.
     pub info: Option<AccountInfo>,
     /// Original account information before modifications.
@@ -28,17 +28,17 @@ pub struct BundleAccount {
     /// If it is different we add it to changeset.
     ///
     /// If Account was destroyed we ignore original value and compare present state with StorageValue::ZERO.
-    pub storage: StorageWithOriginalValues,
+    pub storage: StorageWithOriginalValues<SV>,
     /// Account status.
     pub status: AccountStatus,
 }
 
-impl BundleAccount {
+impl<SV: StorageValueTr> BundleAccount<SV> {
     /// Create new BundleAccount.
     pub fn new(
         original_info: Option<AccountInfo>,
         present_info: Option<AccountInfo>,
-        storage: StorageWithOriginalValues,
+        storage: StorageWithOriginalValues<SV>,
         status: AccountStatus,
     ) -> Self {
         Self {
@@ -58,13 +58,13 @@ impl BundleAccount {
 
     /// Return storage slot if it exists.
     ///
-    /// In case we know that account is newly created or destroyed, return `Some(U256::ZERO)`
-    pub fn storage_slot(&self, slot: U256) -> Option<FlaggedStorage> {
+    /// In case we know that account is newly created or destroyed, return `Some(SV::ZERO)`
+    pub fn storage_slot(&self, slot: U256) -> Option<SV> {
         let slot = self.storage.get(&slot).map(|s| s.present_value);
         if slot.is_some() {
             slot
         } else if self.status.is_storage_known() {
-            Some(FlaggedStorage::ZERO)
+            Some(SV::ZERO)
         } else {
             None
         }
@@ -91,7 +91,7 @@ impl BundleAccount {
     }
 
     /// Revert account to previous state and return true if account can be removed.
-    pub fn revert(&mut self, revert: AccountRevert) -> bool {
+    pub fn revert(&mut self, revert: AccountRevert<SV>) -> bool {
         self.status = revert.previous_status;
 
         match revert.account {
@@ -104,7 +104,7 @@ impl BundleAccount {
                 } else {
                     // Set all storage to zero but preserve original values.
                     self.storage.iter_mut().for_each(|(_, v)| {
-                        v.present_value = FlaggedStorage::ZERO;
+                        v.present_value = SV::ZERO;
                     });
                     return false;
                 }
@@ -137,23 +137,23 @@ impl BundleAccount {
     /// If no revert is present, update is noop.
     pub fn update_and_create_revert(
         &mut self,
-        transition: TransitionAccount,
-    ) -> Option<AccountRevert> {
+        transition: TransitionAccount<SV>,
+    ) -> Option<AccountRevert<SV>> {
         let updated_info = transition.info;
         let updated_storage = transition.storage;
         let updated_status = transition.status;
 
         // The helper that extends this storage but preserves original value.
         let extend_storage =
-            |this_storage: &mut StorageWithOriginalValues,
-             storage_update: StorageWithOriginalValues| {
+            |this_storage: &mut StorageWithOriginalValues<SV>,
+             storage_update: StorageWithOriginalValues<SV>| {
                 for (key, value) in storage_update {
                     this_storage.entry(key).or_insert(value).present_value = value.present_value;
                 }
             };
 
         let previous_storage_from_update =
-            |updated_storage: &StorageWithOriginalValues| -> HashMap<StorageKey, RevertToSlot> {
+            |updated_storage: &StorageWithOriginalValues<SV>| -> HashMap<StorageKey, RevertToSlot<SV>> {
                 updated_storage
                     .iter()
                     .filter(|s| s.1.is_changed())

--- a/crates/database/src/states/bundle_state.rs
+++ b/crates/database/src/states/bundle_state.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use bytecode::Bytecode;
 use core::{mem, ops::RangeInclusive};
-use primitives::{alloy_primitives::FlaggedStorage, StorageKey};
+use primitives::{StorageKey, StorageValueTr};
 use primitives::{hash_map::Entry, Address, HashMap, HashSet, B256, KECCAK_EMPTY, U256};
 use state::AccountInfo;
 use std::{
@@ -16,16 +16,16 @@ use std::{
 
 /// This builder is used to help to facilitate the initialization of `BundleState` struct
 #[derive(Debug)]
-pub struct BundleBuilder {
+pub struct BundleBuilder<SV: StorageValueTr = U256> {
     states: HashSet<Address>,
     state_original: HashMap<Address, AccountInfo>,
     state_present: HashMap<Address, AccountInfo>,
-    state_storage: HashMap<Address, HashMap<U256, (FlaggedStorage, FlaggedStorage)>>,
+    state_storage: HashMap<Address, HashMap<U256, (SV, SV)>>,
 
     reverts: BTreeSet<(u64, Address)>,
     revert_range: RangeInclusive<u64>,
     revert_account: HashMap<(u64, Address), Option<Option<AccountInfo>>>,
-    revert_storage: HashMap<(u64, Address), Vec<(StorageKey, FlaggedStorage)>>,
+    revert_storage: HashMap<(u64, Address), Vec<(StorageKey, SV)>>,
 
     contracts: HashMap<B256, Bytecode>,
 }
@@ -52,7 +52,7 @@ impl OriginalValuesKnown {
     }
 }
 
-impl Default for BundleBuilder {
+impl<SV: StorageValueTr> Default for BundleBuilder<SV> {
     fn default() -> Self {
         BundleBuilder {
             states: HashSet::default(),
@@ -68,7 +68,7 @@ impl Default for BundleBuilder {
     }
 }
 
-impl BundleBuilder {
+impl<SV: StorageValueTr> BundleBuilder<SV> {
     /// Creates builder instance.
     ///
     /// `revert_range` indicates the size of BundleState `reverts` field.
@@ -118,7 +118,7 @@ impl BundleBuilder {
     pub fn state_storage(
         mut self,
         address: Address,
-        storage: HashMap<StorageKey, (FlaggedStorage, FlaggedStorage)>,
+        storage: HashMap<StorageKey, (SV, SV)>,
     ) -> Self {
         self.set_state_storage(address, storage);
         self
@@ -155,7 +155,7 @@ impl BundleBuilder {
         mut self,
         block_number: u64,
         address: Address,
-        storage: Vec<(StorageKey, FlaggedStorage)>,
+        storage: Vec<(StorageKey, SV)>,
     ) -> Self {
         self.set_revert_storage(block_number, address, storage);
         self
@@ -199,7 +199,7 @@ impl BundleBuilder {
     pub fn set_state_storage(
         &mut self,
         address: Address,
-        storage: HashMap<StorageKey, (FlaggedStorage, FlaggedStorage)>,
+        storage: HashMap<StorageKey, (SV, SV)>,
     ) -> &mut Self {
         self.states.insert(address);
         self.state_storage.insert(address, storage);
@@ -229,7 +229,7 @@ impl BundleBuilder {
         &mut self,
         block_number: u64,
         address: Address,
-        storage: Vec<(StorageKey, FlaggedStorage)>,
+        storage: Vec<(StorageKey, SV)>,
     ) -> &mut Self {
         self.reverts.insert((block_number, address));
         self.revert_storage.insert((block_number, address), storage);
@@ -243,7 +243,7 @@ impl BundleBuilder {
     }
 
     /// Creates `BundleState` instance based on collected information.
-    pub fn build(mut self) -> BundleState {
+    pub fn build(mut self) -> BundleState<SV> {
         let mut state_size = 0;
         let state = self
             .states
@@ -343,7 +343,7 @@ impl BundleBuilder {
     /// Mutable getter for `state_storage` field
     pub fn get_state_storage_mut(
         &mut self,
-    ) -> &mut HashMap<Address, HashMap<U256, (FlaggedStorage, FlaggedStorage)>> {
+    ) -> &mut HashMap<Address, HashMap<U256, (SV, SV)>> {
         &mut self.state_storage
     }
 
@@ -367,7 +367,7 @@ impl BundleBuilder {
     /// Mutable getter for `revert_storage` field
     pub fn get_revert_storage_mut(
         &mut self,
-    ) -> &mut HashMap<(u64, Address), Vec<(U256, FlaggedStorage)>> {
+    ) -> &mut HashMap<(u64, Address), Vec<(U256, SV)>> {
         &mut self.revert_storage
     }
 
@@ -404,9 +404,10 @@ impl BundleRetention {
 /// And can be used to revert BundleState to the state before transition.
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BundleState {
+#[cfg_attr(feature = "serde", serde(bound = "SV: serde::Serialize + serde::de::DeserializeOwned"))]
+pub struct BundleState<SV: StorageValueTr = U256> {
     /// Account state
-    pub state: HashMap<Address, BundleAccount>,
+    pub state: HashMap<Address, BundleAccount<SV>>,
     /// All created contracts in this block.
     pub contracts: HashMap<B256, Bytecode>,
     /// Changes to revert
@@ -414,16 +415,16 @@ pub struct BundleState {
     /// **Note**: Inside vector is *not* sorted by address.
     ///
     /// But it is unique by address.
-    pub reverts: Reverts,
+    pub reverts: Reverts<SV>,
     /// The size of the plain state in the bundle state
     pub state_size: usize,
     /// The size of reverts in the bundle state
     pub reverts_size: usize,
 }
 
-impl BundleState {
+impl<SV: StorageValueTr> BundleState<SV> {
     /// Returns builder instance for further manipulation.
-    pub fn builder(revert_range: RangeInclusive<u64>) -> BundleBuilder {
+    pub fn builder(revert_range: RangeInclusive<u64>) -> BundleBuilder<SV> {
         BundleBuilder::new(revert_range)
     }
 
@@ -434,7 +435,7 @@ impl BundleState {
                 Address,
                 Option<AccountInfo>,
                 Option<AccountInfo>,
-                HashMap<StorageKey, (FlaggedStorage, FlaggedStorage)>,
+                HashMap<StorageKey, (SV, SV)>,
             ),
         >,
         reverts: impl IntoIterator<
@@ -442,7 +443,7 @@ impl BundleState {
                 Item = (
                     Address,
                     Option<Option<AccountInfo>>,
-                    impl IntoIterator<Item = (StorageKey, FlaggedStorage)>,
+                    impl IntoIterator<Item = (StorageKey, SV)>,
                 ),
             >,
         >,
@@ -514,7 +515,7 @@ impl BundleState {
     }
 
     /// Returns reference to the state.
-    pub fn state(&self) -> &HashMap<Address, BundleAccount> {
+    pub fn state(&self) -> &HashMap<Address, BundleAccount<SV>> {
         &self.state
     }
 
@@ -529,7 +530,7 @@ impl BundleState {
     }
 
     /// Gets account from state.
-    pub fn account(&self, address: &Address) -> Option<&BundleAccount> {
+    pub fn account(&self, address: &Address) -> Option<&BundleAccount<SV>> {
         self.state.get(address)
     }
 
@@ -545,7 +546,7 @@ impl BundleState {
     /// be retained.
     pub fn apply_transitions_and_create_reverts(
         &mut self,
-        transitions: TransitionState,
+        transitions: TransitionState<SV>,
         retention: BundleRetention,
     ) {
         let include_reverts = retention.includes_reverts();
@@ -597,7 +598,7 @@ impl BundleState {
 
     /// Generate a [`StateChangeset`] from the bundle state without consuming
     /// it.
-    pub fn to_plain_state(&self, is_value_known: OriginalValuesKnown) -> StateChangeset {
+    pub fn to_plain_state(&self, is_value_known: OriginalValuesKnown) -> StateChangeset<SV> {
         // Pessimistically pre-allocate assuming _all_ accounts changed.
         let state_len = self.state.len();
         let mut accounts = Vec::with_capacity(state_len);
@@ -620,8 +621,7 @@ impl BundleState {
             for (&key, &slot) in account.storage.iter() {
                 // If storage was destroyed that means that storage was wiped.
                 // In that case we need to check if present storage value is different then ZERO.
-                // TODO(Seismic): do we need to check visibility here?
-                let destroyed_and_not_zero = was_destroyed && !slot.present_value.value.is_zero();
+                let destroyed_and_not_zero = was_destroyed && !slot.present_value.value().is_zero();
 
                 // If account is not destroyed check if original values was changed,
                 // so we can update it.
@@ -661,7 +661,7 @@ impl BundleState {
 
     /// Converts the bundle state into a [`StateChangeset`].
     #[deprecated = "Use `to_plain_state` instead"]
-    pub fn into_plain_state(self, is_value_known: OriginalValuesKnown) -> StateChangeset {
+    pub fn into_plain_state(self, is_value_known: OriginalValuesKnown) -> StateChangeset<SV> {
         self.to_plain_state(is_value_known)
     }
 
@@ -670,7 +670,7 @@ impl BundleState {
     pub fn to_plain_state_and_reverts(
         &self,
         is_value_known: OriginalValuesKnown,
-    ) -> (StateChangeset, PlainStateReverts) {
+    ) -> (StateChangeset<SV>, PlainStateReverts<SV>) {
         (
             self.to_plain_state(is_value_known),
             self.reverts.to_plain_state_reverts(),
@@ -683,14 +683,14 @@ impl BundleState {
     pub fn into_plain_state_and_reverts(
         self,
         is_value_known: OriginalValuesKnown,
-    ) -> (StateChangeset, PlainStateReverts) {
+    ) -> (StateChangeset<SV>, PlainStateReverts<SV>) {
         self.to_plain_state_and_reverts(is_value_known)
     }
 
     /// Extends the bundle with other state.
     ///
     /// Updates the `other` state only if `other` is not flagged as destroyed.
-    pub fn extend_state(&mut self, other_state: HashMap<Address, BundleAccount>) {
+    pub fn extend_state(&mut self, other_state: HashMap<Address, BundleAccount<SV>>) {
         for (address, other_account) in other_state {
             match self.state.entry(address) {
                 Entry::Occupied(mut entry) => {
@@ -771,7 +771,7 @@ impl BundleState {
     }
 
     /// Takes first N raw reverts from the [BundleState].
-    pub fn take_n_reverts(&mut self, reverts_to_take: usize) -> Reverts {
+    pub fn take_n_reverts(&mut self, reverts_to_take: usize) -> Reverts<SV> {
         // Split is done as [0, num) and [num, len].
         if reverts_to_take > self.reverts.len() {
             return self.take_all_reverts();
@@ -787,7 +787,7 @@ impl BundleState {
     }
 
     /// Returns and clears all reverts from [BundleState].
-    pub fn take_all_reverts(&mut self) -> Reverts {
+    pub fn take_all_reverts(&mut self) -> Reverts<SV> {
         self.reverts_size = 0;
         mem::take(&mut self.reverts)
     }
@@ -856,7 +856,7 @@ impl BundleState {
     /// It adds changes from the given state but does not override any existing changes.
     ///
     /// Reverts are not updated.
-    pub fn prepend_state(&mut self, mut other: BundleState) {
+    pub fn prepend_state(&mut self, mut other: BundleState<SV>) {
         // Take this bundle
         let this_bundle = mem::take(self);
         // Extend other bundle state with this
@@ -885,7 +885,7 @@ mod tests {
             code: None,
         };
 
-        let mut bundle_state = BundleState::default();
+        let mut bundle_state = BundleState::<U256>::default();
 
         // Have transition from loaded to all other states
 
@@ -936,8 +936,8 @@ mod tests {
                         code: None,
                     }),
                     HashMap::from_iter([
-                        (slot1(), (U256::from(0).into(), U256::from(10).into())),
-                        (slot2(), (U256::from(0).into(), U256::from(15).into())),
+                        (slot1(), (U256::from(0), U256::from(10))),
+                        (slot2(), (U256::from(0), U256::from(15))),
                     ]),
                 ),
                 (
@@ -957,8 +957,8 @@ mod tests {
                     account1(),
                     Some(None),
                     vec![
-                        (slot1(), U256::from(0).into()),
-                        (slot2(), U256::from(0).into()),
+                        (slot1(), U256::from(0)),
+                        (slot2(), U256::from(0)),
                     ],
                 ),
                 (account2(), Some(None), vec![]),
@@ -980,7 +980,7 @@ mod tests {
                     code_hash: KECCAK_EMPTY,
                     code: None,
                 }),
-                HashMap::from_iter([(slot1(), (U256::from(0).into(), U256::from(15).into()))]),
+                HashMap::from_iter([(slot1(), (U256::from(0), U256::from(15)))]),
             )],
             vec![vec![(
                 account1(),
@@ -990,7 +990,7 @@ mod tests {
                     code_hash: KECCAK_EMPTY,
                     code: None,
                 })),
-                vec![(slot1(), U256::from(10).into())],
+                vec![(slot1(), U256::from(10))],
             )]],
             vec![],
         )
@@ -1010,7 +1010,7 @@ mod tests {
             )
             .state_storage(
                 account1(),
-                HashMap::from_iter([(slot1(), (U256::from(0).into(), U256::from(10).into()))]),
+                HashMap::from_iter([(slot1(), (U256::from(0), U256::from(10)))]),
             )
             .state_address(account2())
             .state_present_account_info(
@@ -1024,7 +1024,7 @@ mod tests {
             )
             .revert_address(0, account1())
             .revert_account_info(0, account1(), Some(None))
-            .revert_storage(0, account1(), vec![(slot1(), U256::from(0).into())])
+            .revert_storage(0, account1(), vec![(slot1(), U256::from(0))])
             .revert_account_info(0, account2(), Some(None))
             .build()
     }
@@ -1043,7 +1043,7 @@ mod tests {
             )
             .state_storage(
                 account1(),
-                HashMap::from_iter([(slot1(), (U256::from(0).into(), U256::from(15).into()))]),
+                HashMap::from_iter([(slot1(), (U256::from(0), U256::from(15)))]),
             )
             .revert_address(0, account1())
             .revert_account_info(
@@ -1056,7 +1056,7 @@ mod tests {
                     code: None,
                 })),
             )
-            .revert_storage(0, account1(), vec![(slot1(), U256::from(10).into())])
+            .revert_storage(0, account1(), vec![(slot1(), U256::from(10))])
             .build()
     }
 
@@ -1125,7 +1125,7 @@ mod tests {
         revert1
             .1
             .storage
-            .insert(slot2(), RevertToSlot::Some(U256::from(15).into()));
+            .insert(slot2(), RevertToSlot::Some(U256::from(15)));
 
         assert_eq!(
             b1.reverts.as_ref(),
@@ -1156,7 +1156,7 @@ mod tests {
 
     #[test]
     fn test_multi_reverts_with_delete() {
-        let mut state = BundleBuilder::new(0..=3)
+        let mut state = BundleBuilder::<U256>::new(0..=3)
             .revert_address(0, account1())
             .revert_account_info(2, account1(), Some(Some(AccountInfo::default())))
             .revert_account_info(3, account1(), Some(None))
@@ -1186,7 +1186,7 @@ mod tests {
             .revert_address(2, account2())
             .revert_account_info(0, account1(), Some(None))
             .revert_account_info(2, account2(), None)
-            .revert_storage(0, account1(), vec![(slot1(), U256::from(10).into())])
+            .revert_storage(0, account1(), vec![(slot1(), U256::from(10))])
             .build();
 
         assert_eq!(state.reverts.len(), 4);
@@ -1255,11 +1255,11 @@ mod tests {
             ..Default::default()
         };
 
-        let present_state = BundleState::builder(2..=2)
+        let present_state = BundleState::<U256>::builder(2..=2)
             .state_present_account_info(address1, account1_changed.clone())
             .build();
         assert_eq!(present_state.reverts.len(), 1);
-        let previous_state = BundleState::builder(1..=1)
+        let previous_state = BundleState::<U256>::builder(1..=1)
             .state_present_account_info(address1, account1)
             .state_present_account_info(address2, account2.clone())
             .build();
@@ -1332,7 +1332,7 @@ mod tests {
         assert!(builder.get_revert_storage_mut().is_empty());
         builder
             .get_revert_storage_mut()
-            .insert((0, account1()), vec![(slot1(), U256::from(0).into())]);
+            .insert((0, account1()), vec![(slot1(), U256::from(0))]);
         assert!(builder
             .get_revert_storage_mut()
             .contains_key(&(0, account1())));

--- a/crates/database/src/states/cache.rs
+++ b/crates/database/src/states/cache.rs
@@ -2,7 +2,7 @@ use super::{
     plain_account::PlainStorage, transition_account::TransitionAccount, CacheAccount, PlainAccount,
 };
 use bytecode::Bytecode;
-use primitives::{Address, HashMap, B256};
+use primitives::{Address, HashMap, StorageValueTr, B256, U256};
 use state::{Account, AccountInfo, EvmState};
 use std::vec::Vec;
 
@@ -15,22 +15,22 @@ use std::vec::Vec;
 ///
 /// It generates transitions that is used to build BundleState.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CacheState {
+pub struct CacheState<SV: StorageValueTr = U256> {
     /// Block state account with account state
-    pub accounts: HashMap<Address, CacheAccount>,
+    pub accounts: HashMap<Address, CacheAccount<SV>>,
     /// Created contracts
     pub contracts: HashMap<B256, Bytecode>,
     /// Has EIP-161 state clear enabled (Spurious Dragon hardfork)
     pub has_state_clear: bool,
 }
 
-impl Default for CacheState {
+impl<SV: StorageValueTr> Default for CacheState<SV> {
     fn default() -> Self {
         Self::new(true)
     }
 }
 
-impl CacheState {
+impl<SV: StorageValueTr> CacheState<SV> {
     /// Creates a new default state.
     pub fn new(has_state_clear: bool) -> Self {
         Self {
@@ -48,7 +48,7 @@ impl CacheState {
     /// Helper function that returns all accounts.
     ///
     /// Used inside tests to generate merkle tree.
-    pub fn trie_account(&self) -> impl IntoIterator<Item = (Address, &PlainAccount)> {
+    pub fn trie_account(&self) -> impl IntoIterator<Item = (Address, &PlainAccount<SV>)> {
         self.accounts.iter().filter_map(|(address, account)| {
             account
                 .account
@@ -78,7 +78,7 @@ impl CacheState {
         &mut self,
         address: Address,
         info: AccountInfo,
-        storage: PlainStorage,
+        storage: PlainStorage<SV>,
     ) {
         let account = if !info.is_empty() {
             CacheAccount::new_loaded(info, storage)
@@ -89,7 +89,7 @@ impl CacheState {
     }
 
     /// Applies output of revm execution and create account transitions that are used to build BundleState.
-    pub fn apply_evm_state(&mut self, evm_state: EvmState) -> Vec<(Address, TransitionAccount)> {
+    pub fn apply_evm_state(&mut self, evm_state: EvmState<SV>) -> Vec<(Address, TransitionAccount<SV>)> {
         let mut transitions = Vec::with_capacity(evm_state.len());
         for (address, account) in evm_state {
             if let Some(transition) = self.apply_account_state(address, account) {
@@ -105,8 +105,8 @@ impl CacheState {
     fn apply_account_state(
         &mut self,
         address: Address,
-        account: Account,
-    ) -> Option<TransitionAccount> {
+        account: Account<SV>,
+    ) -> Option<TransitionAccount<SV>> {
         // Not touched account are never changed.
         if !account.is_touched() {
             return None;

--- a/crates/database/src/states/cache_account.rs
+++ b/crates/database/src/states/cache_account.rs
@@ -2,28 +2,27 @@ use super::{
     plain_account::PlainStorage, AccountStatus, BundleAccount, PlainAccount,
     StorageWithOriginalValues, TransitionAccount,
 };
-use primitives::alloy_primitives::FlaggedStorage;
-use primitives::{HashMap, U256};
+use primitives::{HashMap, StorageValueTr, U256};
 use state::AccountInfo;
 
 /// Cache account contains plain state that gets updated
 /// at every transaction when evm output is applied to CacheState.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CacheAccount {
+pub struct CacheAccount<SV: StorageValueTr = U256> {
     /// Account information and storage, if account exists.
-    pub account: Option<PlainAccount>,
+    pub account: Option<PlainAccount<SV>>,
     /// Account status flags.
     pub status: AccountStatus,
 }
 
-impl From<BundleAccount> for CacheAccount {
-    fn from(account: BundleAccount) -> Self {
+impl<SV: StorageValueTr> From<BundleAccount<SV>> for CacheAccount<SV> {
+    fn from(account: BundleAccount<SV>) -> Self {
         CacheAccount::from(&account)
     }
 }
 
-impl From<&BundleAccount> for CacheAccount {
-    fn from(account: &BundleAccount) -> Self {
+impl<SV: StorageValueTr> From<&BundleAccount<SV>> for CacheAccount<SV> {
+    fn from(account: &BundleAccount<SV>) -> Self {
         let storage = account
             .storage
             .iter()
@@ -39,9 +38,9 @@ impl From<&BundleAccount> for CacheAccount {
     }
 }
 
-impl CacheAccount {
+impl<SV: StorageValueTr> CacheAccount<SV> {
     /// Creates new account that is loaded from database.
-    pub fn new_loaded(info: AccountInfo, storage: PlainStorage) -> Self {
+    pub fn new_loaded(info: AccountInfo, storage: PlainStorage<SV>) -> Self {
         Self {
             account: Some(PlainAccount { info, storage }),
             status: AccountStatus::Loaded,
@@ -49,7 +48,7 @@ impl CacheAccount {
     }
 
     /// Creates new account that is loaded empty from database.
-    pub fn new_loaded_empty_eip161(storage: PlainStorage) -> Self {
+    pub fn new_loaded_empty_eip161(storage: PlainStorage<SV>) -> Self {
         Self {
             account: Some(PlainAccount::new_empty_with_storage(storage)),
             status: AccountStatus::LoadedEmptyEIP161,
@@ -65,7 +64,7 @@ impl CacheAccount {
     }
 
     /// Creates new account that is newly created.
-    pub fn new_newly_created(info: AccountInfo, storage: PlainStorage) -> Self {
+    pub fn new_newly_created(info: AccountInfo, storage: PlainStorage<SV>) -> Self {
         Self {
             account: Some(PlainAccount { info, storage }),
             status: AccountStatus::InMemoryChange,
@@ -81,7 +80,7 @@ impl CacheAccount {
     }
 
     /// Creates changed account.
-    pub fn new_changed(info: AccountInfo, storage: PlainStorage) -> Self {
+    pub fn new_changed(info: AccountInfo, storage: PlainStorage<SV>) -> Self {
         Self {
             account: Some(PlainAccount { info, storage }),
             status: AccountStatus::Changed,
@@ -101,7 +100,7 @@ impl CacheAccount {
     }
 
     /// Returns storage slot if it exists.
-    pub fn storage_slot(&self, slot: U256) -> Option<FlaggedStorage> {
+    pub fn storage_slot(&self, slot: U256) -> Option<SV> {
         self.account
             .as_ref()
             .and_then(|a| a.storage.get(&slot).cloned())
@@ -113,15 +112,15 @@ impl CacheAccount {
     }
 
     /// Dissolves account into components.
-    pub fn into_components(self) -> (Option<(AccountInfo, PlainStorage)>, AccountStatus) {
+    pub fn into_components(self) -> (Option<(AccountInfo, PlainStorage<SV>)>, AccountStatus) {
         (self.account.map(|a| a.into_components()), self.status)
     }
 
     /// Account got touched and before EIP161 state clear this account is considered created.
     pub fn touch_create_pre_eip161(
         &mut self,
-        storage: StorageWithOriginalValues,
-    ) -> Option<TransitionAccount> {
+        storage: StorageWithOriginalValues<SV>,
+    ) -> Option<TransitionAccount<SV>> {
         let previous_status = self.status;
 
         let had_no_info = self
@@ -149,7 +148,7 @@ impl CacheAccount {
     /// Touch empty account, related to EIP-161 state clear.
     ///
     /// This account returns the Transition that is used to create the BundleState.
-    pub fn touch_empty_eip161(&mut self) -> Option<TransitionAccount> {
+    pub fn touch_empty_eip161(&mut self) -> Option<TransitionAccount<SV>> {
         let previous_status = self.status;
 
         // Set account to None.
@@ -180,7 +179,7 @@ impl CacheAccount {
     /// Consumes self and make account as destroyed.
     ///
     /// Sets account as None and set status to Destroyer or DestroyedAgain.
-    pub fn selfdestruct(&mut self) -> Option<TransitionAccount> {
+    pub fn selfdestruct(&mut self) -> Option<TransitionAccount<SV>> {
         // Account should be None after selfdestruct so we can take it.
         let previous_info = self.account.take().map(|a| a.info);
         let previous_status = self.status;
@@ -205,8 +204,8 @@ impl CacheAccount {
     pub fn newly_created(
         &mut self,
         new_info: AccountInfo,
-        new_storage: StorageWithOriginalValues,
-    ) -> TransitionAccount {
+        new_storage: StorageWithOriginalValues<SV>,
+    ) -> TransitionAccount<SV> {
         let previous_status = self.status;
         let previous_info = self.account.take().map(|a| a.info);
 
@@ -235,7 +234,7 @@ impl CacheAccount {
     /// overflow or be zero.
     ///
     /// Note: Only if balance is zero we would return None as no transition would be made.
-    pub fn increment_balance(&mut self, balance: u128) -> Option<TransitionAccount> {
+    pub fn increment_balance(&mut self, balance: u128) -> Option<TransitionAccount<SV>> {
         if balance == 0 {
             return None;
         }
@@ -248,7 +247,7 @@ impl CacheAccount {
     fn account_info_change<T, F: FnOnce(&mut AccountInfo) -> T>(
         &mut self,
         change: F,
-    ) -> (T, TransitionAccount) {
+    ) -> (T, TransitionAccount<SV>) {
         let previous_status = self.status;
         let previous_info = self.account_info();
         let mut account = self.account.take().unwrap_or_default();
@@ -277,7 +276,7 @@ impl CacheAccount {
     /// Drain balance from account and return drained amount and transition.
     ///
     /// Used for DAO hardfork transition.
-    pub fn drain_balance(&mut self) -> (u128, TransitionAccount) {
+    pub fn drain_balance(&mut self) -> (u128, TransitionAccount<SV>) {
         self.account_info_change(|info| {
             let output = info.balance;
             info.balance = U256::ZERO;
@@ -291,8 +290,8 @@ impl CacheAccount {
     pub fn change(
         &mut self,
         new: AccountInfo,
-        storage: StorageWithOriginalValues,
-    ) -> TransitionAccount {
+        storage: StorageWithOriginalValues<SV>,
+    ) -> TransitionAccount<SV> {
         let previous_status = self.status;
         let (previous_info, mut this_storage) = if let Some(account) = self.account.take() {
             (Some(account.info), account.storage)

--- a/crates/database/src/states/changes.rs
+++ b/crates/database/src/states/changes.rs
@@ -1,7 +1,6 @@
 use super::RevertToSlot;
 use bytecode::Bytecode;
-use primitives::alloy_primitives::FlaggedStorage;
-use primitives::{Address, StorageKey, B256, U256};
+use primitives::{Address, StorageKey, StorageValueTr, B256, U256};
 use state::AccountInfo;
 use std::vec::Vec;
 
@@ -13,11 +12,11 @@ use std::vec::Vec;
 /// **Note**: That data is **not** sorted. Some database benefit of faster inclusion
 /// and smaller footprint if data is inserted in sorted order.
 #[derive(Clone, Debug, Default)]
-pub struct StateChangeset {
+pub struct StateChangeset<SV: StorageValueTr = U256> {
     /// Vector of **not** sorted accounts information.
     pub accounts: Vec<(Address, Option<AccountInfo>)>,
     /// Vector of **not** sorted storage.
-    pub storage: Vec<PlainStorageChangeset>,
+    pub storage: Vec<PlainStorageChangeset<SV>>,
     /// Vector of contracts by bytecode hash. **not** sorted.
     pub contracts: Vec<(B256, Bytecode)>,
 }
@@ -26,20 +25,20 @@ pub struct StateChangeset {
 ///
 /// Used to apply storage changes of plain state to the database.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub struct PlainStorageChangeset {
+pub struct PlainStorageChangeset<SV: StorageValueTr = U256> {
     /// Address of account
     pub address: Address,
     /// Wipe storage
     pub wipe_storage: bool,
     /// Storage key value pairs
-    pub storage: Vec<(U256, FlaggedStorage)>,
+    pub storage: Vec<(U256, SV)>,
 }
 
 /// Plain Storage Revert.
 ///
 /// [`PlainStorageRevert`] contains old values of changed storage.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub struct PlainStorageRevert {
+pub struct PlainStorageRevert<SV: StorageValueTr = U256> {
     /// Address of account
     pub address: Address,
     /// Whether storage is wiped in this revert
@@ -50,23 +49,23 @@ pub struct PlainStorageRevert {
     /// Contains the storage key and old values of that storage
     ///
     /// **Note**: Reverts are **not** sorted.
-    pub storage_revert: Vec<(StorageKey, RevertToSlot)>,
+    pub storage_revert: Vec<(StorageKey, RevertToSlot<SV>)>,
 }
 
 /// Plain state reverts are used to easily store reverts into database.
 ///
 /// Note that accounts are assumed **not** sorted.
 #[derive(Clone, Debug, Default)]
-pub struct PlainStateReverts {
+pub struct PlainStateReverts<SV: StorageValueTr = U256> {
     /// Vector of account with removed contracts bytecode.
     ///
     /// **Note**: If AccountInfo is None means that account needs to be removed.
     pub accounts: Vec<Vec<(Address, Option<AccountInfo>)>>,
     /// Vector of storage with its address.
-    pub storage: Vec<Vec<PlainStorageRevert>>,
+    pub storage: Vec<Vec<PlainStorageRevert<SV>>>,
 }
 
-impl PlainStateReverts {
+impl<SV: StorageValueTr> PlainStateReverts<SV> {
     /// Constructs new [`PlainStateReverts`] with pre-allocated capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
@@ -77,4 +76,4 @@ impl PlainStateReverts {
 }
 
 /// Storage reverts
-pub type StorageRevert = Vec<Vec<(Address, bool, Vec<(StorageKey, RevertToSlot)>)>>;
+pub type StorageRevert<SV = U256> = Vec<Vec<(Address, bool, Vec<(StorageKey, RevertToSlot<SV>)>)>>;

--- a/crates/database/src/states/plain_account.rs
+++ b/crates/database/src/states/plain_account.rs
@@ -1,19 +1,18 @@
-use primitives::alloy_primitives::FlaggedStorage;
-use primitives::{HashMap, StorageKey, U256};
+use primitives::{HashMap, StorageKey, StorageValueTr, U256};
 use state::{AccountInfo, EvmStorageSlot};
 
 /// Plain account of StateDatabase.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct PlainAccount {
+pub struct PlainAccount<SV: StorageValueTr = U256> {
     /// Account information.
     pub info: AccountInfo,
     /// Account storage.
-    pub storage: PlainStorage,
+    pub storage: PlainStorage<SV>,
 }
 
-impl PlainAccount {
+impl<SV: StorageValueTr> PlainAccount<SV> {
     /// Creates a new empty account with the given storage.
-    pub fn new_empty_with_storage(storage: PlainStorage) -> Self {
+    pub fn new_empty_with_storage(storage: PlainStorage<SV>) -> Self {
         Self {
             info: AccountInfo::default(),
             storage,
@@ -21,7 +20,7 @@ impl PlainAccount {
     }
 
     /// Consumes the account and returns its components.
-    pub fn into_components(self) -> (AccountInfo, PlainStorage) {
+    pub fn into_components(self) -> (AccountInfo, PlainStorage<SV>) {
         (self.info, self.storage)
     }
 }
@@ -29,26 +28,27 @@ impl PlainAccount {
 /// This type keeps track of the current value of a storage slot.
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct StorageSlot {
+#[cfg_attr(feature = "serde", serde(bound = "SV: serde::Serialize + serde::de::DeserializeOwned"))]
+pub struct StorageSlot<SV: StorageValueTr = U256> {
     /// The value of the storage slot before it was changed.
     ///
     /// When the slot is first loaded, this is the original value.
     ///
     /// If the slot was not changed, this is equal to the present value.
-    pub previous_or_original_value: FlaggedStorage,
+    pub previous_or_original_value: SV,
     /// When loaded with sload present value is set to original value
-    pub present_value: FlaggedStorage,
+    pub present_value: SV,
 }
 
-impl From<EvmStorageSlot> for StorageSlot {
-    fn from(value: EvmStorageSlot) -> Self {
+impl<SV: StorageValueTr> From<EvmStorageSlot<SV>> for StorageSlot<SV> {
+    fn from(value: EvmStorageSlot<SV>) -> Self {
         Self::new_changed(value.original_value, value.present_value)
     }
 }
 
-impl StorageSlot {
+impl<SV: StorageValueTr> StorageSlot<SV> {
     /// Creates a new _unchanged_ `StorageSlot` for the given value.
-    pub fn new(original: FlaggedStorage) -> Self {
+    pub fn new(original: SV) -> Self {
         Self {
             previous_or_original_value: original,
             present_value: original,
@@ -57,8 +57,8 @@ impl StorageSlot {
 
     /// Creates a new _changed_ `StorageSlot`.
     pub fn new_changed(
-        previous_or_original_value: FlaggedStorage,
-        present_value: FlaggedStorage,
+        previous_or_original_value: SV,
+        present_value: SV,
     ) -> Self {
         Self {
             previous_or_original_value,
@@ -72,12 +72,12 @@ impl StorageSlot {
     }
 
     /// Returns the original value of the storage slot.
-    pub fn original_value(&self) -> FlaggedStorage {
+    pub fn original_value(&self) -> SV {
         self.previous_or_original_value
     }
 
     /// Returns the current value of the storage slot.
-    pub fn present_value(&self) -> FlaggedStorage {
+    pub fn present_value(&self) -> SV {
         self.present_value
     }
 }
@@ -85,13 +85,13 @@ impl StorageSlot {
 /// This storage represent values that are before block changed.
 ///
 /// Note: Storage that we get EVM contains original values before block changed.
-pub type StorageWithOriginalValues = HashMap<StorageKey, StorageSlot>;
+pub type StorageWithOriginalValues<SV = U256> = HashMap<StorageKey, StorageSlot<SV>>;
 
 /// Simple plain storage that does not have previous value.
 /// This is used for loading from database, cache and for bundle state.
-pub type PlainStorage = HashMap<U256, FlaggedStorage>;
+pub type PlainStorage<SV = U256> = HashMap<U256, SV>;
 
-impl From<AccountInfo> for PlainAccount {
+impl<SV: StorageValueTr> From<AccountInfo> for PlainAccount<SV> {
     fn from(info: AccountInfo) -> Self {
         Self {
             info,

--- a/crates/database/src/states/reverts.rs
+++ b/crates/database/src/states/reverts.rs
@@ -6,33 +6,33 @@ use core::{
     cmp::Ordering,
     ops::{Deref, DerefMut},
 };
-use primitives::alloy_primitives::FlaggedStorage;
-use primitives::{Address, HashMap, StorageKey};
+use primitives::{Address, HashMap, StorageKey, StorageValueTr, U256};
 use state::AccountInfo;
 use std::vec::Vec;
 
 /// Contains reverts of multiple account in multiple transitions (Transitions as a block).
 #[derive(Clone, Debug, Default, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Reverts(Vec<Vec<(Address, AccountRevert)>>);
+#[cfg_attr(feature = "serde", serde(bound = "SV: serde::Serialize + serde::de::DeserializeOwned"))]
+pub struct Reverts<SV: StorageValueTr = U256>(Vec<Vec<(Address, AccountRevert<SV>)>>);
 
-impl Deref for Reverts {
-    type Target = Vec<Vec<(Address, AccountRevert)>>;
+impl<SV: StorageValueTr> Deref for Reverts<SV> {
+    type Target = Vec<Vec<(Address, AccountRevert<SV>)>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl DerefMut for Reverts {
+impl<SV: StorageValueTr> DerefMut for Reverts<SV> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl Reverts {
+impl<SV: StorageValueTr> Reverts<SV> {
     /// Creates new reverts.
-    pub fn new(reverts: Vec<Vec<(Address, AccountRevert)>>) -> Self {
+    pub fn new(reverts: Vec<Vec<(Address, AccountRevert<SV>)>>) -> Self {
         Self(reverts)
     }
 
@@ -44,14 +44,14 @@ impl Reverts {
     }
 
     /// Extends reverts with other reverts.
-    pub fn extend(&mut self, other: Reverts) {
+    pub fn extend(&mut self, other: Reverts<SV>) {
         self.0.extend(other.0);
     }
 
     /// Generates a [`PlainStateReverts`].
     ///
     /// Note that account are sorted by address.
-    pub fn to_plain_state_reverts(&self) -> PlainStateReverts {
+    pub fn to_plain_state_reverts(&self) -> PlainStateReverts<SV> {
         let mut state_reverts = PlainStateReverts::with_capacity(self.0.len());
         for reverts in &self.0 {
             // Pessimistically pre-allocate assuming _all_ accounts changed.
@@ -119,12 +119,12 @@ impl Reverts {
     ///
     /// Note that account are sorted by address.
     #[deprecated = "Use `to_plain_state_reverts` instead"]
-    pub fn into_plain_state_reverts(self) -> PlainStateReverts {
+    pub fn into_plain_state_reverts(self) -> PlainStateReverts<SV> {
         self.to_plain_state_reverts()
     }
 }
 
-impl PartialEq for Reverts {
+impl<SV: StorageValueTr> PartialEq for Reverts<SV> {
     fn eq(&self, other: &Self) -> bool {
         self.content_eq(other)
     }
@@ -142,18 +142,19 @@ impl PartialEq for Reverts {
 /// And we need to be able to read it from database.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct AccountRevert {
+#[cfg_attr(feature = "serde", serde(bound = "SV: serde::Serialize + serde::de::DeserializeOwned"))]
+pub struct AccountRevert<SV: StorageValueTr = U256> {
     /// Account information revert.
     pub account: AccountInfoRevert,
     /// Storage slots to revert.
-    pub storage: HashMap<StorageKey, RevertToSlot>,
+    pub storage: HashMap<StorageKey, RevertToSlot<SV>>,
     /// Previous account status before the change.
     pub previous_status: AccountStatus,
     /// Whether to wipe the storage.
     pub wipe_storage: bool,
 }
 
-impl AccountRevert {
+impl<SV: StorageValueTr> AccountRevert<SV> {
     /// The approximate size of changes needed to store this account revert.
     ///
     /// `1 + storage_reverts_len`
@@ -166,12 +167,12 @@ impl AccountRevert {
     pub fn new_selfdestructed_again(
         status: AccountStatus,
         account: AccountInfoRevert,
-        mut previous_storage: StorageWithOriginalValues,
-        updated_storage: StorageWithOriginalValues,
+        mut previous_storage: StorageWithOriginalValues<SV>,
+        updated_storage: StorageWithOriginalValues<SV>,
     ) -> Self {
         // Take present storage values as the storages that we are going to revert to.
         // As those values got destroyed.
-        let mut previous_storage: HashMap<StorageKey, RevertToSlot> = previous_storage
+        let mut previous_storage: HashMap<StorageKey, RevertToSlot<SV>> = previous_storage
             .drain()
             .map(|(key, value)| (key, RevertToSlot::Some(value.present_value)))
             .collect();
@@ -191,8 +192,8 @@ impl AccountRevert {
     /// Creates revert for states that were before selfdestruct.
     pub fn new_selfdestructed_from_bundle(
         account_info_revert: AccountInfoRevert,
-        bundle_account: &mut BundleAccount,
-        updated_storage: &StorageWithOriginalValues,
+        bundle_account: &mut BundleAccount<SV>,
+        updated_storage: &StorageWithOriginalValues<SV>,
     ) -> Option<Self> {
         match bundle_account.status {
             AccountStatus::InMemoryChange
@@ -216,7 +217,7 @@ impl AccountRevert {
     pub fn new_selfdestructed(
         status: AccountStatus,
         account: AccountInfoRevert,
-        mut storage: StorageWithOriginalValues,
+        mut storage: StorageWithOriginalValues<SV>,
     ) -> Self {
         // Zero all present storage values and save present values to AccountRevert.
         let previous_storage = storage
@@ -247,14 +248,14 @@ impl AccountRevert {
 }
 
 /// Implements partial ordering for AccountRevert
-impl PartialOrd for AccountRevert {
+impl<SV: StorageValueTr> PartialOrd for AccountRevert<SV> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 /// Implements total ordering for AccountRevert
-impl Ord for AccountRevert {
+impl<SV: StorageValueTr> Ord for AccountRevert<SV> {
     fn cmp(&self, other: &Self) -> Ordering {
         // First compare accounts
         if let Some(ord) = self.account.partial_cmp(&other.account) {
@@ -317,19 +318,20 @@ pub enum AccountInfoRevert {
 /// Because if it is destroyed, previous values can be found in database or it can be zero.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum RevertToSlot {
+#[cfg_attr(feature = "serde", serde(bound = "SV: serde::Serialize + serde::de::DeserializeOwned"))]
+pub enum RevertToSlot<SV: StorageValueTr = U256> {
     /// Revert to this value.
-    Some(FlaggedStorage),
+    Some(SV),
     /// Storage was destroyed.
     Destroyed,
 }
 
-impl RevertToSlot {
+impl<SV: StorageValueTr> RevertToSlot<SV> {
     /// Returns the previous value to set on revert.
-    pub fn to_previous_value(self) -> FlaggedStorage {
+    pub fn to_previous_value(self) -> SV {
         match self {
             RevertToSlot::Some(value) => value,
-            RevertToSlot::Destroyed => FlaggedStorage::ZERO,
+            RevertToSlot::Destroyed => SV::ZERO,
         }
     }
 }

--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -3,22 +3,24 @@ use super::{
     CacheAccount, StateBuilder, TransitionAccount, TransitionState,
 };
 use bytecode::Bytecode;
-use database_interface::{Database, DatabaseCommit, DatabaseRef, EmptyDB};
-use primitives::{hash_map, Address, HashMap, StorageKey, B256, BLOCK_HASH_HISTORY};
+use database_interface::{Database, DatabaseCommit, DatabaseRef, EmptyDBTyped};
+use primitives::{hash_map, Address, HashMap, StorageKey, StorageValueTr, B256, BLOCK_HASH_HISTORY, U256};
 use state::{Account, AccountInfo};
 use std::{
     boxed::Box,
     collections::{btree_map, BTreeMap},
+    convert::Infallible,
     vec::Vec,
 };
 
 /// Database boxed with a lifetime and Send
-pub type DBBox<'a, E> = Box<dyn Database<Error = E> + Send + 'a>;
+pub type DBBox<'a, E, SV = U256> =
+    Box<dyn Database<Error = E, StorageValue = SV> + Send + 'a>;
 
 /// More constrained version of State that uses Boxed database with a lifetime
 ///
 /// This is used to make it easier to use State.
-pub type StateDBBox<'a, E> = State<DBBox<'a, E>>;
+pub type StateDBBox<'a, E, SV = U256> = State<DBBox<'a, E, SV>, SV>;
 
 /// State of blockchain
 ///
@@ -26,14 +28,14 @@ pub type StateDBBox<'a, E> = State<DBBox<'a, E>>;
 ///
 /// If you want to disable it use `set_state_clear_flag` function.
 #[derive(Debug)]
-pub struct State<DB> {
+pub struct State<DB, SV: StorageValueTr = U256> {
     /// Cached state contains both changed from evm execution and cached/loaded account/storages
     /// from database
     ///
     /// This allows us to have only one layer of cache where we can fetch data.
     ///
     /// Additionally, we can introduce some preloading of data from database.
-    pub cache: CacheState,
+    pub cache: CacheState<SV>,
     /// Optional database that we use to fetch data from
     ///
     /// If database is not present, we will return not existing account and storage.
@@ -43,13 +45,13 @@ pub struct State<DB> {
     /// Block state, it aggregates transactions transitions into one state
     ///
     /// Build reverts and state that gets applied to the state.
-    pub transition_state: Option<TransitionState>,
+    pub transition_state: Option<TransitionState<SV>>,
     /// After block is finishes we merge those changes inside bundle
     ///
     /// Bundle is used to update database and create changesets.
     ///
     /// Bundle state can be set on initialization if we want to use preloaded bundle.
-    pub bundle_state: BundleState,
+    pub bundle_state: BundleState<SV>,
     /// Addition layer that is going to be used to fetched values before fetching values
     /// from database
     ///
@@ -66,14 +68,14 @@ pub struct State<DB> {
 }
 
 // Have ability to call State::builder without having to specify the type.
-impl State<EmptyDB> {
+impl State<EmptyDBTyped<Infallible>> {
     /// Return the builder that build the State.
-    pub fn builder() -> StateBuilder<EmptyDB> {
+    pub fn builder() -> StateBuilder<EmptyDBTyped<Infallible>> {
         StateBuilder::default()
     }
 }
 
-impl<DB: Database> State<DB> {
+impl<DB: Database<StorageValue = SV>, SV: StorageValueTr> State<DB, SV> {
     /// Returns the size hint for the inner bundle state.
     ///
     /// See [BundleState::size_hint] for more info.
@@ -157,14 +159,14 @@ impl<DB: Database> State<DB> {
         &mut self,
         address: Address,
         info: AccountInfo,
-        storage: PlainStorage,
+        storage: PlainStorage<SV>,
     ) {
         self.cache
             .insert_account_with_storage(address, info, storage)
     }
 
     /// Applies evm transitions to transition state.
-    pub fn apply_transition(&mut self, transitions: Vec<(Address, TransitionAccount)>) {
+    pub fn apply_transition(&mut self, transitions: Vec<(Address, TransitionAccount<SV>)>) {
         // Add transition to transition state.
         if let Some(s) = self.transition_state.as_mut() {
             s.add_transitions(transitions)
@@ -187,7 +189,7 @@ impl<DB: Database> State<DB> {
     ///
     /// If the account is not found in the cache, it will be loaded from the
     /// database and inserted into the cache.
-    pub fn load_cache_account(&mut self, address: Address) -> Result<&mut CacheAccount, DB::Error> {
+    pub fn load_cache_account(&mut self, address: Address) -> Result<&mut CacheAccount<SV>, DB::Error> {
         match self.cache.accounts.entry(address) {
             hash_map::Entry::Vacant(entry) => {
                 if self.use_preloaded_bundle {
@@ -222,13 +224,14 @@ impl<DB: Database> State<DB> {
     /// If the `State` has been built with the
     /// [`StateBuilder::with_bundle_prestate`] option, the pre-state will be
     /// taken along with any changes made by [`State::merge_transitions`].
-    pub fn take_bundle(&mut self) -> BundleState {
+    pub fn take_bundle(&mut self) -> BundleState<SV> {
         core::mem::take(&mut self.bundle_state)
     }
 }
 
-impl<DB: Database> Database for State<DB> {
+impl<DB: Database<StorageValue = SV>, SV: StorageValueTr> Database for State<DB, SV> {
     type Error = DB::Error;
+    type StorageValue = SV;
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         self.load_cache_account(address).map(|a| a.account_info())
@@ -257,7 +260,7 @@ impl<DB: Database> Database for State<DB> {
         &mut self,
         address: Address,
         index: StorageKey,
-    ) -> Result<state::FlaggedStorage, Self::Error> {
+    ) -> Result<Self::StorageValue, Self::Error> {
         // Account is guaranteed to be loaded.
         // Note that storage from bundle is already loaded with account.
         if let Some(account) = self.cache.accounts.get_mut(&address) {
@@ -272,7 +275,7 @@ impl<DB: Database> Database for State<DB> {
                         // If account was destroyed or account is newly built
                         // we return zero and don't ask database.
                         let value = if is_storage_known {
-                            state::FlaggedStorage::ZERO
+                            SV::ZERO
                         } else {
                             self.database.storage(address, index)?
                         };
@@ -309,15 +312,16 @@ impl<DB: Database> Database for State<DB> {
     }
 }
 
-impl<DB: Database> DatabaseCommit for State<DB> {
-    fn commit(&mut self, evm_state: HashMap<Address, Account>) {
+impl<DB: Database<StorageValue = SV>, SV: StorageValueTr> DatabaseCommit<SV> for State<DB, SV> {
+    fn commit(&mut self, evm_state: HashMap<Address, Account<SV>>) {
         let transitions = self.cache.apply_evm_state(evm_state);
         self.apply_transition(transitions);
     }
 }
 
-impl<DB: DatabaseRef> DatabaseRef for State<DB> {
+impl<DB: DatabaseRef<StorageValue = SV>, SV: StorageValueTr> DatabaseRef for State<DB, SV> {
     type Error = DB::Error;
+    type StorageValue = SV;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         // Account is already in cache
@@ -353,7 +357,7 @@ impl<DB: DatabaseRef> DatabaseRef for State<DB> {
         &self,
         address: Address,
         index: StorageKey,
-    ) -> Result<state::FlaggedStorage, Self::Error> {
+    ) -> Result<Self::StorageValue, Self::Error> {
         // Check if account is in cache, the account is not guaranteed to be loaded
         if let Some(account) = self.cache.accounts.get(&address) {
             if let Some(plain_account) = &account.account {
@@ -364,7 +368,7 @@ impl<DB: DatabaseRef> DatabaseRef for State<DB> {
                 // If account was destroyed or account is newly built
                 // we return zero and don't ask database.
                 if account.status.is_storage_known() {
-                    return Ok(state::FlaggedStorage::ZERO);
+                    return Ok(SV::ZERO);
                 }
             }
         }
@@ -453,15 +457,9 @@ mod tests {
             nonce: 1,
             ..Default::default()
         };
-        let existing_account_initial_storage = HashMap::<U256, state::FlaggedStorage>::from_iter([
-            (
-                slot1,
-                state::FlaggedStorage::new_from_value(U256::from(100)),
-            ), // 0x01 => 100
-            (
-                slot2,
-                state::FlaggedStorage::new_from_value(U256::from(100)),
-            ), // 0x02 => 200
+        let existing_account_initial_storage = HashMap::<U256, U256>::from_iter([
+            (slot1, U256::from(100)), // 0x01 => 100
+            (slot2, U256::from(100)), // 0x02 => 200
         ]);
         let existing_account_changed_info = AccountInfo {
             nonce: 2,
@@ -491,7 +489,7 @@ mod tests {
                         slot1,
                         StorageSlot::new_changed(
                             *existing_account_initial_storage.get(&slot1).unwrap(),
-                            state::FlaggedStorage::from(U256::from(1000)),
+                            U256::from(1000),
                         ),
                     )]),
                     storage_was_destroyed: false,
@@ -523,8 +521,8 @@ mod tests {
                     storage: HashMap::from_iter([(
                         slot1,
                         StorageSlot::new_changed(
-                            state::FlaggedStorage::ZERO,
-                            state::FlaggedStorage::from(U256::from(1)),
+                            U256::ZERO,
+                            U256::from(1),
                         ),
                     )]),
                     storage_was_destroyed: false,
@@ -541,23 +539,23 @@ mod tests {
                         (
                             slot1,
                             StorageSlot::new_changed(
-                                state::FlaggedStorage::from(U256::from(100)),
-                                state::FlaggedStorage::from(U256::from(1_000)),
+                                U256::from(100),
+                                U256::from(1_000),
                             ),
                         ),
                         (
                             slot2,
                             StorageSlot::new_changed(
                                 *existing_account_initial_storage.get(&slot2).unwrap(),
-                                state::FlaggedStorage::from(U256::from(2_000)),
+                                U256::from(2_000),
                             ),
                         ),
                         // Create new slot
                         (
                             slot3,
                             StorageSlot::new_changed(
-                                state::FlaggedStorage::ZERO,
-                                state::FlaggedStorage::from(U256::from(3_000)),
+                                U256::ZERO,
+                                U256::from(3_000),
                             ),
                         ),
                     ]),
@@ -582,7 +580,7 @@ mod tests {
                         previous_status: AccountStatus::LoadedNotExisting,
                         storage: HashMap::from_iter([(
                             slot1,
-                            RevertToSlot::Some(state::FlaggedStorage::ZERO)
+                            RevertToSlot::Some(U256::ZERO)
                         )]),
                         wipe_storage: false,
                     }
@@ -605,7 +603,7 @@ mod tests {
                                     *existing_account_initial_storage.get(&slot2).unwrap()
                                 )
                             ),
-                            (slot3, RevertToSlot::Some(state::FlaggedStorage::ZERO))
+                            (slot3, RevertToSlot::Some(U256::ZERO))
                         ]),
                         wipe_storage: false,
                     }
@@ -625,8 +623,8 @@ mod tests {
                 storage: HashMap::from_iter([(
                     slot1,
                     StorageSlot::new_changed(
-                        state::FlaggedStorage::ZERO,
-                        state::FlaggedStorage::from(U256::from(1))
+                        U256::ZERO,
+                        U256::from(1)
                     )
                 )]),
             }),
@@ -646,22 +644,22 @@ mod tests {
                         slot1,
                         StorageSlot::new_changed(
                             *existing_account_initial_storage.get(&slot1).unwrap(),
-                            state::FlaggedStorage::from(U256::from(1_000))
+                            U256::from(1_000)
                         )
                     ),
                     (
                         slot2,
                         StorageSlot::new_changed(
                             *existing_account_initial_storage.get(&slot2).unwrap(),
-                            state::FlaggedStorage::from(U256::from(2_000))
+                            U256::from(2_000)
                         )
                     ),
                     // Create new slot
                     (
                         slot3,
                         StorageSlot::new_changed(
-                            state::FlaggedStorage::ZERO,
-                            state::FlaggedStorage::from(U256::from(3_000))
+                            U256::ZERO,
+                            U256::from(3_000)
                         )
                     ),
                 ]),
@@ -736,15 +734,15 @@ mod tests {
                         (
                             slot1,
                             StorageSlot::new_changed(
-                                state::FlaggedStorage::from(U256::from(1)),
-                                state::FlaggedStorage::from(U256::from(10)),
+                                U256::from(1),
+                                U256::from(10),
                             ),
                         ),
                         (
                             slot2,
                             StorageSlot::new_changed(
-                                state::FlaggedStorage::ZERO,
-                                state::FlaggedStorage::from(U256::from(20)),
+                                U256::ZERO,
+                                U256::from(20),
                             ),
                         ),
                     ]),
@@ -786,15 +784,15 @@ mod tests {
                         (
                             slot1,
                             StorageSlot::new_changed(
-                                state::FlaggedStorage::from(U256::from(10)),
-                                state::FlaggedStorage::from(U256::from(1)),
+                                U256::from(10),
+                                U256::from(1),
                             ),
                         ),
                         (
                             slot2,
                             StorageSlot::new_changed(
-                                state::FlaggedStorage::from(U256::from(20)),
-                                state::FlaggedStorage::ZERO,
+                                U256::from(20),
+                                U256::ZERO,
                             ),
                         ),
                     ]),
@@ -851,8 +849,8 @@ mod tests {
                 storage: HashMap::from_iter([(
                     slot1,
                     StorageSlot::new_changed(
-                        state::FlaggedStorage::ZERO,
-                        state::FlaggedStorage::from(U256::from(1)),
+                        U256::ZERO,
+                        U256::from(1),
                     ),
                 )]),
                 storage_was_destroyed: false,
@@ -884,8 +882,8 @@ mod tests {
                 storage: HashMap::from_iter([(
                     slot2,
                     StorageSlot::new_changed(
-                        state::FlaggedStorage::ZERO,
-                        state::FlaggedStorage::from(U256::from(2)),
+                        U256::ZERO,
+                        U256::from(2),
                     ),
                 )]),
                 storage_was_destroyed: false,
@@ -906,8 +904,8 @@ mod tests {
                     storage: HashMap::from_iter([(
                         slot2,
                         StorageSlot::new_changed(
-                            state::FlaggedStorage::ZERO,
-                            state::FlaggedStorage::from(U256::from(2))
+                            U256::ZERO,
+                            U256::from(2)
                         )
                     )]),
                     status: AccountStatus::DestroyedChanged,

--- a/crates/database/src/states/state_builder.rs
+++ b/crates/database/src/states/state_builder.rs
@@ -1,11 +1,11 @@
 use super::{cache::CacheState, state::DBBox, BundleState, State, TransitionState};
-use database_interface::{DBErrorMarker, Database, DatabaseRef, EmptyDB, WrapDatabaseRef};
-use primitives::B256;
-use std::collections::BTreeMap;
+use database_interface::{DBErrorMarker, Database, DatabaseRef, EmptyDBTyped, WrapDatabaseRef};
+use primitives::{StorageValueTr, B256, U256};
+use std::{collections::BTreeMap, convert::Infallible};
 
 /// Allows building of State and initializing it with different options.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct StateBuilder<DB> {
+pub struct StateBuilder<DB, SV: StorageValueTr = U256> {
     /// Database that we use to fetch data from
     database: DB,
     /// Enabled state clear flag that is introduced in Spurious Dragon hardfork
@@ -14,9 +14,9 @@ pub struct StateBuilder<DB> {
     with_state_clear: bool,
     /// If there is prestate that we want to use,
     /// this would mean that we have additional state layer between evm and disk/database.
-    with_bundle_prestate: Option<BundleState>,
+    with_bundle_prestate: Option<BundleState<SV>>,
     /// This will initialize cache to this state.
-    with_cache_prestate: Option<CacheState>,
+    with_cache_prestate: Option<CacheState<SV>>,
     /// Do we want to create reverts and update bundle state?
     ///
     /// Default is false.
@@ -31,7 +31,7 @@ pub struct StateBuilder<DB> {
     with_block_hashes: BTreeMap<u64, B256>,
 }
 
-impl StateBuilder<EmptyDB> {
+impl StateBuilder<EmptyDBTyped<Infallible>> {
     /// Creates a new builder with an empty database.
     ///
     /// If you want to instantiate it with a specific database, use
@@ -41,13 +41,13 @@ impl StateBuilder<EmptyDB> {
     }
 }
 
-impl<DB: Database + Default> Default for StateBuilder<DB> {
+impl<DB: Database + Default, SV: StorageValueTr> Default for StateBuilder<DB, SV> {
     fn default() -> Self {
         Self::new_with_database(DB::default())
     }
 }
 
-impl<DB: Database> StateBuilder<DB> {
+impl<DB: Database, SV: StorageValueTr> StateBuilder<DB, SV> {
     /// Create a new builder with the given database.
     pub fn new_with_database(database: DB) -> Self {
         Self {
@@ -62,7 +62,7 @@ impl<DB: Database> StateBuilder<DB> {
     }
 
     /// Set the database.
-    pub fn with_database<ODB: Database>(self, database: ODB) -> StateBuilder<ODB> {
+    pub fn with_database<ODB: Database>(self, database: ODB) -> StateBuilder<ODB, SV> {
         // Cast to the different database.
         // Note that we return different type depending on the database NewDBError.
         StateBuilder {
@@ -80,15 +80,15 @@ impl<DB: Database> StateBuilder<DB> {
     pub fn with_database_ref<ODB: DatabaseRef>(
         self,
         database: ODB,
-    ) -> StateBuilder<WrapDatabaseRef<ODB>> {
+    ) -> StateBuilder<WrapDatabaseRef<ODB>, SV> {
         self.with_database(WrapDatabaseRef(database))
     }
 
     /// With boxed version of database.
     pub fn with_database_boxed<Error: DBErrorMarker + core::error::Error>(
         self,
-        database: DBBox<'_, Error>,
-    ) -> StateBuilder<DBBox<'_, Error>> {
+        database: DBBox<'_, Error, SV>,
+    ) -> StateBuilder<DBBox<'_, Error, SV>, SV> {
         self.with_database(database)
     }
 
@@ -109,7 +109,7 @@ impl<DB: Database> StateBuilder<DB> {
     /// And State after not finding data inside StateCache will try to find it inside BundleState.
     ///
     /// On update Bundle state will be changed and updated.
-    pub fn with_bundle_prestate(self, bundle: BundleState) -> Self {
+    pub fn with_bundle_prestate(self, bundle: BundleState<SV>) -> Self {
         Self {
             with_bundle_prestate: Some(bundle),
             ..self
@@ -134,7 +134,7 @@ impl<DB: Database> StateBuilder<DB> {
     /// And will ignore `without_state_clear` flag as cache contains its own state_clear flag.
     ///
     /// This is useful for testing.
-    pub fn with_cached_prestate(self, cache: CacheState) -> Self {
+    pub fn with_cached_prestate(self, cache: CacheState<SV>) -> Self {
         Self {
             with_cache_prestate: Some(cache),
             ..self
@@ -159,7 +159,7 @@ impl<DB: Database> StateBuilder<DB> {
     }
 
     /// Builds the State with the configured settings.
-    pub fn build(mut self) -> State<DB> {
+    pub fn build(mut self) -> State<DB, SV> {
         let use_preloaded_bundle = if self.with_cache_prestate.is_some() {
             self.with_bundle_prestate = None;
             false

--- a/crates/database/src/states/transition_account.rs
+++ b/crates/database/src/states/transition_account.rs
@@ -1,6 +1,6 @@
 use super::{AccountRevert, AccountStatus, BundleAccount, StorageWithOriginalValues};
 use bytecode::Bytecode;
-use primitives::{hash_map, B256, U256};
+use primitives::{hash_map, StorageValueTr, B256, U256};
 use state::AccountInfo;
 
 /// Account Created when EVM state is merged to cache state.
@@ -9,7 +9,7 @@ use state::AccountInfo;
 /// It is used when block state gets merged to bundle state to
 /// create needed Reverts.
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
-pub struct TransitionAccount {
+pub struct TransitionAccount<SV: StorageValueTr = U256> {
     /// Account information, if account exists.
     pub info: Option<AccountInfo>,
     /// Current account status.
@@ -21,7 +21,7 @@ pub struct TransitionAccount {
     /// Mostly needed when previous status Loaded/LoadedEmpty.
     pub previous_status: AccountStatus,
     /// Storage contains both old and new account
-    pub storage: StorageWithOriginalValues,
+    pub storage: StorageWithOriginalValues<SV>,
     /// If there is transition that clears the storage we should mark it here and
     /// delete all storages in BundleState. This flag is needed if we have transition
     /// between Destroyed states from DestroyedChanged-> DestroyedAgain-> DestroyedChanged
@@ -30,9 +30,9 @@ pub struct TransitionAccount {
     pub storage_was_destroyed: bool,
 }
 
-impl TransitionAccount {
+impl<SV: StorageValueTr> TransitionAccount<SV> {
     /// Create new LoadedEmpty account.
-    pub fn new_empty_eip161(storage: StorageWithOriginalValues) -> Self {
+    pub fn new_empty_eip161(storage: StorageWithOriginalValues<SV>) -> Self {
         Self {
             info: Some(AccountInfo::default()),
             status: AccountStatus::InMemoryChange,
@@ -109,13 +109,13 @@ impl TransitionAccount {
     }
 
     /// Consume Self and create account revert from it.
-    pub fn create_revert(self) -> Option<AccountRevert> {
+    pub fn create_revert(self) -> Option<AccountRevert<SV>> {
         let mut previous_account = self.original_bundle_account();
         previous_account.update_and_create_revert(self)
     }
 
     /// Present bundle account
-    pub fn present_bundle_account(&self) -> BundleAccount {
+    pub fn present_bundle_account(&self) -> BundleAccount<SV> {
         BundleAccount {
             info: self.info.clone(),
             original_info: self.previous_info.clone(),
@@ -125,7 +125,7 @@ impl TransitionAccount {
     }
 
     /// Original bundle account
-    fn original_bundle_account(&self) -> BundleAccount {
+    fn original_bundle_account(&self) -> BundleAccount<SV> {
         BundleAccount {
             info: self.previous_info.clone(),
             original_info: self.previous_info.clone(),

--- a/crates/database/src/states/transition_state.rs
+++ b/crates/database/src/states/transition_state.rs
@@ -1,17 +1,17 @@
 use super::TransitionAccount;
-use primitives::{hash_map::Entry, Address, HashMap};
+use primitives::{hash_map::Entry, Address, HashMap, StorageValueTr, U256};
 use std::vec::Vec;
 
 /// State of accounts in transition between transaction executions.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct TransitionState {
+pub struct TransitionState<SV: StorageValueTr = U256> {
     /// Block state account with account state
-    pub transitions: HashMap<Address, TransitionAccount>,
+    pub transitions: HashMap<Address, TransitionAccount<SV>>,
 }
 
-impl TransitionState {
+impl<SV: StorageValueTr> TransitionState<SV> {
     /// Create new transition state containing one [`TransitionAccount`].
-    pub fn single(address: Address, transition: TransitionAccount) -> Self {
+    pub fn single(address: Address, transition: TransitionAccount<SV>) -> Self {
         let mut transitions = HashMap::default();
         transitions.insert(address, transition);
         TransitionState { transitions }
@@ -21,7 +21,7 @@ impl TransitionState {
     /// empty one.
     ///
     /// See [core::mem::take].
-    pub fn take(&mut self) -> TransitionState {
+    pub fn take(&mut self) -> TransitionState<SV> {
         core::mem::take(self)
     }
 
@@ -29,7 +29,7 @@ impl TransitionState {
     ///
     /// This will insert new [`TransitionAccount`]s, or update existing ones via
     /// [`update`][TransitionAccount::update].
-    pub fn add_transitions(&mut self, transitions: Vec<(Address, TransitionAccount)>) {
+    pub fn add_transitions(&mut self, transitions: Vec<(Address, TransitionAccount<SV>)>) {
         for (address, account) in transitions {
             match self.transitions.entry(address) {
                 Entry::Occupied(entry) => {

--- a/crates/handler/src/api.rs
+++ b/crates/handler/src/api.rs
@@ -165,12 +165,13 @@ pub trait ExecuteCommitEvm: ExecuteEvm {
 impl<CTX, INSP, INST, PRECOMPILES> ExecuteEvm
     for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
 where
-    CTX: ContextTr<Journal: JournalTr<State = EvmState>> + ContextSetters,
+    CTX: ContextTr<Journal: JournalTr<State = EvmState<<CTX::Db as Database>::StorageValue>>>
+        + ContextSetters,
     INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     type ExecutionResult = ExecutionResult<HaltReason>;
-    type State = EvmState;
+    type State = EvmState<<CTX::Db as Database>::StorageValue>;
     type Error = EVMError<<CTX::Db as Database>::Error, InvalidTransaction>;
     type Tx = <CTX as ContextTr>::Tx;
     type Block = <CTX as ContextTr>::Block;
@@ -192,7 +193,10 @@ where
     }
 
     #[inline]
-    fn replay(&mut self) -> Result<ResultAndState<HaltReason>, Self::Error> {
+    fn replay(
+        &mut self,
+    ) -> Result<ResultAndState<HaltReason, EvmState<<CTX::Db as Database>::StorageValue>>, Self::Error>
+    {
         MainnetHandler::default().run(self).map(|result| {
             let state = self.finalize();
             ResultAndState::new(result, state)
@@ -203,7 +207,10 @@ where
 impl<CTX, INSP, INST, PRECOMPILES> ExecuteCommitEvm
     for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
 where
-    CTX: ContextTr<Journal: JournalTr<State = EvmState>, Db: DatabaseCommit> + ContextSetters,
+    CTX: ContextTr<
+            Journal: JournalTr<State = EvmState<<CTX::Db as Database>::StorageValue>>,
+            Db: DatabaseCommit<<CTX::Db as Database>::StorageValue>,
+        > + ContextSetters,
     INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {

--- a/crates/handler/src/mainnet_builder.rs
+++ b/crates/handler/src/mainnet_builder.rs
@@ -84,7 +84,6 @@ mod test {
     use context::{Context, TxEnv};
     use context_interface::transaction::Authorization;
     use database::{BenchmarkDB, EEADDRESS, FFADDRESS};
-    use primitives::alloy_primitives::FlaggedStorage;
     use primitives::{hardfork::SpecId, TxKind, U256};
 
     #[test]
@@ -124,7 +123,7 @@ mod test {
         assert_eq!(auth_acc.info.nonce, 1);
         assert_eq!(
             auth_acc.storage.get(&U256::from(1)).unwrap().present_value,
-            FlaggedStorage::new_from_value(U256::from(1))
+            U256::from(1)
         );
     }
 }

--- a/crates/handler/src/mainnet_handler.rs
+++ b/crates/handler/src/mainnet_handler.rs
@@ -2,7 +2,6 @@ use super::{EvmTrError, Handler};
 use crate::{evm::FrameTr, EvmTr, FrameResult};
 use context_interface::{result::HaltReason, ContextTr, JournalTr};
 use interpreter::interpreter_action::FrameInit;
-use state::EvmState;
 
 /// Mainnet handler that implements the default [`Handler`] trait for the Evm.
 #[derive(Debug, Clone)]
@@ -13,7 +12,7 @@ pub struct MainnetHandler<CTX, ERROR, FRAME> {
 
 impl<EVM, ERROR, FRAME> Handler for MainnetHandler<EVM, ERROR, FRAME>
 where
-    EVM: EvmTr<Context: ContextTr<Journal: JournalTr<State = EvmState>>, Frame = FRAME>,
+    EVM: EvmTr<Context: ContextTr<Journal: JournalTr>, Frame = FRAME>,
     ERROR: EvmTrError<EVM>,
     // TODO `FrameResult` should be a generic trait.
     // TODO `FrameInit` should be a generic.

--- a/crates/handler/src/system_call.rs
+++ b/crates/handler/src/system_call.rs
@@ -23,7 +23,7 @@ use crate::{
     frame::EthFrame, instructions::InstructionProvider, ExecuteCommitEvm, ExecuteEvm, Handler,
     MainnetHandler, PrecompileProvider,
 };
-use context::{result::ExecResultAndState, ContextSetters, ContextTr, Evm, JournalTr, TxEnv};
+use context::{result::ExecResultAndState, ContextSetters, ContextTr, Database, Evm, JournalTr, TxEnv};
 use database_interface::DatabaseCommit;
 use interpreter::{interpreter::EthInterpreter, InterpreterResult};
 use primitives::{address, Address, Bytes, TxKind};
@@ -220,7 +220,10 @@ pub trait SystemCallCommitEvm: SystemCallEvm + ExecuteCommitEvm {
 impl<CTX, INSP, INST, PRECOMPILES> SystemCallEvm
     for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
 where
-    CTX: ContextTr<Journal: JournalTr<State = EvmState>, Tx: SystemCallTx> + ContextSetters,
+    CTX: ContextTr<
+            Journal: JournalTr<State = EvmState<<CTX::Db as Database>::StorageValue>>,
+            Tx: SystemCallTx,
+        > + ContextSetters,
     INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
@@ -244,8 +247,11 @@ where
 impl<CTX, INSP, INST, PRECOMPILES> SystemCallCommitEvm
     for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
 where
-    CTX: ContextTr<Journal: JournalTr<State = EvmState>, Db: DatabaseCommit, Tx: SystemCallTx>
-        + ContextSetters,
+    CTX: ContextTr<
+            Journal: JournalTr<State = EvmState<<CTX::Db as Database>::StorageValue>>,
+            Db: DatabaseCommit<<CTX::Db as Database>::StorageValue>,
+            Tx: SystemCallTx,
+        > + ContextSetters,
     INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
@@ -318,7 +324,7 @@ mod tests {
             output.state[&HISTORY_STORAGE_ADDRESS]
                 .storage
                 .get(&U256::from(0))
-                .map(|slot| slot.present_value.value)
+                .map(|slot| slot.present_value)
                 .unwrap_or_default(),
             U256::from_be_bytes(block_hash.0),
             "State is not updated {:?}",

--- a/crates/inspector/src/inspector.rs
+++ b/crates/inspector/src/inspector.rs
@@ -4,7 +4,7 @@ use interpreter::{
     interpreter::EthInterpreter, CallInputs, CallOutcome, CreateInputs, CreateOutcome, Interpreter,
     InterpreterTypes,
 };
-use primitives::{Address, Log, U256};
+use primitives::{Address, Log, StorageValueTr, U256};
 use state::EvmState;
 
 /// EVM hooks into execution.
@@ -174,38 +174,43 @@ where
 /// Extends the journal with additional methods that are used by the inspector.
 #[auto_impl(&mut, Box)]
 pub trait JournalExt {
+    /// The storage value type used by this journal.
+    type StorageValue: StorageValueTr;
+
     /// Get all logs from the journal.
     fn logs(&self) -> &[Log];
 
     /// Get the journal entries that are created from last checkpoint.
     /// new checkpoint is created when sub call is made.
-    fn journal(&self) -> &[JournalEntry];
+    fn journal(&self) -> &[JournalEntry<Self::StorageValue>];
 
     /// Return the current Journaled state.
-    fn evm_state(&self) -> &EvmState;
+    fn evm_state(&self) -> &EvmState<Self::StorageValue>;
 
     /// Return the mutable current Journaled state.
-    fn evm_state_mut(&mut self) -> &mut EvmState;
+    fn evm_state_mut(&mut self) -> &mut EvmState<Self::StorageValue>;
 }
 
-impl<DB: Database> JournalExt for Journal<DB> {
+impl<DB: Database, SV: StorageValueTr> JournalExt for Journal<DB, JournalEntry<SV>> {
+    type StorageValue = SV;
+
     #[inline]
     fn logs(&self) -> &[Log] {
         &self.logs
     }
 
     #[inline]
-    fn journal(&self) -> &[JournalEntry] {
-        &self.journal
+    fn journal(&self) -> &[JournalEntry<SV>] {
+        &self.inner.journal
     }
 
     #[inline]
-    fn evm_state(&self) -> &EvmState {
+    fn evm_state(&self) -> &EvmState<SV> {
         &self.state
     }
 
     #[inline]
-    fn evm_state_mut(&mut self) -> &mut EvmState {
+    fn evm_state_mut(&mut self) -> &mut EvmState<SV> {
         &mut self.state
     }
 }

--- a/crates/inspector/src/mainnet_inspect.rs
+++ b/crates/inspector/src/mainnet_inspect.rs
@@ -2,7 +2,7 @@ use crate::{
     inspect::{InspectCommitEvm, InspectEvm, InspectSystemCallEvm},
     Inspector, InspectorEvmTr, InspectorHandler, JournalExt,
 };
-use context::{ContextSetters, ContextTr, Evm, JournalTr};
+use context::{ContextSetters, ContextTr, Database, Evm, JournalTr};
 use database_interface::DatabaseCommit;
 use handler::{
     instructions::InstructionProvider, system_call::SystemCallTx, EthFrame, EvmTr, EvmTrError,
@@ -16,7 +16,7 @@ use state::EvmState;
 impl<EVM, ERROR> InspectorHandler for MainnetHandler<EVM, ERROR, EthFrame<EthInterpreter>>
 where
     EVM: InspectorEvmTr<
-        Context: ContextTr<Journal: JournalTr<State = EvmState>>,
+        Context: ContextTr<Journal: JournalTr>,
         Frame = EthFrame<EthInterpreter>,
         Inspector: Inspector<<<Self as Handler>::Evm as EvmTr>::Context, EthInterpreter>,
     >,
@@ -29,7 +29,11 @@ where
 impl<CTX, INSP, INST, PRECOMPILES> InspectEvm
     for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
 where
-    CTX: ContextSetters + ContextTr<Journal: JournalTr<State = EvmState> + JournalExt>,
+    CTX: ContextSetters
+        + ContextTr<
+            Journal: JournalTr<State = EvmState<<CTX::Db as Database>::StorageValue>>
+                + JournalExt,
+        >,
     INSP: Inspector<CTX, EthInterpreter>,
     INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
@@ -51,7 +55,11 @@ impl<CTX, INSP, INST, PRECOMPILES> InspectCommitEvm
     for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
 where
     CTX: ContextSetters
-        + ContextTr<Journal: JournalTr<State = EvmState> + JournalExt, Db: DatabaseCommit>,
+        + ContextTr<
+            Journal: JournalTr<State = EvmState<<CTX::Db as Database>::StorageValue>>
+                + JournalExt,
+            Db: DatabaseCommit<<CTX::Db as Database>::StorageValue>,
+        >,
     INSP: Inspector<CTX, EthInterpreter>,
     INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,
@@ -63,7 +71,11 @@ impl<CTX, INSP, INST, PRECOMPILES> InspectSystemCallEvm
     for Evm<CTX, INSP, INST, PRECOMPILES, EthFrame<EthInterpreter>>
 where
     CTX: ContextSetters
-        + ContextTr<Journal: JournalTr<State = EvmState> + JournalExt, Tx: SystemCallTx>,
+        + ContextTr<
+            Journal: JournalTr<State = EvmState<<CTX::Db as Database>::StorageValue>>
+                + JournalExt,
+            Tx: SystemCallTx,
+        >,
     INSP: Inspector<CTX, EthInterpreter>,
     INST: InstructionProvider<Context = CTX, InterpreterTypes = EthInterpreter>,
     PRECOMPILES: PrecompileProvider<CTX, Output = InterpreterResult>,

--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -3,12 +3,12 @@ use crate::{num_words, tri, SStoreResult, SelfDestructResult, StateLoad};
 use context_interface::{
     journaled_state::AccountLoad, transaction::AccessListItemTr as _, Transaction, TransactionType,
 };
-use primitives::{eip7702, hardfork::SpecId, U256};
+use primitives::{eip7702, hardfork::SpecId, StorageValueTr, U256};
 
 /// `SSTORE` opcode refund calculation.
 #[allow(clippy::collapsible_else_if)]
 #[inline]
-pub fn sstore_refund(spec_id: SpecId, vals: &SStoreResult) -> i64 {
+pub fn sstore_refund<SV: StorageValueTr>(spec_id: SpecId, vals: &SStoreResult<SV>) -> i64 {
     if spec_id.is_enabled_in(SpecId::ISTANBUL) {
         // EIP-3529: Reduction in refunds
         let sstore_clears_schedule = if spec_id.is_enabled_in(SpecId::LONDON) {
@@ -195,7 +195,7 @@ pub const fn sstore_cost_static(spec_id: SpecId) -> u64 {
 
 /// Dynamic gas cost for sstore.
 #[inline]
-pub const fn sstore_cost_dynamic(spec_id: SpecId, vals: &SStoreResult, is_cold: bool) -> u64 {
+pub fn sstore_cost_dynamic<SV: StorageValueTr>(spec_id: SpecId, vals: &SStoreResult<SV>, is_cold: bool) -> u64 {
     sstore_cost(spec_id, vals, is_cold) - sstore_cost_static(spec_id)
 }
 
@@ -213,16 +213,16 @@ pub const fn static_sstore_cost(spec_id: SpecId) -> u64 {
 
 /// Dynamic gas cost for sstore.
 #[inline]
-pub const fn dyn_sstore_cost(spec_id: SpecId, vals: &SStoreResult, is_cold: bool) -> u64 {
+pub fn dyn_sstore_cost<SV: StorageValueTr>(spec_id: SpecId, vals: &SStoreResult<SV>, is_cold: bool) -> u64 {
     sstore_cost(spec_id, vals, is_cold) - static_sstore_cost(spec_id)
 }
 
 /// `SSTORE` opcode cost calculation.
 #[inline]
-pub const fn sstore_cost(spec_id: SpecId, vals: &SStoreResult, is_cold: bool) -> u64 {
+pub fn sstore_cost<SV: StorageValueTr>(spec_id: SpecId, vals: &SStoreResult<SV>, is_cold: bool) -> u64 {
     if spec_id.is_enabled_in(SpecId::BERLIN) {
         // Berlin specification logic
-        let mut gas_cost = istanbul_sstore_cost::<WARM_STORAGE_READ_COST, WARM_SSTORE_RESET>(vals);
+        let mut gas_cost = istanbul_sstore_cost::<WARM_STORAGE_READ_COST, WARM_SSTORE_RESET, SV>(vals);
 
         if is_cold {
             gas_cost += COLD_SLOAD_COST;
@@ -230,7 +230,7 @@ pub const fn sstore_cost(spec_id: SpecId, vals: &SStoreResult, is_cold: bool) ->
         gas_cost
     } else if spec_id.is_enabled_in(SpecId::ISTANBUL) {
         // Istanbul logic
-        istanbul_sstore_cost::<ISTANBUL_SLOAD_GAS, SSTORE_RESET>(vals)
+        istanbul_sstore_cost::<ISTANBUL_SLOAD_GAS, SSTORE_RESET, SV>(vals)
     } else {
         // Frontier logic
         frontier_sstore_cost(vals)
@@ -239,8 +239,8 @@ pub const fn sstore_cost(spec_id: SpecId, vals: &SStoreResult, is_cold: bool) ->
 
 /// EIP-2200: Structured Definitions for Net Gas Metering
 #[inline]
-const fn istanbul_sstore_cost<const SLOAD_GAS: u64, const SSTORE_RESET_GAS: u64>(
-    vals: &SStoreResult,
+fn istanbul_sstore_cost<const SLOAD_GAS: u64, const SSTORE_RESET_GAS: u64, SV: StorageValueTr>(
+    vals: &SStoreResult<SV>,
 ) -> u64 {
     if vals.is_new_eq_present() {
         SLOAD_GAS
@@ -255,7 +255,7 @@ const fn istanbul_sstore_cost<const SLOAD_GAS: u64, const SSTORE_RESET_GAS: u64>
 
 /// Frontier sstore cost just had two cases set and reset values.
 #[inline]
-const fn frontier_sstore_cost(vals: &SStoreResult) -> u64 {
+fn frontier_sstore_cost<SV: StorageValueTr>(vals: &SStoreResult<SV>) -> u64 {
     if vals.is_present_zero() && !vals.is_new_zero() {
         SSTORE_SET
     } else {

--- a/crates/interpreter/src/instructions/host.rs
+++ b/crates/interpreter/src/instructions/host.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use context_interface::host::LoadError;
 use core::cmp::min;
+use primitives::StorageValueTr;
 use primitives::{hardfork::SpecId::*, Bytes, Log, LogData, B256, BLOCK_HASH_HISTORY, U256};
 
 use crate::InstructionContext;
@@ -245,7 +246,7 @@ pub fn sload<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionConte
                     gas!(context.interpreter, COLD_SLOAD_COST_ADDITIONAL);
                 }
 
-                *index = storage.data;
+                *index = storage.data.value();
             }
             Err(LoadError::ColdLoadSkipped) => context.interpreter.halt_oog(),
             Err(LoadError::DBError) => context.interpreter.halt_fatal(),
@@ -254,7 +255,7 @@ pub fn sload<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionConte
         let Some(storage) = context.host.sload(target, *index) else {
             return context.interpreter.halt_fatal();
         };
-        *index = storage.data;
+        *index = storage.data.value();
     };
 }
 
@@ -288,18 +289,19 @@ pub fn sstore<WIRE: InterpreterTypes, H: Host + ?Sized>(context: InstructionCont
         gas::static_sstore_cost(context.interpreter.runtime_flag.spec_id())
     );
 
+    let storage_value = H::StorageValue::from_u256(value);
     let state_load = if spec_id.is_enabled_in(BERLIN) {
         let skip_cold = context.interpreter.gas.remaining() < COLD_SLOAD_COST_ADDITIONAL;
         let res = context
             .host
-            .sstore_skip_cold_load(target, index, value, skip_cold);
+            .sstore_skip_cold_load(target, index, storage_value, skip_cold);
         match res {
             Ok(load) => load,
             Err(LoadError::ColdLoadSkipped) => return context.interpreter.halt_oog(),
             Err(LoadError::DBError) => return context.interpreter.halt_fatal(),
         }
     } else {
-        let Some(load) = context.host.sstore(target, index, value) else {
+        let Some(load) = context.host.sstore(target, index, storage_value) else {
             return context.interpreter.halt_fatal();
         };
         load

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -428,7 +428,7 @@ where
 
             // Increment sender nonce and account balance for the mint amount. Deposits
             // always persist the mint amount, even if the transaction fails.
-            let acc: &mut revm::state::Account = evm.ctx().journal_mut().load_account(caller)?.data;
+            let acc = evm.ctx().journal_mut().load_account(caller)?.data;
 
             let old_balance = acc.info.balance;
 

--- a/crates/op-revm/src/l1block.rs
+++ b/crates/op-revm/src/l1block.rs
@@ -15,6 +15,7 @@ use revm::{
         gas::{get_tokens_in_calldata, NON_ZERO_BYTE_MULTIPLIER_ISTANBUL, STANDARD_TOKEN_COST},
         Gas,
     },
+    primitives::StorageValueTr,
     primitives::{hardfork::SpecId, U256},
 };
 
@@ -67,11 +68,11 @@ impl L1BlockInfo {
             let _ = db.basic(L1_BLOCK_CONTRACT)?;
         }
 
-        let l1_base_fee = db.storage(L1_BLOCK_CONTRACT, L1_BASE_FEE_SLOT)?.value;
+        let l1_base_fee = db.storage(L1_BLOCK_CONTRACT, L1_BASE_FEE_SLOT)?.value();
 
         if !spec_id.is_enabled_in(OpSpecId::ECOTONE) {
-            let l1_fee_overhead = db.storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)?.value;
-            let l1_fee_scalar = db.storage(L1_BLOCK_CONTRACT, L1_SCALAR_SLOT)?.value;
+            let l1_fee_overhead = db.storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)?.value();
+            let l1_fee_scalar = db.storage(L1_BLOCK_CONTRACT, L1_SCALAR_SLOT)?.value();
 
             Ok(L1BlockInfo {
                 l1_base_fee: l1_base_fee.into(),
@@ -82,10 +83,10 @@ impl L1BlockInfo {
         } else {
             let l1_blob_base_fee = db
                 .storage(L1_BLOCK_CONTRACT, ECOTONE_L1_BLOB_BASE_FEE_SLOT)?
-                .value;
+                .value();
             let l1_scalars_u256: U256 = db
                 .storage(L1_BLOCK_CONTRACT, ECOTONE_L1_FEE_SCALARS_SLOT)?
-                .into();
+                .value();
             let l1_fee_scalars = l1_scalars_u256.to_be_bytes::<32>();
 
             let l1_base_fee_scalar = U256::from_be_slice(
@@ -102,13 +103,13 @@ impl L1BlockInfo {
                 && l1_fee_scalars[BASE_FEE_SCALAR_OFFSET..BLOB_BASE_FEE_SCALAR_OFFSET + 4]
                     == EMPTY_SCALARS;
             let l1_fee_overhead = empty_ecotone_scalars
-                .then(|| Ok(db.storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)?.value))
+                .then(|| Ok(db.storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)?.value()))
                 .transpose()?;
 
             if spec_id.is_enabled_in(OpSpecId::ISTHMUS) {
                 let operator_fee_scalars = db
                     .storage(L1_BLOCK_CONTRACT, OPERATOR_FEE_SCALARS_SLOT)?
-                    .value
+                    .value()
                     .to_be_bytes::<32>();
 
                 // Post-isthmus L1 block info

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -25,9 +25,11 @@ pub mod eip7825;
 pub mod eip7907;
 pub mod hardfork;
 mod once_lock;
+pub mod storage_value;
 
 pub use constants::*;
 pub use once_lock::OnceLock;
+pub use storage_value::StorageValueTr;
 
 // Reexport alloy primitives.
 
@@ -44,6 +46,10 @@ pub type StorageKey = U256;
 /// Type alias for EVM storage values (256-bit unsigned integers).
 /// Used to store data values in smart contract storage slots.
 pub type StorageValue = U256;
+
+/// Type alias for EVM transient storage values (256-bit unsigned integers).
+/// Used for EIP-1153 transient storage, which is cleared after transaction execution.
+pub type TransientStorageValue = U256;
 
 /// Optimize short address access.
 pub const SHORT_ADDRESS_CAP: usize = 300;

--- a/crates/primitives/src/storage_value.rs
+++ b/crates/primitives/src/storage_value.rs
@@ -1,0 +1,73 @@
+//! Storage value trait for generic storage in the EVM.
+//!
+//! This trait abstracts over the storage value type, allowing the EVM to be generic
+//! over `U256` (upstream) or `FlaggedStorage` (Seismic, which carries a privacy flag).
+
+use crate::U256;
+use alloy_primitives::FlaggedStorage;
+use core::fmt::Debug;
+use core::hash::Hash;
+
+/// Trait for EVM storage values.
+///
+/// Upstream revm uses `U256` for storage values. Seismic extends this to
+/// `FlaggedStorage` which carries an `is_private` flag alongside the value.
+///
+/// This trait provides the minimal interface needed by gas calculations and
+/// instruction stack operations. Seismic-specific methods (like `is_private`)
+/// stay on `FlaggedStorage` directly.
+pub trait StorageValueTr:
+    Copy + Clone + Debug + Default + PartialEq + Eq + PartialOrd + Ord + Hash + Send + Sync + 'static
+{
+    /// The zero value.
+    const ZERO: Self;
+
+    /// Extract the U256 value.
+    fn value(&self) -> U256;
+
+    /// Check if the value is zero (for gas calculation purposes).
+    /// For `FlaggedStorage`, this checks both value == 0 AND is_public.
+    fn is_zero(&self) -> bool;
+
+    /// Create from a U256 value (used by upstream SSTORE instruction).
+    fn from_u256(value: U256) -> Self;
+}
+
+impl StorageValueTr for U256 {
+    const ZERO: Self = U256::ZERO;
+
+    #[inline]
+    fn value(&self) -> U256 {
+        *self
+    }
+
+    #[inline]
+    fn is_zero(&self) -> bool {
+        self.is_zero()
+    }
+
+    #[inline]
+    fn from_u256(value: U256) -> Self {
+        value
+    }
+}
+
+impl StorageValueTr for FlaggedStorage {
+    const ZERO: Self = FlaggedStorage::ZERO;
+
+    #[inline]
+    fn value(&self) -> U256 {
+        self.value
+    }
+
+    #[inline]
+    fn is_zero(&self) -> bool {
+        // FlaggedStorage::is_zero checks is_public() && value.is_zero()
+        FlaggedStorage::is_zero(self)
+    }
+
+    #[inline]
+    fn from_u256(value: U256) -> Self {
+        FlaggedStorage::new(value, false)
+    }
+}

--- a/crates/seismic/src/api/builder.rs
+++ b/crates/seismic/src/api/builder.rs
@@ -35,8 +35,8 @@ where
     BLOCK: Block,
     TX: SeismicTxTr,
     CFG: Cfg<Spec = SeismicSpecId>,
-    DB: Database,
-    JOURNAL: JournalTr<Database = DB, State = EvmState>,
+    DB: Database<StorageValue = revm::primitives::FlaggedStorage>,
+    JOURNAL: JournalTr<Database = DB, State = EvmState<revm::primitives::FlaggedStorage>>,
 {
     type Context = Self;
 

--- a/crates/seismic/src/api/default_ctx.rs
+++ b/crates/seismic/src/api/default_ctx.rs
@@ -1,9 +1,14 @@
-use crate::{transaction::abstraction::SeismicTransaction, SeismicChain, SeismicSpecId};
+use crate::{
+    evm::SeismicEmptyDB, transaction::abstraction::SeismicTransaction, SeismicChain, SeismicSpecId,
+};
 use revm::{
     context::{BlockEnv, CfgEnv, TxEnv},
-    database_interface::EmptyDB,
-    Context, Journal, MainContext,
+    primitives::FlaggedStorage,
+    Context, Journal, JournalEntry, MainContext,
 };
+
+/// Type alias for a Seismic journal using FlaggedStorage entries.
+pub type SeismicJournal<DB> = Journal<DB, JournalEntry<FlaggedStorage>>;
 
 /// Type alias for the default context type of the SeismicEvm.
 pub type SeismicContext<DB> = Context<
@@ -11,21 +16,22 @@ pub type SeismicContext<DB> = Context<
     SeismicTransaction<TxEnv>,
     CfgEnv<SeismicSpecId>,
     DB,
-    Journal<DB>,
+    SeismicJournal<DB>,
     SeismicChain,
 >;
 
 /// Trait that allows for a default context to be created.
 pub trait DefaultSeismicContext {
     /// Create a default context.
-    fn seismic() -> SeismicContext<EmptyDB>;
+    fn seismic() -> SeismicContext<SeismicEmptyDB>;
     /// Create a context with a specific RNG keypair.
-    fn seismic_with_rng_key(rng_keypair: schnorrkel::Keypair) -> SeismicContext<EmptyDB>;
+    fn seismic_with_rng_key(rng_keypair: schnorrkel::Keypair) -> SeismicContext<SeismicEmptyDB>;
 }
 
-impl DefaultSeismicContext for SeismicContext<EmptyDB> {
+impl DefaultSeismicContext for SeismicContext<SeismicEmptyDB> {
     fn seismic() -> Self {
         Context::mainnet()
+            .with_db(SeismicEmptyDB::new())
             .with_tx(SeismicTransaction::default())
             .with_cfg(CfgEnv::new_with_spec(SeismicSpecId::MERCURY))
             .with_chain(SeismicChain::default())
@@ -33,6 +39,7 @@ impl DefaultSeismicContext for SeismicContext<EmptyDB> {
 
     fn seismic_with_rng_key(rng_keypair: schnorrkel::Keypair) -> Self {
         Context::mainnet()
+            .with_db(SeismicEmptyDB::new())
             .with_tx(SeismicTransaction::default())
             .with_cfg(CfgEnv::new_with_spec(SeismicSpecId::MERCURY))
             .with_chain(SeismicChain::with_live_rng_key(Some(rng_keypair)))

--- a/crates/seismic/src/api/exec.rs
+++ b/crates/seismic/src/api/exec.rs
@@ -22,7 +22,7 @@ use revm::{
 // Type alias for Seismic context
 pub trait SeismicContextTr:
     ContextTr<
-    Journal: JournalTr<State = EvmState>,
+    Journal: JournalTr<State = EvmState<revm::primitives::FlaggedStorage>>,
     Tx: SeismicTxTr,
     Cfg: Cfg<Spec = SeismicSpecId>,
     Chain = SeismicChain,
@@ -32,7 +32,7 @@ pub trait SeismicContextTr:
 
 impl<T> SeismicContextTr for T where
     T: ContextTr<
-        Journal: JournalTr<State = EvmState>,
+        Journal: JournalTr<State = EvmState<revm::primitives::FlaggedStorage>>,
         Tx: SeismicTxTr,
         Cfg: Cfg<Spec = SeismicSpecId>,
         Chain = SeismicChain,
@@ -51,7 +51,7 @@ where
 {
     type Tx = <CTX as ContextTr>::Tx;
     type Block = <CTX as ContextTr>::Block;
-    type State = EvmState;
+    type State = EvmState<revm::primitives::FlaggedStorage>;
     type Error = SeismicError<CTX>;
     type ExecutionResult = ExecutionResult<SeismicHaltReason>;
 
@@ -83,7 +83,7 @@ where
 impl<CTX, INSP, PRECOMPILE> ExecuteCommitEvm
     for SeismicEvm<CTX, INSP, SeismicInstructions<EthInterpreter, CTX>, PRECOMPILE>
 where
-    CTX: SeismicContextTr<Db: DatabaseCommit> + ContextSetters,
+    CTX: SeismicContextTr<Db: DatabaseCommit<revm::primitives::FlaggedStorage>> + ContextSetters,
     PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
     fn commit(&mut self, state: Self::State) {
@@ -114,7 +114,7 @@ where
 impl<CTX, INSP, PRECOMPILE> InspectCommitEvm
     for SeismicEvm<CTX, INSP, SeismicInstructions<EthInterpreter, CTX>, PRECOMPILE>
 where
-    CTX: SeismicContextTr<Journal: JournalExt, Db: DatabaseCommit> + ContextSetters,
+    CTX: SeismicContextTr<Journal: JournalExt, Db: DatabaseCommit<revm::primitives::FlaggedStorage>> + ContextSetters,
     INSP: Inspector<CTX, EthInterpreter>,
     PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {

--- a/crates/seismic/src/evm.rs
+++ b/crates/seismic/src/evm.rs
@@ -3,17 +3,27 @@ use crate::{
     instructions::instruction_provider::SeismicInstructions,
     precompiles::{mercury_with_extra, SeismicPrecompiles},
 };
+use core::convert::Infallible;
 use revm::{
     context::{ContextError, ContextSetters, ContextTr, Evm, FrameStack},
+    database::CacheDB,
+    database_interface::EmptyDBTyped,
     handler::{
         instructions::InstructionProvider, EthFrame, EvmTr, FrameInitOrResult, FrameTr,
         ItemOrResult, PrecompileProvider,
     },
     inspector::{InspectorEvmTr, JournalExt},
-    interpreter::{interpreter::EthInterpreter, InterpreterResult},
+    interpreter::{interpreter::EthInterpreter, Host, InterpreterResult},
     precompile::Precompiles,
+    primitives::FlaggedStorage,
     Database, Inspector,
 };
+
+/// EmptyDB with FlaggedStorage for Seismic.
+pub type SeismicEmptyDB = EmptyDBTyped<Infallible, FlaggedStorage>;
+
+/// InMemoryDB with FlaggedStorage for Seismic.
+pub type SeismicInMemoryDB = CacheDB<SeismicEmptyDB, FlaggedStorage>;
 
 pub struct SeismicEvm<
     CTX,
@@ -23,7 +33,7 @@ pub struct SeismicEvm<
     F = EthFrame<EthInterpreter>,
 >(pub Evm<CTX, INSP, I, P, F>);
 
-impl<CTX: SeismicContextTr, INSP>
+impl<CTX: SeismicContextTr + Host<StorageValue = FlaggedStorage>, INSP>
     SeismicEvm<CTX, INSP, SeismicInstructions<EthInterpreter, CTX>, SeismicPrecompiles<CTX>>
 {
     pub fn new(ctx: CTX, inspector: INSP) -> Self {
@@ -200,9 +210,10 @@ mod tests {
     };
     use anyhow::bail;
     use rand_core::RngCore;
-    use revm::context::result::{ExecutionResult, Output, ResultAndState};
+    use revm::context::result::{ExecResultAndState, ExecutionResult, Output};
+    use revm::state::EvmState;
     use revm::context::{BlockEnv, CfgEnv, Context, ContextTr, JournalTr, TxEnv};
-    use revm::database::{EmptyDB, InMemoryDB, BENCH_CALLER};
+    use revm::database::BENCH_CALLER;
     use revm::interpreter::gas::calculate_initial_tx_gas;
     use revm::interpreter::InitialAndFloorGas;
     use revm::precompile::u64_to_address;
@@ -256,13 +267,13 @@ mod tests {
 
     fn deploy_contract_with_bytecode(
         bytecode: Bytes,
-    ) -> anyhow::Result<(SeismicContext<InMemoryDB>, Address)> {
+    ) -> anyhow::Result<(SeismicContext<SeismicInMemoryDB>, Address)> {
         let ctx = Context::seismic()
             .modify_tx_chained(|tx| {
                 tx.base.kind = TxKind::Create;
                 tx.base.data = bytecode.clone();
             })
-            .with_db(InMemoryDB::default());
+            .with_db(SeismicInMemoryDB::default());
 
         let mut evm = ctx.build_seismic_evm();
         let receipt = evm.replay_commit()?;
@@ -278,12 +289,12 @@ mod tests {
     }
 
     fn prepare_call(
-        ctx: SeismicContext<InMemoryDB>,
+        ctx: SeismicContext<SeismicInMemoryDB>,
         contract: Address,
         selector: Bytes,
         gas_limit: u64,
         gas_price: u64,
-    ) -> SeismicContext<InMemoryDB> {
+    ) -> SeismicContext<SeismicInMemoryDB> {
         let mut ctx = ctx;
 
         ctx.modify_tx(|tx| {
@@ -299,7 +310,7 @@ mod tests {
     }
 
     fn assert_storage_access_error(
-        result: &ResultAndState<SeismicHaltReason>,
+        result: &ExecResultAndState<ExecutionResult<SeismicHaltReason>, EvmState<FlaggedStorage>>,
         expected_reason: SeismicHaltReason,
         starting_balance: u64,
         gas_limit: u64,
@@ -388,14 +399,7 @@ mod tests {
         spec: SeismicSpecId,
         bytes_requested: u32,
         personalization: Vec<u8>,
-    ) -> Context<
-        BlockEnv,
-        SeismicTransaction<TxEnv>,
-        CfgEnv<SeismicSpecId>,
-        EmptyDB,
-        Journal<EmptyDB>,
-        SeismicChain,
-    > {
+    ) -> SeismicContext<SeismicEmptyDB> {
         let mut input_data = bytes_requested.to_be_bytes().to_vec();
         input_data.extend(personalization.clone());
         let input = Bytes::from(input_data);
@@ -466,5 +470,75 @@ mod tests {
             expected_root_rng_state,
             "root rng state should be as expected"
         );
+    }
+
+    #[test]
+    fn test_insert_account_storage_private() {
+        use revm::database::CacheDB;
+        use revm::state::AccountInfo;
+
+        let account = Address::with_last_byte(42);
+        let nonce = 42;
+        let mut init_state = CacheDB::new(SeismicEmptyDB::default());
+        init_state.insert_account_info(
+            account,
+            AccountInfo {
+                nonce,
+                ..Default::default()
+            },
+        );
+
+        let (key, value) = (
+            U256::from(123),
+            FlaggedStorage::from(U256::from(456)).mark_private(),
+        );
+        let mut new_state = CacheDB::new(init_state);
+        new_state
+            .insert_account_storage(account, key, value)
+            .unwrap();
+
+        assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);
+        assert_eq!(new_state.storage(account, key), Ok(value));
+    }
+
+    #[test]
+    fn test_replace_account_storage_private() {
+        use revm::database::CacheDB;
+        use revm::state::AccountInfo;
+
+        let account = Address::with_last_byte(42);
+        let nonce = 42;
+        let mut init_state = CacheDB::new(SeismicEmptyDB::default());
+        init_state.insert_account_info(
+            account,
+            AccountInfo {
+                nonce,
+                ..Default::default()
+            },
+        );
+
+        let (key0, value0) = (
+            U256::from(123),
+            FlaggedStorage::from(U256::from(456)).mark_private(),
+        );
+        let (key1, value1) = (
+            U256::from(789),
+            FlaggedStorage::from(U256::from(999)).mark_private(),
+        );
+        init_state
+            .insert_account_storage(account, key0, value0)
+            .unwrap();
+
+        let mut new_state = CacheDB::new(init_state);
+        new_state
+            .replace_account_storage(account, [(key1, value1)].into())
+            .unwrap();
+
+        assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);
+        assert_eq!(
+            new_state.storage(account, key0),
+            Ok(FlaggedStorage::ZERO)
+        );
+        assert_eq!(new_state.storage(account, key1), Ok(value1));
     }
 }

--- a/crates/seismic/src/handler.rs
+++ b/crates/seismic/src/handler.rs
@@ -133,10 +133,11 @@ mod tests {
     )]
 
     use super::*;
-    use crate::{api::default_ctx::SeismicContext, DefaultSeismicContext, SeismicBuilder};
+    use crate::{
+        api::default_ctx::SeismicContext, evm::SeismicEmptyDB, DefaultSeismicContext, SeismicBuilder,
+    };
     use revm::{
         context::{result::EVMError, Context},
-        database_interface::EmptyDB,
         handler::EthFrame,
         interpreter::{CallOutcome, Gas, InstructionResult, InterpreterResult},
         primitives::Bytes,
@@ -144,7 +145,7 @@ mod tests {
 
     /// Creates frame result.
     fn call_last_frame_return(
-        ctx: SeismicContext<EmptyDB>,
+        ctx: SeismicContext<SeismicEmptyDB>,
         instruction_result: InstructionResult,
         gas: Gas,
     ) -> Gas {

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -1,5 +1,6 @@
 use crate::{check, SeismicHaltReason, SeismicHost};
 use revm::primitives::hardfork::SpecId::*;
+use revm::primitives::FlaggedStorage;
 use revm::{
     context::host::LoadError,
     interpreter::{
@@ -45,7 +46,7 @@ pub fn sload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
                 if storage.is_cold {
                     gas!(context.interpreter, COLD_SLOAD_COST_ADDITIONAL);
                 }
-                if storage.is_private {
+                if storage.data.is_private {
                     context.interpreter.halt_fatal();
                     context
                         .host
@@ -53,7 +54,7 @@ pub fn sload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
                     return;
                 }
 
-                *index = storage.data;
+                *index = storage.data.value;
             }
             Err(LoadError::ColdLoadSkipped) => context.interpreter.halt_oog(),
             Err(LoadError::DBError) => context.interpreter.halt_fatal(),
@@ -62,14 +63,14 @@ pub fn sload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
         let Some(storage) = context.host.sload(target, *index) else {
             return context.interpreter.halt_fatal();
         };
-        if storage.is_private {
+        if storage.data.is_private {
             context.interpreter.halt_fatal();
             context
                 .host
                 .set_halt_reason(SeismicHaltReason::InvalidPrivateStorageAccess);
             return;
         }
-        *index = storage.data;
+        *index = storage.data.value;
     };
 }
 
@@ -94,7 +95,7 @@ pub fn cload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
     let Some(storage) = context.host.sload(target, *index) else {
         return context.interpreter.halt_fatal();
     };
-    *index = storage.data;
+    *index = storage.data.value;
 }
 
 /// Implements the SSTORE instruction.
@@ -132,16 +133,22 @@ pub fn sstore<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
 
     let state_load = if spec_id.is_enabled_in(BERLIN) {
         let skip_cold = context.interpreter.gas.remaining() < COLD_SLOAD_COST_ADDITIONAL;
-        let res = context
-            .host
-            .sstore_skip_cold_load(target, index, value, skip_cold);
+        let res = context.host.sstore_skip_cold_load(
+            target,
+            index,
+            FlaggedStorage::new(value, false),
+            skip_cold,
+        );
         match res {
             Ok(load) => load,
             Err(LoadError::ColdLoadSkipped) => return context.interpreter.halt_oog(),
             Err(LoadError::DBError) => return context.interpreter.halt_fatal(),
         }
     } else {
-        let Some(load) = context.host.sstore(target, index, value) else {
+        let Some(load) = context
+            .host
+            .sstore(target, index, FlaggedStorage::new(value, false))
+        else {
             return context.interpreter.halt_fatal();
         };
         load
@@ -214,7 +221,10 @@ pub fn cstore<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
         + COLD_SLOAD_COST_ADDITIONAL;
     gas!(context.interpreter, flat_gas);
 
-    let result = context.host.cstore(target, index, value, false);
+    let result =
+        context
+            .host
+            .sstore_skip_cold_load(target, index, FlaggedStorage::new(value, true), false);
     match result {
         Ok(state_load) => {
             // Privacy check: CSTORE cannot overwrite non-zero public slots
@@ -261,8 +271,8 @@ mod tests {
         clippy::panic
     )]
 
-    use crate::SeismicSpecId;
     use crate::instructions::seismic_host::SeismicDummyHost;
+    use crate::SeismicSpecId;
 
     use super::*;
     use revm::context_interface::context::SStoreResult;
@@ -403,13 +413,13 @@ mod tests {
             WARM_STORAGE_READ_COST + CSTORE_FIXED_GAS + COLD_SLOAD_COST_ADDITIONAL;
 
         struct MockCstoreHost {
-            sstore_result: SStoreResult,
+            sstore_result: SStoreResult<FlaggedStorage>,
             #[allow(dead_code)]
             is_cold: bool,
         }
 
         impl MockCstoreHost {
-            fn new(sstore_result: SStoreResult, is_cold: bool) -> Self {
+            fn new(sstore_result: SStoreResult<FlaggedStorage>, is_cold: bool) -> Self {
                 Self {
                     sstore_result,
                     is_cold,
@@ -468,6 +478,8 @@ mod tests {
         }
 
         impl Host for MockCstoreHost {
+            type StorageValue = FlaggedStorage;
+
             fn basefee(&self) -> U256 {
                 U256::ZERO
             }
@@ -522,12 +534,6 @@ mod tests {
             fn tload(&mut self, _: Address, _: U256) -> U256 {
                 U256::ZERO
             }
-            fn sstore(&mut self, _: Address, _: U256, _: U256) -> Option<StateLoad<SStoreResult>> {
-                None
-            }
-            fn sload(&mut self, _: Address, _: U256) -> Option<StateLoad<U256>> {
-                None
-            }
             fn balance(&mut self, _: Address) -> Option<StateLoad<U256>> {
                 None
             }
@@ -552,34 +558,17 @@ mod tests {
                 &mut self,
                 _: Address,
                 _: U256,
-                _: U256,
+                _: FlaggedStorage,
                 _: bool,
-            ) -> Result<StateLoad<SStoreResult>, LoadError> {
-                Err(LoadError::DBError)
+            ) -> Result<StateLoad<SStoreResult<FlaggedStorage>>, LoadError> {
+                Ok(StateLoad::new(self.sstore_result.clone(), false))
             }
             fn sload_skip_cold_load(
                 &mut self,
                 _: Address,
                 _: U256,
                 _: bool,
-            ) -> Result<StateLoad<U256>, LoadError> {
-                Err(LoadError::DBError)
-            }
-            fn cstore(
-                &mut self,
-                _: Address,
-                _: U256,
-                _: U256,
-                _: bool,
-            ) -> Result<StateLoad<SStoreResult>, LoadError> {
-                Ok(StateLoad::new(self.sstore_result.clone(), false, true))
-            }
-            fn cload(
-                &mut self,
-                _: Address,
-                _: U256,
-                _: bool,
-            ) -> Result<StateLoad<U256>, LoadError> {
+            ) -> Result<StateLoad<FlaggedStorage>, LoadError> {
                 Err(LoadError::DBError)
             }
         }
@@ -795,6 +784,8 @@ mod tests {
         }
 
         impl Host for MockStorageHost {
+            type StorageValue = FlaggedStorage;
+
             fn basefee(&self) -> U256 {
                 U256::ZERO
             }
@@ -850,90 +841,29 @@ mod tests {
                 U256::ZERO
             }
 
-            fn sload(&mut self, _: Address, _: U256) -> Option<StateLoad<U256>> {
-                Some(StateLoad::new(
-                    self.storage_state.value,
-                    false,
-                    self.storage_state.is_private,
-                ))
-            }
-
             fn sload_skip_cold_load(
                 &mut self,
                 _: Address,
                 _: U256,
                 _: bool,
-            ) -> Result<StateLoad<U256>, LoadError> {
-                Ok(StateLoad::new(
-                    self.storage_state.value,
-                    false,
-                    self.storage_state.is_private,
-                ))
-            }
-
-            fn sstore(
-                &mut self,
-                _: Address,
-                _: U256,
-                new_value: U256,
-            ) -> Option<StateLoad<SStoreResult>> {
-                Some(StateLoad::new(
-                    SStoreResult {
-                        original_value: self.storage_state,
-                        present_value: self.storage_state,
-                        new_value: FlaggedStorage::new(new_value, false),
-                    },
-                    false,
-                    false,
-                ))
+            ) -> Result<StateLoad<FlaggedStorage>, LoadError> {
+                Ok(StateLoad::new(self.storage_state, false))
             }
 
             fn sstore_skip_cold_load(
                 &mut self,
                 _: Address,
                 _: U256,
-                new_value: U256,
+                new_value: FlaggedStorage,
                 _: bool,
-            ) -> Result<StateLoad<SStoreResult>, LoadError> {
+            ) -> Result<StateLoad<SStoreResult<FlaggedStorage>>, LoadError> {
                 Ok(StateLoad::new(
                     SStoreResult {
                         original_value: self.storage_state,
                         present_value: self.storage_state,
-                        new_value: FlaggedStorage::new(new_value, false),
+                        new_value,
                     },
                     false,
-                    false,
-                ))
-            }
-
-            fn cstore(
-                &mut self,
-                _: Address,
-                _: U256,
-                new_value: U256,
-                _: bool,
-            ) -> Result<StateLoad<SStoreResult>, LoadError> {
-                Ok(StateLoad::new(
-                    SStoreResult {
-                        original_value: self.storage_state,
-                        present_value: self.storage_state,
-                        new_value: FlaggedStorage::new(new_value, true),
-                    },
-                    false,
-                    true,
-                ))
-            }
-
-            fn cload(
-                &mut self,
-                _: Address,
-                _: U256,
-                _: bool,
-            ) -> Result<StateLoad<U256>, LoadError> {
-                Ok(StateLoad::new(
-                    self.storage_state.value,
-                    false,
-                    self.storage_state.is_private,
                 ))
             }
 

--- a/crates/seismic/src/instructions/seismic_host.rs
+++ b/crates/seismic/src/instructions/seismic_host.rs
@@ -3,13 +3,13 @@ use revm::{
     context_interface::{context::ContextError, journaled_state::AccountLoad, Database},
     database::EmptyDB,
     interpreter::{host::DummyHost, Host, SStoreResult, SelfDestructResult, StateLoad},
-    primitives::{Address, Bytes, Log, StorageKey, StorageValue, B256, U256},
+    primitives::{Address, Bytes, FlaggedStorage, Log, StorageKey, B256, U256},
 };
 
 use crate::{api::exec::SeismicContextTr, SeismicHaltReason};
 
 // Extend Host with an associated Db type and error() method
-pub trait SeismicHost: Host {
+pub trait SeismicHost: Host<StorageValue = FlaggedStorage> {
     type Db: Database;
 
     fn ctx_error(&mut self) -> &mut Result<(), ContextError<<Self::Db as Database>::Error>>;
@@ -27,7 +27,7 @@ pub trait SeismicHost: Host {
 
 impl<CTX> SeismicHost for CTX
 where
-    CTX: SeismicContextTr + Host,
+    CTX: SeismicContextTr + Host<StorageValue = FlaggedStorage>,
 {
     type Db = CTX::Db;
 
@@ -65,6 +65,8 @@ impl SeismicHost for SeismicDummyHost {
 }
 
 impl Host for SeismicDummyHost {
+    type StorageValue = FlaggedStorage;
+
     fn basefee(&self) -> U256 {
         self.dummy_host.basefee()
     }
@@ -133,38 +135,6 @@ impl Host for SeismicDummyHost {
         self.dummy_host.log(_log)
     }
 
-    fn cstore(
-        &mut self,
-        address: Address,
-        key: U256,
-        value: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError> {
-        self.dummy_host.cstore(address, key, value, skip_cold_load)
-    }
-
-    fn cload(
-        &mut self,
-        address: Address,
-        key: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, LoadError> {
-        self.dummy_host.cload(address, key, skip_cold_load)
-    }
-
-    fn sstore(
-        &mut self,
-        address: Address,
-        key: U256,
-        value: U256,
-    ) -> Option<StateLoad<SStoreResult>> {
-        self.dummy_host.sstore(address, key, value)
-    }
-
-    fn sload(&mut self, address: Address, key: U256) -> Option<StateLoad<U256>> {
-        self.dummy_host.sload(address, key)
-    }
-
     fn tstore(&mut self, address: Address, key: U256, value: U256) {
         self.dummy_host.tstore(address, key, value)
     }
@@ -202,9 +172,9 @@ impl Host for SeismicDummyHost {
         &mut self,
         _address: Address,
         _key: StorageKey,
-        _value: StorageValue,
+        _value: FlaggedStorage,
         _skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, LoadError> {
+    ) -> Result<StateLoad<SStoreResult<FlaggedStorage>>, LoadError> {
         Err(LoadError::DBError)
     }
 
@@ -213,7 +183,7 @@ impl Host for SeismicDummyHost {
         _address: Address,
         _key: StorageKey,
         _skip_cold_load: bool,
-    ) -> Result<StateLoad<StorageValue>, LoadError> {
+    ) -> Result<StateLoad<FlaggedStorage>, LoadError> {
         Err(LoadError::DBError)
     }
 }

--- a/crates/seismic/src/lib.rs
+++ b/crates/seismic/src/lib.rs
@@ -17,10 +17,10 @@ pub mod transaction;
 
 pub use api::{
     builder::SeismicBuilder,
-    default_ctx::{DefaultSeismicContext, SeismicContext},
+    default_ctx::{DefaultSeismicContext, SeismicContext, SeismicJournal},
 };
 pub use chain::seismic_chain::SeismicChain;
-pub use evm::SeismicEvm;
+pub use evm::{SeismicEmptyDB, SeismicEvm, SeismicInMemoryDB};
 pub use instructions::seismic_host::SeismicHost;
 pub use result::SeismicHaltReason;
 pub use spec::*;

--- a/crates/seismic/src/precompiles.rs
+++ b/crates/seismic/src/precompiles.rs
@@ -210,8 +210,8 @@ mod tests {
     )]
 
     use super::*;
+    use crate::evm::SeismicEmptyDB;
     use revm::{
-        database::EmptyDB,
         interpreter::{CallScheme, CallValue},
         primitives::{hex, U256},
     };
@@ -221,7 +221,7 @@ mod tests {
     #[test]
     fn test_cancun_precompiles_in_mercury() {
         assert_eq!(
-            mercury::<SeismicContext<EmptyDB>>()
+            mercury::<SeismicContext<SeismicEmptyDB>>()
                 .0
                 .difference(Precompiles::prague())
                 .len(),
@@ -232,10 +232,10 @@ mod tests {
     #[test]
     fn test_default_precompiles_is_latest() {
         let latest =
-            SeismicPrecompiles::<SeismicContext<EmptyDB>>::new_with_spec(SeismicSpecId::default())
+            SeismicPrecompiles::<SeismicContext<SeismicEmptyDB>>::new_with_spec(SeismicSpecId::default())
                 .inner
                 .precompiles;
-        let default = SeismicPrecompiles::<SeismicContext<EmptyDB>>::default()
+        let default = SeismicPrecompiles::<SeismicContext<SeismicEmptyDB>>::default()
             .inner
             .precompiles;
         assert_eq!(latest.len(), default.len());
@@ -261,8 +261,8 @@ mod tests {
     #[test]
     fn test_seismic_precompiles_rng() {
         let mut precompiles =
-            SeismicPrecompiles::<SeismicContext<EmptyDB>>::new_with_spec(SeismicSpecId::MERCURY);
-        let mut context = SeismicContext::<EmptyDB>::seismic();
+            SeismicPrecompiles::<SeismicContext<SeismicEmptyDB>>::new_with_spec(SeismicSpecId::MERCURY);
+        let mut context = SeismicContext::<SeismicEmptyDB>::seismic();
         let rng_address = *precompiles
             .stateful_precompiles
             .addresses()
@@ -334,7 +334,7 @@ mod tests {
     fn test_seismic_precompiles_warm_addresses() {
         // Setup the SeismicPrecompiles
         let precompiles =
-            SeismicPrecompiles::<SeismicContext<EmptyDB>>::new_with_spec(SeismicSpecId::MERCURY);
+            SeismicPrecompiles::<SeismicContext<SeismicEmptyDB>>::new_with_spec(SeismicSpecId::MERCURY);
 
         // Get all warm addresses
         let warm_addresses: Vec<Address> = precompiles.warm_addresses().collect();

--- a/crates/seismic/src/precompiles/rng/precompile.rs
+++ b/crates/seismic/src/precompiles/rng/precompile.rs
@@ -189,12 +189,12 @@ mod tests {
         clippy::useless_conversion
     )]
 
+    use crate::evm::SeismicEmptyDB;
     use crate::transaction::abstraction::SeismicTransaction;
     use crate::{DefaultSeismicContext, SeismicContext};
     use std::vec;
 
     use super::*;
-    use revm::database::EmptyDB;
     use revm::precompile::PrecompileError;
     use revm::primitives::{Bytes, B256};
     use revm::Context;
@@ -205,8 +205,8 @@ mod tests {
     ) -> (
         u64,
         Bytes,
-        SeismicContext<EmptyDB>,
-        StatefulPrecompileWithAddress<SeismicContext<EmptyDB>>,
+        SeismicContext<SeismicEmptyDB>,
+        StatefulPrecompileWithAddress<SeismicContext<SeismicEmptyDB>>,
     ) {
         let gas_limit = 6000;
 
@@ -225,7 +225,7 @@ mod tests {
         let context = Context::seismic().with_tx(tx);
 
         // Get precompile function
-        let precompile = rng_precompile::<SeismicContext<EmptyDB>>;
+        let precompile = rng_precompile::<SeismicContext<SeismicEmptyDB>>;
 
         (gas_limit, input, context, precompile())
     }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -14,23 +14,23 @@ pub use types::{EvmState, EvmStorage, TransientStorage};
 
 use bitflags::bitflags;
 use primitives::hardfork::SpecId;
-use primitives::{HashMap, StorageKey};
+use primitives::{HashMap, StorageKey, StorageValueTr, U256};
 
 /// Account type used inside Journal to track changed to state.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Account {
+pub struct Account<SV: StorageValueTr = U256> {
     /// Balance, nonce, and code
     pub info: AccountInfo,
     /// Transaction id, used to track when account was toched/loaded into journal.
     pub transaction_id: usize,
     /// Storage cache
-    pub storage: EvmStorage,
+    pub storage: EvmStorage<SV>,
     /// Account status flags
     pub status: AccountStatus,
 }
 
-impl Account {
+impl<SV: StorageValueTr> Account<SV> {
     /// Creates new account and mark it as non existing.
     pub fn new_not_existing(transaction_id: usize) -> Self {
         Self {
@@ -197,7 +197,7 @@ impl Account {
     /// Returns an iterator over the storage slots that have been changed.
     ///
     /// See also [EvmStorageSlot::is_changed].
-    pub fn changed_storage_slots(&self) -> impl Iterator<Item = (&StorageKey, &EvmStorageSlot)> {
+    pub fn changed_storage_slots(&self) -> impl Iterator<Item = (&StorageKey, &EvmStorageSlot<SV>)> {
         self.storage.iter().filter(|(_, slot)| slot.is_changed())
     }
 
@@ -210,7 +210,7 @@ impl Account {
     /// Populates storage from an iterator of storage slots and returns self for method chaining.
     pub fn with_storage<I>(mut self, storage_iter: I) -> Self
     where
-        I: Iterator<Item = (StorageKey, EvmStorageSlot)>,
+        I: Iterator<Item = (StorageKey, EvmStorageSlot<SV>)>,
     {
         for (key, slot) in storage_iter {
             self.storage.insert(key, slot);
@@ -256,7 +256,7 @@ impl Account {
     }
 }
 
-impl From<AccountInfo> for Account {
+impl<SV: StorageValueTr> From<AccountInfo> for Account<SV> {
     fn from(info: AccountInfo) -> Self {
         Self {
             info,
@@ -335,11 +335,11 @@ impl Default for AccountStatus {
 /// This type keeps track of the current value of a storage slot.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct EvmStorageSlot {
+pub struct EvmStorageSlot<SV: StorageValueTr = primitives::U256> {
     /// Original value of the storage slot.
-    pub original_value: FlaggedStorage,
+    pub original_value: SV,
     /// Present value of the storage slot.
-    pub present_value: FlaggedStorage,
+    pub present_value: SV,
     /// Represents if the storage slot is cold.
     /// Transaction id, used to track when storage slot was made warm.
     pub transaction_id: usize,
@@ -347,9 +347,9 @@ pub struct EvmStorageSlot {
     pub is_cold: bool,
 }
 
-impl EvmStorageSlot {
+impl<SV: StorageValueTr> EvmStorageSlot<SV> {
     /// Creates a new _unchanged_ `EvmStorageSlot` for the given value.
-    pub fn new(original: FlaggedStorage, transaction_id: usize) -> Self {
+    pub fn new(original: SV, transaction_id: usize) -> Self {
         Self {
             original_value: original,
             present_value: original,
@@ -359,11 +359,7 @@ impl EvmStorageSlot {
     }
 
     /// Creates a new _changed_ `EvmStorageSlot`.
-    pub fn new_changed(
-        original_value: FlaggedStorage,
-        present_value: FlaggedStorage,
-        transaction_id: usize,
-    ) -> Self {
+    pub fn new_changed(original_value: SV, present_value: SV, transaction_id: usize) -> Self {
         Self {
             original_value,
             present_value,
@@ -378,13 +374,13 @@ impl EvmStorageSlot {
 
     /// Returns the original value of the storage slot.
     #[inline]
-    pub fn original_value(&self) -> FlaggedStorage {
+    pub fn original_value(&self) -> SV {
         self.original_value
     }
 
     /// Returns the current value of the storage slot.
     #[inline]
-    pub fn present_value(&self) -> FlaggedStorage {
+    pub fn present_value(&self) -> SV {
         self.present_value
     }
 
@@ -421,7 +417,7 @@ mod tests {
 
     #[test]
     fn account_is_empty_balance() {
-        let mut account = Account::default();
+        let mut account = Account::<FlaggedStorage>::default();
         assert!(account.is_empty());
 
         account.info.balance = U256::from(1);
@@ -433,7 +429,7 @@ mod tests {
 
     #[test]
     fn account_is_empty_nonce() {
-        let mut account = Account::default();
+        let mut account = Account::<FlaggedStorage>::default();
         assert!(account.is_empty());
 
         account.info.nonce = 1;
@@ -445,7 +441,7 @@ mod tests {
 
     #[test]
     fn account_is_empty_code_hash() {
-        let mut account = Account::default();
+        let mut account = Account::<FlaggedStorage>::default();
         assert!(account.is_empty());
 
         account.info.code_hash = [1; 32].into();
@@ -460,7 +456,7 @@ mod tests {
 
     #[test]
     fn account_state() {
-        let mut account = Account::default();
+        let mut account = Account::<FlaggedStorage>::default();
 
         assert!(!account.is_touched());
         assert!(!account.is_selfdestructed());
@@ -480,7 +476,7 @@ mod tests {
 
     #[test]
     fn account_is_cold() {
-        let mut account = Account::default();
+        let mut account = Account::<FlaggedStorage>::default();
 
         // Account is not cold by default
         assert!(!account.status.contains(crate::AccountStatus::Cold));
@@ -501,7 +497,7 @@ mod tests {
     #[test]
     fn test_account_with_info() {
         let info = AccountInfo::default();
-        let account = Account::default().with_info(info.clone());
+        let account = Account::<FlaggedStorage>::default().with_info(info.clone());
 
         assert_eq!(account.info, info);
         assert_eq!(account.storage, HashMap::default());
@@ -510,7 +506,7 @@ mod tests {
 
     #[test]
     fn test_account_with_storage() {
-        let mut storage = HashMap::<StorageKey, EvmStorageSlot>::default();
+        let mut storage = HashMap::<StorageKey, EvmStorageSlot<FlaggedStorage>>::default();
         let key1 = StorageKey::from(1);
         let key2 = StorageKey::from(2);
         let slot1 = EvmStorageSlot::new(FlaggedStorage::from(10), 0);
@@ -519,7 +515,7 @@ mod tests {
         storage.insert(key1, slot1.clone());
         storage.insert(key2, slot2.clone());
 
-        let account = Account::default().with_storage(storage.clone().into_iter());
+        let account = Account::<FlaggedStorage>::default().with_storage(storage.clone().into_iter());
 
         assert_eq!(account.storage.len(), 2);
         assert_eq!(account.storage.get(&key1), Some(&slot1));
@@ -528,7 +524,7 @@ mod tests {
 
     #[test]
     fn test_account_with_selfdestruct_mark() {
-        let account = Account::default().with_selfdestruct_mark();
+        let account = Account::<FlaggedStorage>::default().with_selfdestruct_mark();
 
         assert!(account.is_selfdestructed());
         assert!(!account.is_touched());
@@ -537,7 +533,7 @@ mod tests {
 
     #[test]
     fn test_account_with_touched_mark() {
-        let account = Account::default().with_touched_mark();
+        let account = Account::<FlaggedStorage>::default().with_touched_mark();
 
         assert!(!account.is_selfdestructed());
         assert!(account.is_touched());
@@ -546,7 +542,7 @@ mod tests {
 
     #[test]
     fn test_account_with_created_mark() {
-        let account = Account::default().with_created_mark();
+        let account = Account::<FlaggedStorage>::default().with_created_mark();
 
         assert!(!account.is_selfdestructed());
         assert!(!account.is_touched());
@@ -555,7 +551,7 @@ mod tests {
 
     #[test]
     fn test_account_with_cold_mark() {
-        let account = Account::default().with_cold_mark();
+        let account = Account::<FlaggedStorage>::default().with_cold_mark();
 
         assert!(account.status.contains(AccountStatus::Cold));
     }
@@ -584,7 +580,7 @@ mod tests {
     #[test]
     fn test_account_with_warm_mark() {
         // Start with a cold account
-        let cold_account = Account::default().with_cold_mark();
+        let cold_account = Account::<FlaggedStorage>::default().with_cold_mark();
         assert!(cold_account.status.contains(AccountStatus::Cold));
 
         // Use with_warm_mark to warm it
@@ -603,7 +599,7 @@ mod tests {
     #[test]
     fn test_account_with_warm() {
         // Start with a cold account
-        let cold_account = Account::default().with_cold_mark();
+        let cold_account = Account::<FlaggedStorage>::default().with_cold_mark();
         assert!(cold_account.status.contains(AccountStatus::Cold));
 
         // Use with_warm to warm it
@@ -622,11 +618,11 @@ mod tests {
 
         let slot_key = StorageKey::from(42);
         let slot_value = EvmStorageSlot::new(FlaggedStorage::from(123), 0);
-        let mut storage = HashMap::<StorageKey, EvmStorageSlot>::default();
+        let mut storage = HashMap::<StorageKey, EvmStorageSlot<FlaggedStorage>>::default();
         storage.insert(slot_key, slot_value.clone());
 
         // Chain multiple builder methods together
-        let account = Account::default()
+        let account = Account::<FlaggedStorage>::default()
             .with_info(info.clone())
             .with_storage(storage.into_iter())
             .with_created_mark()
@@ -644,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_account_is_cold_transaction_id() {
-        let mut account = Account::default();
+        let mut account = Account::<FlaggedStorage>::default();
         // only case where it is warm.
         assert!(!account.is_cold_transaction_id(0));
 
@@ -653,5 +649,13 @@ mod tests {
         account.mark_cold();
         assert!(account.is_cold_transaction_id(0));
         assert!(account.is_cold_transaction_id(1));
+    }
+
+    #[test]
+    fn test_evm_storage_slot_u256() {
+        let slot = EvmStorageSlot::<U256>::new(U256::from(42), 0);
+        assert_eq!(slot.original_value(), U256::from(42));
+        assert_eq!(slot.present_value(), U256::from(42));
+        assert!(!slot.is_changed());
     }
 }

--- a/crates/state/src/types.rs
+++ b/crates/state/src/types.rs
@@ -1,11 +1,11 @@
 use super::{Account, EvmStorageSlot};
-use primitives::{Address, HashMap, StorageKey, StorageValue};
+use primitives::{Address, HashMap, StorageKey, StorageValue, StorageValueTr, U256};
 
 /// EVM State is a mapping from addresses to accounts.
-pub type EvmState = HashMap<Address, Account>;
+pub type EvmState<SV = U256> = HashMap<Address, Account<SV>>;
 
 /// Structure used for EIP-1153 transient storage
 pub type TransientStorage = HashMap<(Address, StorageKey), StorageValue>;
 
 /// An account's Storage is a mapping from 256-bit integer keys to [EvmStorageSlot]s.
-pub type EvmStorage = HashMap<StorageKey, EvmStorageSlot>;
+pub type EvmStorage<SV: StorageValueTr = U256> = HashMap<StorageKey, EvmStorageSlot<SV>>;

--- a/crates/statetest-types/src/test_unit.rs
+++ b/crates/statetest-types/src/test_unit.rs
@@ -67,7 +67,7 @@ impl TestUnit {
     /// # Returns
     ///
     /// A [`CacheState`] object containing the pre-state accounts and storages.
-    pub fn state(&self) -> CacheState {
+    pub fn state(&self) -> CacheState<revm::state::FlaggedStorage> {
         let mut cache_state = CacheState::new(false);
         for (address, info) in &self.pre {
             let code_hash = keccak256(&info.code);

--- a/examples/block_traces/src/main.rs
+++ b/examples/block_traces/src/main.rs
@@ -9,7 +9,7 @@ use alloy_provider::{network::primitives::BlockTransactions, Provider, ProviderB
 use indicatif::ProgressBar;
 use revm::{
     context::TxEnv,
-    database::{AlloyDB, CacheDB, StateBuilder},
+    database::{AlloyDB, CacheDB},
     database_interface::WrapDatabaseAsync,
     inspector::{inspectors::TracerEip3155, InspectEvm},
     primitives::{TxKind, U256},
@@ -75,10 +75,9 @@ async fn main() -> anyhow::Result<()> {
     // SAFETY: This cannot fail since this is in the top-level tokio runtime
 
     let state_db = WrapDatabaseAsync::new(AlloyDB::new(client, prev_id)).unwrap();
-    let cache_db: CacheDB<_> = CacheDB::new(state_db);
-    let mut state = StateBuilder::new_with_database(cache_db).build();
+    let mut cache_db = CacheDB::new(state_db);
     let ctx = Context::mainnet()
-        .with_db(&mut state)
+        .with_db(&mut cache_db)
         .modify_block_chained(|b| {
             b.number = U256::from(block.header.number);
             b.beneficiary = block.header.beneficiary;

--- a/examples/cheatcode_inspector/src/main.rs
+++ b/examples/cheatcode_inspector/src/main.rs
@@ -27,7 +27,7 @@ use revm::{
         interpreter::EthInterpreter, CallInputs, CallOutcome, InterpreterResult, SStoreResult,
         SelfDestructResult, StateLoad,
     },
-    primitives::{hardfork::SpecId, Address, HashSet, Log, StorageKey, StorageValue, B256, U256},
+    primitives::{hardfork::SpecId, Address, HashSet, Log, StorageKey, B256, U256},
     state::{Account, Bytecode, EvmState},
     Context, Database, DatabaseCommit, InspectEvm, Inspector, Journal, JournalEntry,
 };
@@ -61,26 +61,6 @@ impl JournalTr for Backend {
     type Database = InMemoryDB;
     type State = EvmState;
 
-    fn cload(
-        &mut self,
-        address: Address,
-        key: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<U256>, <Self::Database as Database>::Error> {
-        self.journaled_state.cload(address, key, skip_cold_load)
-    }
-
-    fn cstore(
-        &mut self,
-        address: Address,
-        key: U256,
-        value: U256,
-        skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, <Self::Database as Database>::Error> {
-        self.journaled_state
-            .cstore(address, key, value, skip_cold_load)
-    }
-
     fn new(database: InMemoryDB) -> Self {
         Self::new(SpecId::default(), database)
     }
@@ -97,7 +77,7 @@ impl JournalTr for Backend {
         &mut self,
         address: Address,
         key: StorageKey,
-    ) -> Result<StateLoad<StorageValue>, <Self::Database as Database>::Error> {
+    ) -> Result<StateLoad<U256>, <Self::Database as Database>::Error> {
         self.journaled_state.sload(address, key)
     }
 
@@ -105,16 +85,16 @@ impl JournalTr for Backend {
         &mut self,
         address: Address,
         key: StorageKey,
-        value: StorageValue,
-    ) -> Result<StateLoad<SStoreResult>, <Self::Database as Database>::Error> {
+        value: U256,
+    ) -> Result<StateLoad<SStoreResult<U256>>, <Self::Database as Database>::Error> {
         self.journaled_state.sstore(address, key, value)
     }
 
-    fn tload(&mut self, address: Address, key: StorageKey) -> StorageValue {
+    fn tload(&mut self, address: Address, key: StorageKey) -> U256 {
         self.journaled_state.tload(address, key)
     }
 
-    fn tstore(&mut self, address: Address, key: StorageKey, value: StorageValue) {
+    fn tstore(&mut self, address: Address, key: StorageKey, value: U256) {
         self.journaled_state.tstore(address, key, value)
     }
 
@@ -280,7 +260,7 @@ impl JournalTr for Backend {
         address: Address,
         key: StorageKey,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<StorageValue>, JournalLoadError<<Self::Database as Database>::Error>>
+    ) -> Result<StateLoad<U256>, JournalLoadError<<Self::Database as Database>::Error>>
     {
         self.journaled_state
             .sload_skip_cold_load(address, key, skip_cold_load)
@@ -290,9 +270,9 @@ impl JournalTr for Backend {
         &mut self,
         address: Address,
         key: StorageKey,
-        value: StorageValue,
+        value: U256,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, JournalLoadError<<Self::Database as Database>::Error>>
+    ) -> Result<StateLoad<SStoreResult<U256>>, JournalLoadError<<Self::Database as Database>::Error>>
     {
         self.journaled_state
             .sstore_skip_cold_load(address, key, value, skip_cold_load)
@@ -310,6 +290,8 @@ impl JournalTr for Backend {
 }
 
 impl JournalExt for Backend {
+    type StorageValue = U256;
+
     fn logs(&self) -> &[Log] {
         self.journaled_state.logs()
     }
@@ -612,7 +594,10 @@ where
 
 /// Mimics <https://github.com/foundry-rs/foundry/blob/25cc1ac68b5f6977f23d713c01ec455ad7f03d21/crates/evm/core/src/backend/mod.rs#L1968>
 /// Omits persistent accounts (accounts that should be kept persistent when switching forks) for simplicity.
-fn update_state<DB: Database>(state: &mut EvmState, db: &mut DB) -> Result<(), DB::Error> {
+fn update_state<DB: Database<StorageValue = U256>>(
+    state: &mut EvmState,
+    db: &mut DB,
+) -> Result<(), DB::Error> {
     for (addr, acc) in state.iter_mut() {
         acc.info = db.basic(*addr)?.unwrap_or_default();
         for (key, val) in acc.storage.iter_mut() {

--- a/examples/contract_deployment/src/main.rs
+++ b/examples/contract_deployment/src/main.rs
@@ -8,7 +8,7 @@ use revm::{
     context_interface::result::{ExecutionResult, Output},
     database::CacheDB,
     database_interface::EmptyDB,
-    primitives::{hex, Bytes, FlaggedStorage, StorageValue, TxKind},
+    primitives::{hex, Bytes, StorageValue, TxKind, U256},
     ExecuteCommitEvm, ExecuteEvm, MainBuilder, MainContext,
 };
 
@@ -92,7 +92,7 @@ fn main() -> anyhow::Result<()> {
     println!("storage U256(0) at {address}:  {storage0:#?}");
     assert_eq!(
         storage0.present_value(),
-        FlaggedStorage::new_from_value(param),
+        U256::from(param),
         "{:#?}",
         output.result
     );

--- a/examples/custom_precompile_journal/src/custom_evm.rs
+++ b/examples/custom_precompile_journal/src/custom_evm.rs
@@ -31,7 +31,7 @@ pub struct CustomEvm<CTX, INSP>(
 
 impl<CTX, INSP> CustomEvm<CTX, INSP>
 where
-    CTX: ContextTr<Cfg: revm::context::Cfg<Spec = SpecId>>,
+    CTX: ContextTr<Cfg: revm::context::Cfg<Spec = SpecId>, Db: Database<StorageValue = revm::primitives::FlaggedStorage>>,
 {
     /// Creates a new instance of CustomEvm with the provided context and inspector.
     ///
@@ -60,7 +60,7 @@ where
 
 impl<CTX, INSP> EvmTr for CustomEvm<CTX, INSP>
 where
-    CTX: ContextTr<Cfg: revm::context::Cfg<Spec = SpecId>>,
+    CTX: ContextTr<Cfg: revm::context::Cfg<Spec = SpecId>, Db: Database<StorageValue = revm::primitives::FlaggedStorage>>,
 {
     type Context = CTX;
     type Instructions = EthInstructions<EthInterpreter, CTX>;
@@ -119,7 +119,7 @@ where
 
 impl<CTX, INSP> InspectorEvmTr for CustomEvm<CTX, INSP>
 where
-    CTX: ContextSetters<Cfg: revm::context::Cfg<Spec = SpecId>, Journal: JournalExt>,
+    CTX: ContextSetters<Cfg: revm::context::Cfg<Spec = SpecId>, Journal: JournalExt, Db: Database<StorageValue = revm::primitives::FlaggedStorage>>,
     INSP: Inspector<CTX, EthInterpreter>,
 {
     type Inspector = INSP;

--- a/examples/custom_precompile_journal/src/main.rs
+++ b/examples/custom_precompile_journal/src/main.rs
@@ -9,13 +9,15 @@
 use example_custom_precompile_journal::{
     precompile_provider::CUSTOM_PRECOMPILE_ADDRESS, CustomEvm,
 };
+use core::convert::Infallible;
 use revm::{
     context::{result::InvalidTransaction, Context, ContextSetters, ContextTr, TxEnv},
     context_interface::result::EVMError,
-    database::InMemoryDB,
+    database::CacheDB,
+    database_interface::EmptyDBTyped,
     handler::{Handler, MainnetHandler},
     inspector::NoOpInspector,
-    primitives::{address, TxKind, U256},
+    primitives::{address, FlaggedStorage, TxKind, U256},
     state::AccountInfo,
     Database, MainContext,
 };
@@ -28,7 +30,8 @@ fn main() -> anyhow::Result<()> {
 
     // Setup initial accounts
     let user_address = address!("0000000000000000000000000000000000000001");
-    let mut db = InMemoryDB::default();
+    let mut db: CacheDB<EmptyDBTyped<Infallible, FlaggedStorage>, FlaggedStorage> =
+        CacheDB::default();
 
     // Give the user some ETH for gas
     let user_balance = U256::from(10).pow(U256::from(18)); // 1 ETH

--- a/examples/custom_precompile_journal/src/precompile_provider.rs
+++ b/examples/custom_precompile_journal/src/precompile_provider.rs
@@ -6,7 +6,8 @@ use revm::{
     handler::{EthPrecompiles, PrecompileProvider},
     interpreter::{CallInputs, Gas, InstructionResult, InterpreterResult},
     precompile::{PrecompileError, PrecompileOutput, PrecompileResult},
-    primitives::{address, hardfork::SpecId, Address, Bytes, U256},
+    primitives::{address, hardfork::SpecId, Address, Bytes, FlaggedStorage, StorageValueTr, U256},
+    Database,
 };
 use std::boxed::Box;
 use std::string::String;
@@ -36,6 +37,7 @@ impl CustomPrecompileProvider {
 impl<CTX> PrecompileProvider<CTX> for CustomPrecompileProvider
 where
     CTX: ContextTr<Cfg: Cfg<Spec = SpecId>>,
+    CTX::Db: Database<StorageValue = FlaggedStorage>,
 {
     type Output = InterpreterResult;
 
@@ -79,7 +81,10 @@ where
 fn run_custom_precompile<CTX: ContextTr>(
     context: &mut CTX,
     inputs: &CallInputs,
-) -> Result<InterpreterResult, String> {
+) -> Result<InterpreterResult, String>
+where
+    CTX::Db: Database<StorageValue = FlaggedStorage>,
+{
     let input_bytes = match &inputs.input {
         revm::interpreter::CallInput::SharedBuffer(range) => {
             if let Some(slice) = context.local().shared_memory_buffer_slice(range.clone()) {
@@ -138,7 +143,10 @@ fn run_custom_precompile<CTX: ContextTr>(
 }
 
 /// Handles reading from storage
-fn handle_read_storage<CTX: ContextTr>(context: &mut CTX, gas_limit: u64) -> PrecompileResult {
+fn handle_read_storage<CTX: ContextTr>(context: &mut CTX, gas_limit: u64) -> PrecompileResult
+where
+    CTX::Db: Database<StorageValue = FlaggedStorage>,
+{
     // Base gas cost for reading storage
     const BASE_GAS: u64 = 2_100;
 
@@ -156,7 +164,7 @@ fn handle_read_storage<CTX: ContextTr>(context: &mut CTX, gas_limit: u64) -> Pre
     // Return the value as output
     Ok(PrecompileOutput::new(
         BASE_GAS,
-        value.to_be_bytes_vec().into(),
+        value.value().to_be_bytes_vec().into(),
     ))
 }
 
@@ -165,7 +173,10 @@ fn handle_write_storage<CTX: ContextTr>(
     context: &mut CTX,
     input: &[u8],
     gas_limit: u64,
-) -> PrecompileResult {
+) -> PrecompileResult
+where
+    CTX::Db: Database<StorageValue = FlaggedStorage>,
+{
     // Base gas cost for the operation
     const BASE_GAS: u64 = 21_000;
     const SSTORE_GAS: u64 = 20_000;
@@ -180,7 +191,11 @@ fn handle_write_storage<CTX: ContextTr>(
     // Store the value in the precompile's storage
     context
         .journal_mut()
-        .sstore(CUSTOM_PRECOMPILE_ADDRESS, STORAGE_KEY, value)
+        .sstore(
+            CUSTOM_PRECOMPILE_ADDRESS,
+            STORAGE_KEY,
+            FlaggedStorage::from_u256(value),
+        )
         .map_err(|e| PrecompileError::Other(format!("Storage write failed: {e:?}")))?;
 
     // Get the caller address

--- a/examples/database_components/src/lib.rs
+++ b/examples/database_components/src/lib.rs
@@ -41,6 +41,7 @@ impl<SE, BHE> DBErrorMarker for DatabaseComponentError<SE, BHE> {}
 
 impl<S: State, BH: BlockHash> Database for DatabaseComponents<S, BH> {
     type Error = DatabaseComponentError<S::Error, BH::Error>;
+    type StorageValue = FlaggedStorage;
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         self.state.basic(address).map_err(Self::Error::State)
@@ -52,7 +53,11 @@ impl<S: State, BH: BlockHash> Database for DatabaseComponents<S, BH> {
             .map_err(Self::Error::State)
     }
 
-    fn storage(&mut self, address: Address, index: U256) -> Result<FlaggedStorage, Self::Error> {
+    fn storage(
+        &mut self,
+        address: Address,
+        index: U256,
+    ) -> Result<Self::StorageValue, Self::Error> {
         self.state
             .storage(address, index)
             .map_err(Self::Error::State)
@@ -67,6 +72,7 @@ impl<S: State, BH: BlockHash> Database for DatabaseComponents<S, BH> {
 
 impl<S: StateRef, BH: BlockHashRef> DatabaseRef for DatabaseComponents<S, BH> {
     type Error = DatabaseComponentError<S::Error, BH::Error>;
+    type StorageValue = FlaggedStorage;
 
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         self.state.basic(address).map_err(Self::Error::State)
@@ -78,7 +84,11 @@ impl<S: StateRef, BH: BlockHashRef> DatabaseRef for DatabaseComponents<S, BH> {
             .map_err(Self::Error::State)
     }
 
-    fn storage_ref(&self, address: Address, index: U256) -> Result<FlaggedStorage, Self::Error> {
+    fn storage_ref(
+        &self,
+        address: Address,
+        index: U256,
+    ) -> Result<Self::StorageValue, Self::Error> {
         self.state
             .storage(address, index)
             .map_err(Self::Error::State)

--- a/examples/erc20_gas/src/exec.rs
+++ b/examples/erc20_gas/src/exec.rs
@@ -10,7 +10,9 @@ use revm::{
         PrecompileProvider,
     },
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
+    primitives::U256,
     state::EvmState,
+    Database,
 };
 
 type Erc20Error<CTX> = EVMError<ContextTrDbError<CTX>, InvalidTransaction>;
@@ -20,10 +22,10 @@ type Erc20Error<CTX> = EVMError<ContextTrDbError<CTX>, InvalidTransaction>;
 /// This function does not commit the state to the database.
 pub fn transact_erc20evm<EVM>(
     evm: &mut EVM,
-) -> Result<(ExecutionResult<HaltReason>, EvmState), Erc20Error<EVM::Context>>
+) -> Result<(ExecutionResult<HaltReason>, EvmState<U256>), Erc20Error<EVM::Context>>
 where
     EVM: EvmTr<
-        Context: ContextTr<Journal: JournalTr<State = EvmState>>,
+        Context: ContextTr<Journal: JournalTr<State = EvmState<U256>>, Db: Database<StorageValue = U256>>,
         Precompiles: PrecompileProvider<EVM::Context, Output = InterpreterResult>,
         Instructions: InstructionProvider<
             Context = EVM::Context,
@@ -46,7 +48,10 @@ pub fn transact_erc20evm_commit<EVM>(
 ) -> Result<ExecutionResult<HaltReason>, Erc20Error<EVM::Context>>
 where
     EVM: EvmTr<
-        Context: ContextTr<Journal: JournalTr<State = EvmState>, Db: DatabaseCommit>,
+        Context: ContextTr<
+            Journal: JournalTr<State = EvmState<U256>>,
+            Db: Database<StorageValue = U256> + DatabaseCommit<U256>,
+        >,
         Precompiles: PrecompileProvider<EVM::Context, Output = InterpreterResult>,
         Instructions: InstructionProvider<
             Context = EVM::Context,

--- a/examples/erc20_gas/src/handler.rs
+++ b/examples/erc20_gas/src/handler.rs
@@ -11,6 +11,7 @@ use revm::{
     interpreter::interpreter_action::FrameInit,
     primitives::{hardfork::SpecId, U256},
     state::EvmState,
+    Database,
 };
 
 use crate::{erc_address_storage, token_operation, TOKEN, TREASURY};
@@ -40,7 +41,7 @@ impl<EVM, ERROR, FRAME> Default for Erc20MainnetHandler<EVM, ERROR, FRAME> {
 
 impl<EVM, ERROR, FRAME> Handler for Erc20MainnetHandler<EVM, ERROR, FRAME>
 where
-    EVM: EvmTr<Context: ContextTr<Journal: JournalTr<State = EvmState>>, Frame = FRAME>,
+    EVM: EvmTr<Context: ContextTr<Journal: JournalTr<State = EvmState<U256>>, Db: Database<StorageValue = U256>>, Frame = FRAME>,
     FRAME: FrameTr<FrameResult = FrameResult, FrameInit = FrameInit>,
     ERROR: EvmTrError<EVM>,
 {

--- a/examples/erc20_gas/src/main.rs
+++ b/examples/erc20_gas/src/main.rs
@@ -16,9 +16,7 @@ use revm::{
     },
     database::{AlloyDB, BlockId, CacheDB},
     database_interface::WrapDatabaseAsync,
-    primitives::{
-        address, hardfork::SpecId, keccak256, Address, FlaggedStorage, TxKind, KECCAK_EMPTY, U256,
-    },
+    primitives::{address, hardfork::SpecId, keccak256, Address, TxKind, KECCAK_EMPTY, U256},
     state::AccountInfo,
     Context, Database, MainBuilder, MainContext,
 };
@@ -43,7 +41,7 @@ async fn main() -> Result<()> {
     let provider = ProviderBuilder::new().connect(rpc_url).await?.erased();
 
     let alloy_db = WrapDatabaseAsync::new(AlloyDB::new(provider, BlockId::latest())).unwrap();
-    let mut cache_db = CacheDB::new(alloy_db);
+    let mut cache_db: AlloyCacheDB = CacheDB::new(alloy_db);
 
     // Random empty account: From
     let account = address!("18B06aaF27d44B756FCF16Ca20C1f183EB49111f");
@@ -56,11 +54,7 @@ async fn main() -> Result<()> {
     let balance_slot = erc_address_storage(account);
     println!("Balance slot: {balance_slot}");
     cache_db
-        .insert_account_storage(
-            TOKEN,
-            balance_slot,
-            FlaggedStorage::new_from_value(hundred_tokens * U256::from(2)),
-        )
+        .insert_account_storage(TOKEN, balance_slot, hundred_tokens * U256::from(2))
         .unwrap();
     cache_db.insert_account_info(
         account,
@@ -72,14 +66,14 @@ async fn main() -> Result<()> {
         },
     );
 
-    let balance_before = balance_of(account, &mut cache_db).unwrap().value;
+    let balance_before = balance_of(account, &mut cache_db).unwrap();
     println!("Balance before: {balance_before}");
 
     // Transfer 100 tokens from account to account_to
     // Magic happens here with custom handlers
     transfer(account, account_to, hundred_tokens, &mut cache_db)?;
 
-    let balance_after = balance_of(account, &mut cache_db)?.value;
+    let balance_after = balance_of(account, &mut cache_db)?;
     println!("Balance after: {balance_after}");
 
     Ok(())
@@ -94,6 +88,7 @@ pub fn token_operation<CTX, ERROR>(
 ) -> Result<(), ERROR>
 where
     CTX: ContextTr,
+    CTX::Db: Database<StorageValue = U256>,
     ERROR: From<InvalidTransaction> + From<InvalidHeader> + From<<CTX::Db as Database>::Error>,
 {
     let sender_balance_slot = erc_address_storage(sender);
@@ -128,7 +123,7 @@ where
     Ok(())
 }
 
-fn balance_of(address: Address, alloy_db: &mut AlloyCacheDB) -> Result<FlaggedStorage> {
+fn balance_of(address: Address, alloy_db: &mut AlloyCacheDB) -> Result<U256> {
     let slot = erc_address_storage(address);
     alloy_db.storage(TOKEN, slot).map_err(From::from)
 }

--- a/examples/uniswap_get_reserves/src/main.rs
+++ b/examples/uniswap_get_reserves/src/main.rs
@@ -4,11 +4,12 @@
 use alloy_eips::BlockId;
 use alloy_provider::ProviderBuilder;
 use alloy_sol_types::{sol, SolCall};
+use core::convert::Infallible;
 use revm::{
     context::TxEnv,
     context_interface::result::{ExecutionResult, Output},
     database::{AlloyDB, CacheDB},
-    database_interface::{DatabaseRef, EmptyDB, WrapDatabaseAsync},
+    database_interface::{DatabaseRef, EmptyDBTyped, WrapDatabaseAsync},
     primitives::{address, StorageKey, TxKind, U256},
     Context, ExecuteEvm, MainBuilder, MainContext,
 };
@@ -55,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
     let value = cache_db.storage_ref(pool_address, slot).unwrap();
 
     // Initialise empty in-memory-db
-    let mut cache_db = CacheDB::new(EmptyDB::default());
+    let mut cache_db = CacheDB::new(EmptyDBTyped::<Infallible>::default());
 
     // Insert basic account info which was generated via Web3DB with the corresponding address
     cache_db.insert_account_info(pool_address, acc_info);


### PR DESCRIPTION
This way we can use revm more as an sdk, passing a FlaggedStorage instead of U256. This is a huge change.. will need to figure out how to test this before going forward.