### PR TITLE
test: fix ethereum execution tests

### DIFF
--- a/.github/workflows/ethereum-tests.yml
+++ b/.github/workflows/ethereum-tests.yml
@@ -10,6 +10,7 @@ on:
     branches: [reth-sdk, "release/**"]
   pull_request:
     branches: [reth-sdk, "release/**"]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/ethereum-tests.yml
+++ b/.github/workflows/ethereum-tests.yml
@@ -6,9 +6,10 @@ concurrency:
 
 on:
   push:
-    branches: [seismic, "release/**"]
+    # TODO(samlaf): change reth-sdk back to seismic once we merge reth-sdk into seismic
+    branches: [reth-sdk, "release/**"]
   pull_request:
-    branches: [seismic, "release/**"]
+    branches: [reth-sdk, "release/**"]
 
 jobs:
   test:

--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -52,6 +52,10 @@ csv = "1.1.6"
 [features]
 # Optionally enable gmp because it doesn't work on i686 github actions runners
 gmp = ["revm/gmp"]
+# Ethereum state tests provide timestamps in seconds, but Seismic's TIMESTAMP opcode
+# divides by 1000 (assuming milliseconds from the host). Enable this feature to skip
+# that division so state tests produce correct results.
+timestamp-in-seconds = ["seismic-revm/timestamp-in-seconds"]
 
 [[bench]]
 name = "evm"

--- a/bins/revme/src/cmd/statetest/merkle_trie.rs
+++ b/bins/revme/src/cmd/statetest/merkle_trie.rs
@@ -61,6 +61,9 @@ impl TrieAccount {
                     .map(|(k, v)| {
                         (
                             k.to_be_bytes::<32>(),
+                            // Seismic hack: we calculate the trie root without the is_private flag, to match ethereum and get the same state roots.
+                            // Note that the state roots calculated here won't be the same as the ones in seismic-revm, but they will be the same as the ones in stock-revm,
+                            // which is what we want for making sure public seismic is compatible with stock-revm.
                             alloy_rlp::encode_fixed_size(&v.value),
                         )
                     }),

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -140,6 +140,8 @@ fn skip_test(path: &Path) -> bool {
         // uses for timestampms/cstore/cload.
         | "undefinedOpcodeFirstByte.json"
         | "all_opcodes.json"
+        // We support the p256 opcode starting at MERCURY SeismicSpecId, which maps to Prague, so its fine for this precompile to exist before Osaka.
+        | "precompile_before_fork.json"
     )
 }
 

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -4,7 +4,7 @@ use context::TxEnv;
 use database::State;
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use inspector::{inspectors::TracerEip3155, InspectCommitEvm};
-use primitives::U256;
+use primitives::{hardfork::SpecId, U256};
 use revm::{
     context::{block::BlockEnv, cfg::CfgEnv},
     context_interface::{
@@ -17,11 +17,10 @@ use revm::{
 };
 use seismic_revm::{
     DefaultSeismicContext, SeismicBuilder, SeismicHaltReason, SeismicHaltReason as HaltReason,
-    SeismicSpecId as SpecId, SeismicTransaction,
+    SeismicSpecId, SeismicTransaction,
 };
 use serde_json::json;
 use statetest_types::{SpecName, Test, TestSuite, TestUnit};
-
 use std::{
     convert::Infallible,
     fmt::Debug,
@@ -124,6 +123,15 @@ fn skip_test(path: &Path) -> bool {
         | "static_Call50000_sha256.json"
         | "loopMul.json"
         | "CALLBlake2f_MaxRounds.json"
+
+        // SEISMIC SKIPS:
+        // These tests fail because they query they call random low addresses where our seismic precompiles live.
+        // Since precompiles are pre-warmed, the gas cost is cheaper on seismic-revm than in stock-revm.
+        | "randomStatetest649.json"
+        | "failed_tx_xcf416c53_Paris.json"
+        // This test fails because it expects certain opcodes to be undefined, which seismic actually uses
+        // for timestampms/cstore/cload.
+        | "undefinedOpcodeFirstByte.json"
     )
 }
 
@@ -131,7 +139,7 @@ struct TestExecutionContext<'a> {
     name: &'a str,
     unit: &'a TestUnit,
     test: &'a Test,
-    cfg: &'a CfgEnv<SpecId>,
+    cfg: &'a CfgEnv<SeismicSpecId>,
     block: &'a BlockEnv,
     tx: &'a SeismicTransaction<TxEnv>,
     cache_state: &'a database::CacheState,
@@ -145,7 +153,7 @@ struct DebugContext<'a> {
     path: &'a str,
     index: usize,
     test: &'a Test,
-    cfg: &'a CfgEnv<SpecId>,
+    cfg: &'a CfgEnv<SeismicSpecId>,
     block: &'a BlockEnv,
     tx: &'a SeismicTransaction<TxEnv>,
     cache_state: &'a database::CacheState,
@@ -157,7 +165,7 @@ fn build_json_output(
     test_name: &str,
     exec_result: &Result<ExecutionResult<HaltReason>, EVMError<Infallible, InvalidTransaction>>,
     validation: &TestValidationResult,
-    spec: SpecId,
+    spec: SeismicSpecId,
     error: Option<String>,
 ) -> serde_json::Value {
     json!({
@@ -228,7 +236,7 @@ fn check_evm_execution(
         EVMError<Infallible, InvalidTransaction>,
     >,
     db: &mut State<EmptyDB>,
-    spec: SpecId,
+    spec: SeismicSpecId,
     print_json_outcome: bool,
 ) -> Result<(), TestErrorKind> {
     let validation = compute_test_roots(exec_result, db);
@@ -319,7 +327,7 @@ pub fn execute_test_suite(
         let cache_state = unit.state();
 
         // Setup base configuration
-        let mut cfg: CfgEnv<SpecId> = CfgEnv::default();
+        let mut cfg = CfgEnv::<SeismicSpecId>::default();
         cfg.chain_id = unit
             .env
             .current_chain_id
@@ -329,23 +337,21 @@ pub fn execute_test_suite(
 
         // Post and execution
         for (spec_name, tests) in &unit.post {
-            // Skip Constantinople spec
-            if *spec_name == SpecName::Constantinople {
+            // Seismic's only hardfork is MERCURY, which is tied to Prague, so we skip all other specs.
+            if *spec_name != SpecName::Prague {
                 continue;
             }
 
-            cfg.spec = SpecId::MERCURY;
+            cfg.spec = SeismicSpecId::MERCURY;
 
-            /*
             // Configure max blobs per spec
-            if cfg.spec.is_enabled_in(SpecId::OSAKA) {
+            if cfg.spec.into_eth_spec().is_enabled_in(SpecId::OSAKA) {
                 cfg.set_max_blobs_per_tx(6);
-            } else if cfg.spec.is_enabled_in(SpecId::PRAGUE) {
+            } else if cfg.spec.into_eth_spec().is_enabled_in(SpecId::PRAGUE) {
                 cfg.set_max_blobs_per_tx(9);
             } else {
                 cfg.set_max_blobs_per_tx(6);
             }
-            */
 
             // Setup block environment for this spec
             let block = unit.block_env(&cfg);
@@ -416,11 +422,13 @@ pub fn execute_test_suite(
 
 fn execute_single_test(ctx: TestExecutionContext) -> Result<(), TestErrorKind> {
     // Prepare state
-    #[allow(unused_mut)]
     let mut cache = ctx.cache_state.clone();
-    /*
-    cache.set_state_clear_flag(ctx.cfg.spec.is_enabled_in(SpecId::SPURIOUS_DRAGON));
-    */
+    cache.set_state_clear_flag(
+        ctx.cfg
+            .spec
+            .into_eth_spec()
+            .is_enabled_in(SpecId::SPURIOUS_DRAGON),
+    );
     let mut state = database::State::builder()
         .with_cached_prestate(cache)
         .with_bundle_update()
@@ -466,11 +474,13 @@ fn debug_failed_test(ctx: DebugContext) {
     println!("\nTraces:");
 
     // Re-run with tracing
-    #[allow(unused_mut)]
     let mut cache = ctx.cache_state.clone();
-    /*
-    cache.set_state_clear_flag(ctx.cfg.spec.is_enabled_in(SpecId::SPURIOUS_DRAGON));
-    */
+    cache.set_state_clear_flag(
+        ctx.cfg
+            .spec
+            .into_eth_spec()
+            .is_enabled_in(SpecId::SPURIOUS_DRAGON),
+    );
     let mut state = database::State::builder()
         .with_cached_prestate(cache)
         .with_bundle_update()

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -125,13 +125,21 @@ fn skip_test(path: &Path) -> bool {
         | "CALLBlake2f_MaxRounds.json"
 
         // SEISMIC SKIPS:
-        // These tests fail because they query they call random low addresses where our seismic precompiles live.
+        // TODO(samlaf): we probably want to find a better solution here.. for example skipping all_opcodes doesn't feel good.
+        // What would be nice is if we could somehow dynamically change opcodes or precompile addresses, so that we could run tests
+        // with precompiles at higher address ranges for example.
+
+        // These tests fail because they call random low addresses where our seismic precompiles live.
         // Since precompiles are pre-warmed, the gas cost is cheaper on seismic-revm than in stock-revm.
         | "randomStatetest649.json"
         | "failed_tx_xcf416c53_Paris.json"
-        // This test fails because it expects certain opcodes to be undefined, which seismic actually uses
-        // for timestampms/cstore/cload.
+        // This test iterates addresses 1..0x101 and expects non-precompile addresses to behave as
+        // empty accounts, but Seismic adds precompiles at 0x64-0x69 (RNG, ECDH, AES, HKDF, Sign).
+        | "precompile_absence.json"
+        // These tests fail because they expect certain opcodes to be undefined, which seismic actually
+        // uses for timestampms/cstore/cload.
         | "undefinedOpcodeFirstByte.json"
+        | "all_opcodes.json"
     )
 }
 

--- a/crates/context/src/journal/inner.rs
+++ b/crates/context/src/journal/inner.rs
@@ -921,18 +921,20 @@ pub fn sload_with_account<DB: Database, ENTRY: JournalEntryTr>(
     let (value, is_cold, is_private) = match account.storage.entry(key) {
         Entry::Occupied(occ) => {
             let slot = occ.into_mut();
+            // skip load if account is cold.
             let is_cold = slot.is_cold_transaction_id(transaction_id);
             if skip_cold_load && is_cold {
                 return Err(JournalLoadError::ColdLoadSkipped);
             }
+            slot.mark_warm_with_transaction_id(transaction_id);
             let is_private = slot.present_value().is_private;
             (slot.present_value.value, is_cold, is_private)
         }
         Entry::Vacant(vac) => {
-            // if storage was cleared, we don't need to ping db.
             if skip_cold_load {
                 return Err(JournalLoadError::ColdLoadSkipped);
             }
+            // if storage was cleared, we don't need to ping db.
             let value = if is_newly_created {
                 FlaggedStorage::ZERO.set_visibility(default_privacy)
             } else {

--- a/crates/primitives/src/hardfork.rs
+++ b/crates/primitives/src/hardfork.rs
@@ -96,6 +96,7 @@ impl SpecId {
 
 /// String identifiers for hardforks.
 pub mod name {
+    /// String identifier for the Frontier hardfork
     pub const FRONTIER: &str = "Frontier";
     /// String identifier for the Frontier Thawing hardfork
     pub const FRONTIER_THAWING: &str = "Frontier Thawing";

--- a/crates/statetest-types/src/account_info.rs
+++ b/crates/statetest-types/src/account_info.rs
@@ -1,7 +1,7 @@
 use revm::primitives::{Bytes, HashMap, StorageKey, U256};
 use serde::Deserialize;
 
-use crate::deserializer::deserialize_str_as_u64;
+use crate::deserializer::{deserialize_storage, deserialize_str_as_u64};
 
 /// Account information
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
@@ -15,5 +15,6 @@ pub struct AccountInfo {
     #[serde(deserialize_with = "deserialize_str_as_u64")]
     pub nonce: u64,
     /// Account storage (key-value pairs)
+    #[serde(deserialize_with = "deserialize_storage")]
     pub storage: HashMap<StorageKey, revm::state::FlaggedStorage>,
 }

--- a/crates/statetest-types/src/blockchain.rs
+++ b/crates/statetest-types/src/blockchain.rs
@@ -3,7 +3,7 @@
 //! This module contains structures for deserializing blockchain test JSON files
 //! from the Ethereum test suite.
 
-use crate::{deserialize_maybe_empty, AccountInfo, TestAuthorization};
+use crate::{deserialize_maybe_empty, deserializer::deserialize_btree_storage, AccountInfo, TestAuthorization};
 use revm::{
     context::{transaction::AccessList, BlockEnv, TxEnv},
     context_interface::block::BlobExcessGasAndPrice,
@@ -210,6 +210,7 @@ pub struct Account {
     /// Nonce
     pub nonce: U256,
     /// Storage
+    #[serde(deserialize_with = "deserialize_btree_storage")]
     pub storage: BTreeMap<U256, revm::state::FlaggedStorage>,
 }
 

--- a/crates/statetest-types/src/deserializer.rs
+++ b/crates/statetest-types/src/deserializer.rs
@@ -45,3 +45,18 @@ where
         .map(|(key, value)| (key, FlaggedStorage::public(value)))
         .collect())
 }
+
+/// Same as [`deserialize_storage`] but returns a [`BTreeMap`] instead of a [`HashMap`].
+pub fn deserialize_btree_storage<'de, D>(
+    deserializer: D,
+) -> Result<std::collections::BTreeMap<U256, FlaggedStorage>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let map: std::collections::BTreeMap<U256, U256> =
+        std::collections::BTreeMap::deserialize(deserializer)?;
+    Ok(map
+        .into_iter()
+        .map(|(key, value)| (key, FlaggedStorage::public(value)))
+        .collect())
+}

--- a/crates/statetest-types/src/deserializer.rs
+++ b/crates/statetest-types/src/deserializer.rs
@@ -1,4 +1,5 @@
-use revm::primitives::Address;
+use revm::primitives::{Address, HashMap, StorageKey, U256};
+use revm::state::FlaggedStorage;
 use serde::{de, Deserialize};
 
 /// Deserializes a [string][String] as a [u64].
@@ -27,4 +28,20 @@ where
     } else {
         string.parse().map_err(de::Error::custom).map(Some)
     }
+}
+
+/// Deserializes a storage HashMap from the upstream Ethereum test format (hex string values)
+/// into public `FlaggedStorage` values.
+/// This is needed so that we can deserialize the Ethereum test fixtures, which assume Storage values are U256 hex strings.
+pub fn deserialize_storage<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<StorageKey, FlaggedStorage>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let map: HashMap<StorageKey, U256> = HashMap::deserialize(deserializer)?;
+    Ok(map
+        .into_iter()
+        .map(|(key, value)| (key, FlaggedStorage::public(value)))
+        .collect())
 }

--- a/crates/statetest-types/src/test_unit.rs
+++ b/crates/statetest-types/src/test_unit.rs
@@ -4,9 +4,9 @@ use std::collections::{BTreeMap, HashMap};
 
 use crate::{AccountInfo, Env, SpecName, Test, TransactionParts};
 use revm::{
-    context::{block::BlockEnv, CfgEnv},
+    context::{block::BlockEnv, cfg::CfgEnv},
     database::CacheState,
-    primitives::{keccak256, Address, Bytes},
+    primitives::{hardfork::SpecId, keccak256, Address, Bytes, B256},
     state::Bytecode,
 };
 
@@ -96,7 +96,6 @@ impl TestUnit {
     /// # Returns
     ///
     /// A configured [`BlockEnv`] ready for execution
-    #[allow(unused_variables)]
     pub fn block_env(&self, cfg: &CfgEnv<SeismicSpecId>) -> BlockEnv {
         let mut block = BlockEnv {
             number: self.env.current_number,
@@ -122,12 +121,10 @@ impl TestUnit {
             );
         }
 
-        /*
         // Set default prevrandao for merge
-        if cfg.spec.is_enabled_in(SpecId::MERGE) && block.prevrandao.is_none() {
+        if cfg.spec.into_eth_spec().is_enabled_in(SpecId::MERGE) && block.prevrandao.is_none() {
             block.prevrandao = Some(B256::default());
         }
-        */
 
         block
     }

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -152,8 +152,8 @@ run_tests() {
     # but Seismic's TIMESTAMP opcode normally divides by 1000 (assuming ms from host).
     $RUST_RUNNER run $CARGO_OPTS -p revme --features timestamp-in-seconds -- statetest "$MAIN_STATIC_DIR/state_tests"
 
-    # echo "Running devnet statetests..."
-    # $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$DEVNET_DIR/state_tests"
+    echo "Running devnet statetests..."
+    $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$DEVNET_DIR/state_tests"
 
     # echo "Running legacy tests..."
     # $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$LEGACY_DIR/Cancun/GeneralStateTests"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -155,17 +155,19 @@ run_tests() {
     echo "Running devnet statetests..."
     $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$DEVNET_DIR/state_tests"
 
-    # echo "Running legacy tests..."
-    # $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$LEGACY_DIR/Cancun/GeneralStateTests"
+    echo "Running legacy tests..."
+    $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$LEGACY_DIR/Cancun/GeneralStateTests"
 
-    # echo "Running main develop blockchain tests..."
-    # $RUST_RUNNER run $CARGO_OPTS -p revme -- btest "$MAIN_DEVELOP_DIR/blockchain_tests"
+    echo "Running main develop blockchain tests..."
+    # timestamp-in-seconds: Ethereum test fixtures provide timestamps in seconds,
+    # but Seismic's TIMESTAMP opcode normally divides by 1000 (assuming ms from host).
+    $RUST_RUNNER run $CARGO_OPTS -p revme --features timestamp-in-seconds -- btest "$MAIN_DEVELOP_DIR/blockchain_tests"
 
-    # echo "Running main static blockchain tests..."
-    # $RUST_RUNNER run $CARGO_OPTS -p revme -- btest "$MAIN_STATIC_DIR/blockchain_tests"
+    echo "Running main static blockchain tests..."
+    $RUST_RUNNER run $CARGO_OPTS -p revme --features timestamp-in-seconds -- btest "$MAIN_STATIC_DIR/blockchain_tests"
 
-    # echo "Running main stable blockchain tests..."
-    # $RUST_RUNNER run $CARGO_OPTS -p revme -- btest "$MAIN_STABLE_DIR/blockchain_tests"
+    echo "Running main stable blockchain tests..."
+    $RUST_RUNNER run $CARGO_OPTS -p revme --features timestamp-in-seconds -- btest "$MAIN_STABLE_DIR/blockchain_tests"
 }
 
 ##############################

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -144,26 +144,28 @@ run_tests() {
     echo "Running main stable statetests..."
     $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$MAIN_STABLE_DIR/state_tests"
 
-    echo "Running main develop statetests..."
-    $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$MAIN_DEVELOP_DIR/state_tests"
+    # echo "Running main develop statetests..."
+    # $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$MAIN_DEVELOP_DIR/state_tests" --no-fail-fast
     
     echo "Running main static statetests..."
-    $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$MAIN_STATIC_DIR/state_tests"
+    # timestamp-in-seconds: Ethereum test fixtures provide timestamps in seconds,
+    # but Seismic's TIMESTAMP opcode normally divides by 1000 (assuming ms from host).
+    $RUST_RUNNER run $CARGO_OPTS -p revme --features timestamp-in-seconds -- statetest "$MAIN_STATIC_DIR/state_tests"
 
-    echo "Running devnet statetests..."
-    $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$DEVNET_DIR/state_tests"
+    # echo "Running devnet statetests..."
+    # $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$DEVNET_DIR/state_tests"
 
-    echo "Running legacy tests..."
-    $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$LEGACY_DIR/Cancun/GeneralStateTests"
+    # echo "Running legacy tests..."
+    # $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$LEGACY_DIR/Cancun/GeneralStateTests"
 
-    echo "Running main develop blockchain tests..."
-    $RUST_RUNNER run $CARGO_OPTS -p revme -- btest "$MAIN_DEVELOP_DIR/blockchain_tests"
+    # echo "Running main develop blockchain tests..."
+    # $RUST_RUNNER run $CARGO_OPTS -p revme -- btest "$MAIN_DEVELOP_DIR/blockchain_tests"
 
-    echo "Running main static blockchain tests..."
-    $RUST_RUNNER run $CARGO_OPTS -p revme -- btest "$MAIN_STATIC_DIR/blockchain_tests"
+    # echo "Running main static blockchain tests..."
+    # $RUST_RUNNER run $CARGO_OPTS -p revme -- btest "$MAIN_STATIC_DIR/blockchain_tests"
 
-    echo "Running main stable blockchain tests..."
-    $RUST_RUNNER run $CARGO_OPTS -p revme -- btest "$MAIN_STABLE_DIR/blockchain_tests"
+    # echo "Running main stable blockchain tests..."
+    # $RUST_RUNNER run $CARGO_OPTS -p revme -- btest "$MAIN_STABLE_DIR/blockchain_tests"
 }
 
 ##############################

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -144,8 +144,8 @@ run_tests() {
     echo "Running main stable statetests..."
     $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$MAIN_STABLE_DIR/state_tests"
 
-    # echo "Running main develop statetests..."
-    # $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$MAIN_DEVELOP_DIR/state_tests" --no-fail-fast
+    echo "Running main develop statetests..."
+    $RUST_RUNNER run $CARGO_OPTS -p revme -- statetest "$MAIN_DEVELOP_DIR/state_tests"
     
     echo "Running main static statetests..."
     # timestamp-in-seconds: Ethereum test fixtures provide timestamps in seconds,


### PR DESCRIPTION
The ethereum execution tests have been broken and the CI [disabled](https://github.com/SeismicSystems/seismic-revm/actions/workflows/ethereum-tests.yml) for a little while.

This PR fixes them (at least as many as possible). Had to skip a few tests due to conflicts with (see exact list in runner.rs):
1. ethereum expecting no opcodes where we deploy our seismic opcodes
2. ethereum expecting no code/warm-status where we have our precompiles deployed
3. state tries are different because of is_private flag. This was already fixed by us but I added a comment explaining that we don't use the is_private flag when calculating our stateroot in the EE tests