### PR TITLE
feat: add MPT verification precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,6 +2445,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
+name = "hash-db"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e7d7786361d7425ae2fe4f9e407eb0efaa0840f5212d109cc018c40c35c6ab4"
+
+[[package]]
+name = "hash256-std-hasher"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c171d55b98633f4ed3860808f004099b36c1cc29c42cfc53aa8591b21efcf2"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2455,6 +2470,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3174,6 +3192,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak-hasher"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ea4653859ca2266a86419d3f592d3f22e7a854b482f99180d2498507902048"
+dependencies = [
+ "hash-db 0.16.0",
+ "hash256-std-hasher",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3247,6 +3276,17 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memory-db"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e300c54e3239a86f9c61cc63ab0f03862eb40b1c6e065dc6fd6ceaeff6da93d"
+dependencies = [
+ "foldhash",
+ "hash-db 0.16.0",
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "merlin"
@@ -4021,6 +4061,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "reference-trie"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693da3c9d23a53bd6b35e36bcb70f584ee58eba8673edc3130ac69ba42ed9822"
+dependencies = [
+ "hash-db 0.16.0",
+ "hashbrown 0.14.5",
+ "keccak-hasher",
+ "parity-scale-codec",
+ "paste",
+ "trie-db",
+ "trie-root",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4318,7 +4373,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "csv",
  "env_logger",
- "hash-db",
+ "hash-db 0.15.2",
  "indicatif",
  "k256",
  "log",
@@ -4801,11 +4856,15 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "auto_impl",
+ "hash-db 0.16.0",
  "hkdf",
  "indicatif",
+ "keccak-hasher",
+ "memory-db",
  "merlin",
  "once_cell",
  "rand_core 0.6.4",
+ "reference-trie",
  "revm",
  "rstest",
  "schnorrkel",
@@ -4814,6 +4873,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "trie-db",
 ]
 
 [[package]]
@@ -5514,12 +5574,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "trie-db"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7795f2df2ef744e4ffb2125f09325e60a21d305cc3ecece0adeef03f7a9e560"
+dependencies = [
+ "hash-db 0.16.0",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-root"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ed310ef5ab98f5fa467900ed906cb9232dd5376597e00fd4cba2a449d06c0b"
+dependencies = [
+ "hash-db 0.16.0",
+]
+
+[[package]]
 name = "triehash"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
 dependencies = [
- "hash-db",
+ "hash-db 0.15.2",
  "rlp",
 ]
 

--- a/crates/seismic/Cargo.toml
+++ b/crates/seismic/Cargo.toml
@@ -32,14 +32,18 @@ once_cell = { version = "1.21", features = ["alloc"] }
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
-# seismic 
+# seismic
 schnorrkel = { version = "0.11.2", default-features = false }
 merlin = { version = "3.0.0", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 hkdf = { version = "0.12", default-features = false }
 seismic-enclave = { workspace = true}
-sha2 = { workspace = true } 
+sha2 = { workspace = true }
 secp256k1 = { workspace = true, features = ["recovery"] }
+
+# MPT verification precompile
+trie-db = "0.31"
+reference-trie = "0.29"
 
 [dev-dependencies]
 anyhow.workspace = true
@@ -47,6 +51,10 @@ indicatif.workspace = true
 rstest.workspace = true
 alloy-sol-types.workspace = true
 serde_json = { workspace = true, features = ["alloc"] }
+# MPT verification precompile tests
+hash-db = "0.16"
+memory-db = "0.34"
+keccak-hasher = "0.16"
 
 [features]
 default = ["std", "c-kzg", "portable", "blst"]

--- a/crates/seismic/src/precompiles.rs
+++ b/crates/seismic/src/precompiles.rs
@@ -20,6 +20,7 @@
 pub mod aes;
 pub mod ecdh_derive_sym_key;
 pub mod hkdf_derive_sym_key;
+pub mod mpt_verify;
 pub mod rng;
 pub mod secp256k1_sign;
 pub mod stateful_precompile;
@@ -96,6 +97,7 @@ pub fn mercury_with_extra<CTX: SeismicContextTr>(
             aes::aes_gcm_enc::AES_GCM_ENC,
             aes::aes_gcm_dec::AES_GCM_DEC,
             secp256k1_sign::SECP256K1_SIGN,
+            mpt_verify::MPT_VERIFY,
         ]);
         Box::new(precompiles)
     });
@@ -225,7 +227,7 @@ mod tests {
                 .0
                 .difference(Precompiles::prague())
                 .len(),
-            6
+            7
         )
     }
 

--- a/crates/seismic/src/precompiles/mpt_verify.rs
+++ b/crates/seismic/src/precompiles/mpt_verify.rs
@@ -1,0 +1,558 @@
+//! MPT (Merkle Patricia Trie) proof verification precompile.
+//!
+//! Verifies an MPT inclusion/exclusion proof for one or more key-value pairs
+//! against a given root. Used to verify Summit consensus state proofs on-chain
+//! via EIP-4788.
+//!
+//! The caller provides the expected values alongside keys. The precompile
+//! verifies the proof is valid using `trie_db::proof::verify_proof`. This
+//! matches Summit's `getStateProof` RPC endpoint which returns shared proofs
+//! for multiple keys.
+
+use revm::precompile::{
+    u64_to_address, Precompile, PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult,
+};
+
+type Layout = reference_trie::ExtensionLayout;
+
+/// Address of the MPT verify precompile.
+pub const MPT_VERIFY_ADDRESS: u64 = 106;
+
+/// Returns the mpt_verify precompile with its address.
+pub fn precompiles() -> impl Iterator<Item = Precompile> {
+    [MPT_VERIFY].into_iter()
+}
+
+/// The MPT verify precompile.
+pub const MPT_VERIFY: Precompile = Precompile::new(
+    PrecompileId::Custom(std::borrow::Cow::Borrowed("MPT_VERIFY")),
+    u64_to_address(MPT_VERIFY_ADDRESS),
+    mpt_verify,
+);
+
+/// Minimum input length: 32 (root) + 4 (item_count) = 36 bytes.
+const MIN_INPUT_LENGTH: usize = 36;
+
+/* --------------------------------------------------------------------------
+ Cost Model
+-------------------------------------------------------------------------- */
+
+/// Base gas cost, comparable to ecrecover (~3000 gas).
+const BASE_COST: u64 = 3000;
+
+/// Per item gas cost (key lookup verification per item).
+const PER_ITEM_COST: u64 = 200;
+
+/// Per proof node gas cost (keccak256 hash + RLP decode per node).
+const PER_PROOF_NODE_COST: u64 = 500;
+
+/* --------------------------------------------------------------------------
+ Precompile Logic
+-------------------------------------------------------------------------- */
+
+/// # MPT Verify
+///
+/// Verifies an MPT proof for one or more key-value pairs against a root.
+///
+/// ## Input layout
+///
+/// ```text
+/// [0..32]             : root — 32-byte Merkle root
+/// [32..36]            : item_count — u32 big-endian, number of items
+/// For each item:
+///   [0..32]           : key — 32-byte keccak256-hashed trie key
+///   [0..1]            : has_value — 0x01 for inclusion, 0x00 for exclusion
+///   If has_value == 0x01:
+///     [0..4]          : value_len — u32 big-endian
+///     [4..4+L]        : value bytes
+/// [next 4 bytes]      : proof_count — u32 big-endian, number of proof nodes
+/// [rest]              : proof_nodes — length-prefixed proof nodes:
+///                         For each node: [0..4] u32 BE node length, [4..4+L] node bytes
+/// ```
+///
+/// ## Output layout
+///
+/// ```text
+/// [0..32] : 0x01 left-padded to 32 bytes (success, for Solidity abi.decode)
+/// ```
+///
+/// ## Errors
+///
+/// Returns `PrecompileError` if:
+/// - Input is too short or malformed
+/// - Proof nodes are truncated
+/// - Proof verification fails (invalid proof, wrong root, or value mismatch)
+/// - Gas limit exceeded
+pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
+    if input.len() < MIN_INPUT_LENGTH {
+        return Err(PrecompileError::Other(format!(
+            "input too short: expected at least {} bytes, got {}",
+            MIN_INPUT_LENGTH,
+            input.len()
+        ))
+        .into());
+    }
+
+    // Parse root
+    let root: [u8; 32] = input[0..32].try_into().expect("slice is 32 bytes");
+
+    // Parse item count
+    let item_count = u32::from_be_bytes(input[32..36].try_into().expect("slice is 4 bytes"));
+    if item_count == 0 {
+        return Err(PrecompileError::Other("item_count must be > 0".into()).into());
+    }
+
+    // Parse items: (key, Option<value>)
+    let mut offset = 36usize;
+    let mut items: Vec<(Vec<u8>, Option<Vec<u8>>)> = Vec::with_capacity(item_count as usize);
+
+    for _ in 0..item_count {
+        // Read key (32 bytes)
+        if offset + 33 > input.len() {
+            return Err(PrecompileError::Other(format!(
+                "input too short for item at offset {}: need at least 33 more bytes, got {}",
+                offset,
+                input.len() - offset
+            ))
+            .into());
+        }
+        let key = input[offset..offset + 32].to_vec();
+        offset += 32;
+
+        // Read has_value flag
+        let has_value = input[offset];
+        offset += 1;
+
+        if has_value == 0x01 {
+            // Inclusion: read value length + value
+            if offset + 4 > input.len() {
+                return Err(
+                    PrecompileError::Other("input too short: missing value length".into()).into(),
+                );
+            }
+            let val_len = u32::from_be_bytes(
+                input[offset..offset + 4]
+                    .try_into()
+                    .expect("slice is 4 bytes"),
+            ) as usize;
+            offset += 4;
+
+            if offset + val_len > input.len() {
+                return Err(PrecompileError::Other(format!(
+                    "input too short: expected {} value bytes, only {} remaining",
+                    val_len,
+                    input.len() - offset
+                ))
+                .into());
+            }
+            let value = input[offset..offset + val_len].to_vec();
+            offset += val_len;
+
+            items.push((key, Some(value)));
+        } else {
+            // Exclusion: no value
+            items.push((key, None));
+        }
+    }
+
+    // Parse proof count
+    if offset + 4 > input.len() {
+        return Err(PrecompileError::Other("input too short: missing proof_count".into()).into());
+    }
+    let proof_count = u32::from_be_bytes(
+        input[offset..offset + 4]
+            .try_into()
+            .expect("slice is 4 bytes"),
+    ) as u64;
+    offset += 4;
+
+    // Calculate and check gas
+    let gas_cost =
+        BASE_COST + (item_count as u64) * PER_ITEM_COST + proof_count * PER_PROOF_NODE_COST;
+    if gas_cost > gas_limit {
+        return Err(PrecompileError::OutOfGas.into());
+    }
+
+    // Parse proof nodes
+    let mut proof_nodes: Vec<Vec<u8>> = Vec::with_capacity(proof_count as usize);
+    for _ in 0..proof_count {
+        if offset + 4 > input.len() {
+            return Err(PrecompileError::Other(
+                "truncated proof node: missing length prefix".into(),
+            )
+            .into());
+        }
+        let node_len = u32::from_be_bytes(
+            input[offset..offset + 4]
+                .try_into()
+                .expect("slice is 4 bytes"),
+        ) as usize;
+        offset += 4;
+
+        if offset + node_len > input.len() {
+            return Err(PrecompileError::Other(format!(
+                "truncated proof node: expected {} bytes, only {} remaining",
+                node_len,
+                input.len() - offset
+            ))
+            .into());
+        }
+        proof_nodes.push(input[offset..offset + node_len].to_vec());
+        offset += node_len;
+    }
+
+    // Verify proof using trie_db
+    trie_db::proof::verify_proof::<Layout, _, _, _>(&root, &proof_nodes, &items)
+        .map_err(|e| PrecompileError::Other(format!("proof verification failed: {e}")))?;
+
+    // Success: return 0x01 left-padded to 32 bytes
+    let mut output = vec![0u8; 32];
+    output[31] = 0x01;
+
+    Ok(PrecompileOutput::new(gas_cost, output.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hash_db::Hasher;
+    use memory_db::{HashKey, MemoryDB};
+    use revm::precompile::PrecompileError;
+    use revm::primitives::Bytes;
+
+    type KeccakHasher = keccak_hasher::KeccakHasher;
+    type TestTrieMemDB = MemoryDB<KeccakHasher, HashKey<KeccakHasher>, Vec<u8>>;
+
+    /// Helper: build a trie, insert entries, return (root, memdb).
+    fn build_test_trie(entries: &[(&[u8], &[u8])]) -> ([u8; 32], TestTrieMemDB) {
+        let mut memdb = TestTrieMemDB::default();
+        let mut root = Default::default();
+        {
+            use trie_db::{TrieDBMutBuilder, TrieMut};
+            let mut trie = TrieDBMutBuilder::<Layout>::new(&mut memdb, &mut root).build();
+            for (key, value) in entries {
+                trie.insert(key, value).expect("insert failed");
+            }
+        }
+        (root, memdb)
+    }
+
+    /// Helper: generate proof for given keys.
+    fn generate_proof(memdb: &TestTrieMemDB, root: &[u8; 32], keys: &[&[u8]]) -> Vec<Vec<u8>> {
+        let key_vecs: Vec<Vec<u8>> = keys.iter().map(|k| k.to_vec()).collect();
+        let key_refs: Vec<&Vec<u8>> = key_vecs.iter().collect();
+        trie_db::proof::generate_proof::<_, Layout, _, _>(memdb, root, key_refs)
+            .expect("proof generation failed")
+    }
+
+    /// Helper: encode precompile input from root, items, and proof nodes.
+    fn encode_input(
+        root: &[u8; 32],
+        items: &[(Vec<u8>, Option<Vec<u8>>)],
+        proof_nodes: &[Vec<u8>],
+    ) -> Vec<u8> {
+        let mut input = Vec::new();
+        input.extend_from_slice(root);
+        input.extend_from_slice(&(items.len() as u32).to_be_bytes());
+        for (key, value) in items {
+            input.extend_from_slice(key);
+            match value {
+                Some(v) => {
+                    input.push(0x01);
+                    input.extend_from_slice(&(v.len() as u32).to_be_bytes());
+                    input.extend_from_slice(v);
+                }
+                None => {
+                    input.push(0x00);
+                }
+            }
+        }
+        input.extend_from_slice(&(proof_nodes.len() as u32).to_be_bytes());
+        for node in proof_nodes {
+            input.extend_from_slice(&(node.len() as u32).to_be_bytes());
+            input.extend_from_slice(node);
+        }
+        input
+    }
+
+    /// Helper: hash a logical key with keccak256.
+    fn hash_key(logical_key: &[u8]) -> [u8; 32] {
+        KeccakHasher::hash(logical_key)
+    }
+
+    #[test]
+    fn test_single_key_inclusion() {
+        let hashed_key = hash_key(b"epoch");
+        let value = 42u64.to_be_bytes().to_vec();
+        let (root, memdb) = build_test_trie(&[(&hashed_key, &value)]);
+        let proof = generate_proof(&memdb, &root, &[&hashed_key]);
+
+        let items = vec![(hashed_key.to_vec(), Some(value))];
+        let input = encode_input(&root, &items, &proof);
+        let result = mpt_verify(&Bytes::from(input), 100_000);
+        assert!(result.is_ok(), "Expected success, got {:?}", result.err());
+
+        let output = result.unwrap();
+        assert_eq!(output.bytes[31], 0x01, "Should return success");
+    }
+
+    #[test]
+    fn test_single_key_exclusion() {
+        let hashed_key_present = hash_key(b"epoch");
+        let value = 42u64.to_be_bytes().to_vec();
+        let (root, memdb) = build_test_trie(&[(&hashed_key_present, &value)]);
+
+        let hashed_key_absent = hash_key(b"nonexistent");
+        let proof = generate_proof(&memdb, &root, &[&hashed_key_absent]);
+
+        let items = vec![(hashed_key_absent.to_vec(), None)];
+        let input = encode_input(&root, &items, &proof);
+        let result = mpt_verify(&Bytes::from(input), 100_000);
+        assert!(result.is_ok(), "Expected success, got {:?}", result.err());
+    }
+
+    #[test]
+    fn test_multiple_keys_inclusion() {
+        let keys_and_values: Vec<([u8; 32], Vec<u8>)> = (0..5u64)
+            .map(|i| {
+                let key = hash_key(format!("key_{}", i).as_bytes());
+                let value = i.to_be_bytes().to_vec();
+                (key, value)
+            })
+            .collect();
+
+        let trie_entries: Vec<(&[u8], &[u8])> = keys_and_values
+            .iter()
+            .map(|(k, v)| (k.as_slice(), v.as_slice()))
+            .collect();
+        let (root, memdb) = build_test_trie(&trie_entries);
+
+        // Prove keys 1, 3
+        let query_keys: Vec<&[u8]> = vec![
+            keys_and_values[1].0.as_slice(),
+            keys_and_values[3].0.as_slice(),
+        ];
+        let proof = generate_proof(&memdb, &root, &query_keys);
+
+        let items = vec![
+            (
+                keys_and_values[1].0.to_vec(),
+                Some(keys_and_values[1].1.clone()),
+            ),
+            (
+                keys_and_values[3].0.to_vec(),
+                Some(keys_and_values[3].1.clone()),
+            ),
+        ];
+        let input = encode_input(&root, &items, &proof);
+        let result = mpt_verify(&Bytes::from(input), 100_000);
+        assert!(result.is_ok(), "Expected success, got {:?}", result.err());
+    }
+
+    #[test]
+    fn test_mixed_inclusion_exclusion() {
+        let hashed_key = hash_key(b"epoch");
+        let value = 42u64.to_be_bytes().to_vec();
+        let (root, memdb) = build_test_trie(&[(&hashed_key, &value)]);
+
+        let hashed_key_absent = hash_key(b"missing");
+        let query_keys: Vec<&[u8]> = vec![&hashed_key, &hashed_key_absent];
+        let proof = generate_proof(&memdb, &root, &query_keys);
+
+        let items = vec![
+            (hashed_key.to_vec(), Some(value)),
+            (hashed_key_absent.to_vec(), None),
+        ];
+        let input = encode_input(&root, &items, &proof);
+        let result = mpt_verify(&Bytes::from(input), 100_000);
+        assert!(result.is_ok(), "Expected success, got {:?}", result.err());
+    }
+
+    #[test]
+    fn test_invalid_proof() {
+        let hashed_key = hash_key(b"epoch");
+        let value = 42u64.to_be_bytes().to_vec();
+        let (root, memdb) = build_test_trie(&[(&hashed_key, &value)]);
+        let mut proof = generate_proof(&memdb, &root, &[&hashed_key]);
+
+        // Tamper with a proof node
+        if let Some(node) = proof.first_mut() {
+            if !node.is_empty() {
+                node[0] ^= 0xFF;
+            }
+        }
+
+        let items = vec![(hashed_key.to_vec(), Some(value))];
+        let input = encode_input(&root, &items, &proof);
+        let result = mpt_verify(&Bytes::from(input), 100_000);
+        assert!(result.is_err(), "Should fail with tampered proof");
+    }
+
+    #[test]
+    fn test_wrong_root() {
+        let hashed_key = hash_key(b"epoch");
+        let value = 42u64.to_be_bytes().to_vec();
+        let (root, memdb) = build_test_trie(&[(&hashed_key, &value)]);
+        let proof = generate_proof(&memdb, &root, &[&hashed_key]);
+
+        let wrong_root = [0xFF; 32];
+        let items = vec![(hashed_key.to_vec(), Some(value))];
+        let input = encode_input(&wrong_root, &items, &proof);
+        let result = mpt_verify(&Bytes::from(input), 100_000);
+        assert!(result.is_err(), "Should fail with wrong root");
+    }
+
+    #[test]
+    fn test_wrong_value() {
+        let hashed_key = hash_key(b"epoch");
+        let value = 42u64.to_be_bytes().to_vec();
+        let (root, memdb) = build_test_trie(&[(&hashed_key, &value)]);
+        let proof = generate_proof(&memdb, &root, &[&hashed_key]);
+
+        let wrong_value = 99u64.to_be_bytes().to_vec();
+        let items = vec![(hashed_key.to_vec(), Some(wrong_value))];
+        let input = encode_input(&root, &items, &proof);
+        let result = mpt_verify(&Bytes::from(input), 100_000);
+        assert!(result.is_err(), "Should fail with wrong value");
+    }
+
+    #[test]
+    fn test_claim_inclusion_for_absent_key() {
+        let hashed_key = hash_key(b"epoch");
+        let value = 42u64.to_be_bytes().to_vec();
+        let (root, memdb) = build_test_trie(&[(&hashed_key, &value)]);
+
+        let hashed_key_absent = hash_key(b"nonexistent");
+        let proof = generate_proof(&memdb, &root, &[&hashed_key_absent]);
+
+        // Claim inclusion for absent key with fake value
+        let items = vec![(hashed_key_absent.to_vec(), Some(vec![1, 2, 3]))];
+        let input = encode_input(&root, &items, &proof);
+        let result = mpt_verify(&Bytes::from(input), 100_000);
+        assert!(
+            result.is_err(),
+            "Should fail when claiming inclusion for absent key"
+        );
+    }
+
+    #[test]
+    fn test_out_of_gas() {
+        let hashed_key = hash_key(b"epoch");
+        let value = 42u64.to_be_bytes().to_vec();
+        let (root, memdb) = build_test_trie(&[(&hashed_key, &value)]);
+        let proof = generate_proof(&memdb, &root, &[&hashed_key]);
+
+        let items = vec![(hashed_key.to_vec(), Some(value))];
+        let input = encode_input(&root, &items, &proof);
+        let result = mpt_verify(&Bytes::from(input), 100);
+        assert!(result.is_err());
+
+        match result.err() {
+            Some(PrecompileError::OutOfGas) => {}
+            other => panic!("Expected OutOfGas, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_invalid_input_length() {
+        let input = vec![0u8; 30];
+        let result = mpt_verify(&Bytes::from(input), 100_000);
+        assert!(result.is_err());
+
+        match result.err() {
+            Some(PrecompileError::Other(msg)) => {
+                assert!(msg.contains("input too short"));
+            }
+            other => panic!("Expected input too short error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_zero_item_count() {
+        let mut input = vec![0u8; 32]; // root
+        input.extend_from_slice(&0u32.to_be_bytes()); // item_count = 0
+        let result = mpt_verify(&Bytes::from(input), 100_000);
+        assert!(result.is_err());
+
+        match result.err() {
+            Some(PrecompileError::Other(msg)) => {
+                assert!(msg.contains("item_count must be > 0"));
+            }
+            other => panic!("Expected item_count error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_truncated_proof_node() {
+        let root = [0u8; 32];
+        let key = [0u8; 32];
+        let mut input = Vec::new();
+        input.extend_from_slice(&root);
+        input.extend_from_slice(&1u32.to_be_bytes()); // 1 item
+        input.extend_from_slice(&key);
+        input.push(0x00); // exclusion
+        input.extend_from_slice(&1u32.to_be_bytes()); // 1 proof node
+        input.extend_from_slice(&100u32.to_be_bytes()); // claims 100 bytes
+        input.extend_from_slice(&[0u8; 10]); // only 10 bytes
+
+        let result = mpt_verify(&Bytes::from(input), 100_000);
+        assert!(result.is_err());
+
+        match result.err() {
+            Some(PrecompileError::Other(msg)) => {
+                assert!(msg.contains("truncated proof node"));
+            }
+            other => panic!("Expected truncated error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_gas_calculation() {
+        let hashed_key = hash_key(b"epoch");
+        let value = 42u64.to_be_bytes().to_vec();
+        let (root, memdb) = build_test_trie(&[(&hashed_key, &value)]);
+        let proof = generate_proof(&memdb, &root, &[&hashed_key]);
+        let proof_count = proof.len() as u64;
+
+        let items = vec![(hashed_key.to_vec(), Some(value))];
+        let input = encode_input(&root, &items, &proof);
+        let result = mpt_verify(&Bytes::from(input), 100_000).unwrap();
+
+        let expected_gas = BASE_COST + 1 * PER_ITEM_COST + proof_count * PER_PROOF_NODE_COST;
+        assert_eq!(result.gas_used, expected_gas);
+    }
+
+    #[test]
+    fn test_large_trie_proof() {
+        // Build a trie with 100 entries, prove a subset
+        let entries: Vec<([u8; 32], Vec<u8>)> = (0..100u64)
+            .map(|i| {
+                let key = hash_key(format!("key_{}", i).as_bytes());
+                let value = i.to_be_bytes().to_vec();
+                (key, value)
+            })
+            .collect();
+
+        let trie_entries: Vec<(&[u8], &[u8])> = entries
+            .iter()
+            .map(|(k, v)| (k.as_slice(), v.as_slice()))
+            .collect();
+        let (root, memdb) = build_test_trie(&trie_entries);
+
+        // Prove every 13th key
+        let query_indices: Vec<usize> = (0..100).step_by(13).collect();
+        let query_keys: Vec<&[u8]> = query_indices
+            .iter()
+            .map(|&i| entries[i].0.as_slice())
+            .collect();
+        let proof = generate_proof(&memdb, &root, &query_keys);
+
+        let items: Vec<(Vec<u8>, Option<Vec<u8>>)> = query_indices
+            .iter()
+            .map(|&i| (entries[i].0.to_vec(), Some(entries[i].1.clone())))
+            .collect();
+        let input = encode_input(&root, &items, &proof);
+        let result = mpt_verify(&Bytes::from(input), 1_000_000);
+        assert!(result.is_ok(), "Expected success, got {:?}", result.err());
+    }
+}

--- a/crates/seismic/src/precompiles/mpt_verify.rs
+++ b/crates/seismic/src/precompiles/mpt_verify.rs
@@ -154,7 +154,9 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
 
     // Parse proof count
     if offset + 4 > input.len() {
-        return Err(PrecompileError::Other("input too short: missing proof_count".into()));
+        return Err(PrecompileError::Other(
+            "input too short: missing proof_count".into(),
+        ));
     }
     let proof_count = u32::from_be_bytes(
         input[offset..offset + 4]

--- a/crates/seismic/src/precompiles/mpt_verify.rs
+++ b/crates/seismic/src/precompiles/mpt_verify.rs
@@ -93,10 +93,18 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
     }
 
     // Parse root
-    let root: [u8; 32] = input[0..32].try_into().expect("slice is 32 bytes");
+    let root: [u8; 32] = input
+        .get(0..32)
+        .and_then(|s| s.try_into().ok())
+        .ok_or_else(|| PrecompileError::Other("input too short for root".into()))?;
 
     // Parse item count
-    let item_count = u32::from_be_bytes(input[32..36].try_into().expect("slice is 4 bytes"));
+    let item_count = u32::from_be_bytes(
+        input
+            .get(32..36)
+            .and_then(|s| s.try_into().ok())
+            .ok_or_else(|| PrecompileError::Other("input too short for item_count".into()))?,
+    );
     if item_count == 0 {
         return Err(PrecompileError::Other("item_count must be > 0".into()));
     }
@@ -114,11 +122,18 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
                 input.len() - offset
             )));
         }
-        let key = input[offset..offset + 32].to_vec();
+        let key = input
+            .get(offset..offset + 32)
+            .ok_or_else(|| {
+                PrecompileError::Other(format!("input too short for key at offset {offset}"))
+            })?
+            .to_vec();
         offset += 32;
 
         // Read has_value flag
-        let has_value = input[offset];
+        let has_value = *input.get(offset).ok_or_else(|| {
+            PrecompileError::Other(format!("input too short for has_value at offset {offset}"))
+        })?;
         offset += 1;
 
         if has_value == 0x01 {
@@ -129,9 +144,12 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
                 ));
             }
             let val_len = u32::from_be_bytes(
-                input[offset..offset + 4]
-                    .try_into()
-                    .expect("slice is 4 bytes"),
+                input
+                    .get(offset..offset + 4)
+                    .and_then(|s| s.try_into().ok())
+                    .ok_or_else(|| {
+                        PrecompileError::Other("input too short: missing value length".into())
+                    })?,
             ) as usize;
             offset += 4;
 
@@ -142,7 +160,12 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
                     input.len() - offset
                 )));
             }
-            let value = input[offset..offset + val_len].to_vec();
+            let value = input
+                .get(offset..offset + val_len)
+                .ok_or_else(|| {
+                    PrecompileError::Other("input too short for value".into())
+                })?
+                .to_vec();
             offset += val_len;
 
             items.push((key, Some(value)));
@@ -159,9 +182,12 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
         ));
     }
     let proof_count = u32::from_be_bytes(
-        input[offset..offset + 4]
-            .try_into()
-            .expect("slice is 4 bytes"),
+        input
+            .get(offset..offset + 4)
+            .and_then(|s| s.try_into().ok())
+            .ok_or_else(|| {
+                PrecompileError::Other("input too short: missing proof_count".into())
+            })?,
     ) as u64;
     offset += 4;
 
@@ -181,9 +207,14 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
             ));
         }
         let node_len = u32::from_be_bytes(
-            input[offset..offset + 4]
-                .try_into()
-                .expect("slice is 4 bytes"),
+            input
+                .get(offset..offset + 4)
+                .and_then(|s| s.try_into().ok())
+                .ok_or_else(|| {
+                    PrecompileError::Other(
+                        "truncated proof node: missing length prefix".into(),
+                    )
+                })?,
         ) as usize;
         offset += 4;
 
@@ -194,7 +225,14 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
                 input.len() - offset
             )));
         }
-        proof_nodes.push(input[offset..offset + node_len].to_vec());
+        proof_nodes.push(
+            input
+                .get(offset..offset + node_len)
+                .ok_or_else(|| {
+                    PrecompileError::Other("truncated proof node".into())
+                })?
+                .to_vec(),
+        );
         offset += node_len;
     }
 
@@ -204,7 +242,9 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
 
     // Success: return 0x01 left-padded to 32 bytes
     let mut output = vec![0u8; 32];
-    output[31] = 0x01;
+    if let Some(byte) = output.get_mut(31) {
+        *byte = 0x01;
+    }
 
     Ok(PrecompileOutput::new(gas_cost, output.into()))
 }

--- a/crates/seismic/src/precompiles/mpt_verify.rs
+++ b/crates/seismic/src/precompiles/mpt_verify.rs
@@ -242,6 +242,13 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::identity_op
+)]
 mod tests {
     use super::*;
     use hash_db::Hasher;

--- a/crates/seismic/src/precompiles/mpt_verify.rs
+++ b/crates/seismic/src/precompiles/mpt_verify.rs
@@ -89,8 +89,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
             "input too short: expected at least {} bytes, got {}",
             MIN_INPUT_LENGTH,
             input.len()
-        ))
-        .into());
+        )));
     }
 
     // Parse root
@@ -99,7 +98,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
     // Parse item count
     let item_count = u32::from_be_bytes(input[32..36].try_into().expect("slice is 4 bytes"));
     if item_count == 0 {
-        return Err(PrecompileError::Other("item_count must be > 0".into()).into());
+        return Err(PrecompileError::Other("item_count must be > 0".into()));
     }
 
     // Parse items: (key, Option<value>)
@@ -113,8 +112,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
                 "input too short for item at offset {}: need at least 33 more bytes, got {}",
                 offset,
                 input.len() - offset
-            ))
-            .into());
+            )));
         }
         let key = input[offset..offset + 32].to_vec();
         offset += 32;
@@ -126,9 +124,9 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
         if has_value == 0x01 {
             // Inclusion: read value length + value
             if offset + 4 > input.len() {
-                return Err(
-                    PrecompileError::Other("input too short: missing value length".into()).into(),
-                );
+                return Err(PrecompileError::Other(
+                    "input too short: missing value length".into(),
+                ));
             }
             let val_len = u32::from_be_bytes(
                 input[offset..offset + 4]
@@ -142,8 +140,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
                     "input too short: expected {} value bytes, only {} remaining",
                     val_len,
                     input.len() - offset
-                ))
-                .into());
+                )));
             }
             let value = input[offset..offset + val_len].to_vec();
             offset += val_len;
@@ -157,7 +154,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
 
     // Parse proof count
     if offset + 4 > input.len() {
-        return Err(PrecompileError::Other("input too short: missing proof_count".into()).into());
+        return Err(PrecompileError::Other("input too short: missing proof_count".into()));
     }
     let proof_count = u32::from_be_bytes(
         input[offset..offset + 4]
@@ -170,7 +167,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
     let gas_cost =
         BASE_COST + (item_count as u64) * PER_ITEM_COST + proof_count * PER_PROOF_NODE_COST;
     if gas_cost > gas_limit {
-        return Err(PrecompileError::OutOfGas.into());
+        return Err(PrecompileError::OutOfGas);
     }
 
     // Parse proof nodes
@@ -179,8 +176,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
         if offset + 4 > input.len() {
             return Err(PrecompileError::Other(
                 "truncated proof node: missing length prefix".into(),
-            )
-            .into());
+            ));
         }
         let node_len = u32::from_be_bytes(
             input[offset..offset + 4]
@@ -194,8 +190,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
                 "truncated proof node: expected {} bytes, only {} remaining",
                 node_len,
                 input.len() - offset
-            ))
-            .into());
+            )));
         }
         proof_nodes.push(input[offset..offset + node_len].to_vec());
         offset += node_len;

--- a/crates/seismic/src/precompiles/mpt_verify.rs
+++ b/crates/seismic/src/precompiles/mpt_verify.rs
@@ -162,9 +162,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
             }
             let value = input
                 .get(offset..offset + val_len)
-                .ok_or_else(|| {
-                    PrecompileError::Other("input too short for value".into())
-                })?
+                .ok_or_else(|| PrecompileError::Other("input too short for value".into()))?
                 .to_vec();
             offset += val_len;
 
@@ -185,9 +183,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
         input
             .get(offset..offset + 4)
             .and_then(|s| s.try_into().ok())
-            .ok_or_else(|| {
-                PrecompileError::Other("input too short: missing proof_count".into())
-            })?,
+            .ok_or_else(|| PrecompileError::Other("input too short: missing proof_count".into()))?,
     ) as u64;
     offset += 4;
 
@@ -211,9 +207,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
                 .get(offset..offset + 4)
                 .and_then(|s| s.try_into().ok())
                 .ok_or_else(|| {
-                    PrecompileError::Other(
-                        "truncated proof node: missing length prefix".into(),
-                    )
+                    PrecompileError::Other("truncated proof node: missing length prefix".into())
                 })?,
         ) as usize;
         offset += 4;
@@ -228,9 +222,7 @@ pub fn mpt_verify(input: &[u8], gas_limit: u64) -> PrecompileResult {
         proof_nodes.push(
             input
                 .get(offset..offset + node_len)
-                .ok_or_else(|| {
-                    PrecompileError::Other("truncated proof node".into())
-                })?
+                .ok_or_else(|| PrecompileError::Other("truncated proof node".into()))?
                 .to_vec(),
         );
         offset += node_len;


### PR DESCRIPTION
This adds a precompile at address `0x000000000000000000000000000000000000006A` for verifying Merkle Patricia Trie proofs. It supports both inclusion proofs and exclusion proofs.

### Input Format

```
root                    (32 bytes)
item_count              (4 bytes, big-endian u32)
  For each item:
    hashed_key          (32 bytes, keccak256 of the logical key)
    has_value           (1 byte: 0x01 for inclusion, 0x00 for exclusion)
    If inclusion:
      value_length      (4 bytes, big-endian u32)
      value             (value_length bytes)
proof_count             (4 bytes, big-endian u32)
  For each proof node:
    node_length         (4 bytes, big-endian u32)
    node                (node_length bytes)
```

### Output

Returns a single 32-byte value: `0x00...01` on success, or reverts on failure.

### Gas Cost

```
gas = 3000 + (item_count * 200) + (proof_count * 500)
```

The base cost of 3000 is comparable to `ecrecover` (3000 gas). Each additional item adds 200 gas, and each proof node adds 500 gas.

### Usage

**Direct `eth_call`**: Applications can verify proofs off-chain by calling the precompile with the root and proof data.

**On-chain**: Contracts can read the root from the EIP-4788 system contract and then call the precompile:

```solidity
contract MptProofVerifier {
    address constant BEACON_ROOTS = 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
    address constant MPT_PRECOMPILE = 0x000000000000000000000000000000000000006a;

    function verify(uint256 timestamp, bytes calldata proofData)
        external view returns (bytes32 root)
    {
        // 1. Read state root from the system contract
        (bool ok, bytes memory rootData) = BEACON_ROOTS.staticcall(
            abi.encode(timestamp)
        );
        require(ok && rootData.length == 32, "root lookup failed");
        root = abi.decode(rootData, (bytes32));

        // 2. Verify MPT proof against the root
        (bool ok2, bytes memory result) = MPT_PRECOMPILE.staticcall(
            abi.encodePacked(root, proofData)
        );
        require(
            ok2 && result.length >= 32 && uint8(result[31]) == 1,
            "MPT verification failed"
        );
    }
}
```