### PR TITLE
chore: bump seismic-alloy-core dep 1.3.1->1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,8 +256,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.3.1"
-source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=33e302d06f56bb4dda85359005af7e302f48272f#33e302d06f56bb4dda85359005af7e302f48272f"
+version = "1.4.1"
+source = "git+https://github.com/SeismicSystems/seismic-alloy-core.git?rev=68313cb636365501a699c47865807158544eace1#68313cb636365501a699c47865807158544eace1"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -265,16 +265,16 @@ dependencies = [
  "cfg-if",
  "const-hex",
  "derive_more",
- "foldhash",
+ "foldhash 0.2.0",
  "getrandom 0.3.3",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "indexmap 2.11.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.6.0",
  "rand 0.9.2",
  "ruint",
  "rustc-hash",
@@ -2142,6 +2142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,7 +2470,16 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "foldhash 0.2.0",
  "serde",
 ]
 
@@ -3874,6 +3889,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4288,7 +4314,7 @@ version = "7.0.5"
 dependencies = [
  "bitflags",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.5.1",
  "revm-bytecode",
  "revm-primitives",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,5 +179,5 @@ inherits = "test"
 opt-level = 3
 
 [patch.crates-io]
-seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "c6bc2ae15b619af1d0ec5e739a90b6f51dd7eb84"}
-alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
+seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "c6bc2ae15b619af1d0ec5e739a90b6f51dd7eb84" }
+alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "68313cb636365501a699c47865807158544eace1" }

--- a/bins/revme/src/cmd/blockchaintest.rs
+++ b/bins/revme/src/cmd/blockchaintest.rs
@@ -300,12 +300,12 @@ impl DebugInfo {
     fn capture_committed_state(
         state: &State<EmptyDB>,
     ) -> HashMap<Address, (AccountInfo, HashMap<U256, FlaggedStorage>)> {
-        let mut committed_state = HashMap::new();
+        let mut committed_state = HashMap::default();
 
         // Access the cache state to get all accounts
         for (address, cache_account) in &state.cache.accounts {
             if let Some(plain_account) = &cache_account.account {
-                let mut storage = HashMap::new();
+                let mut storage = HashMap::default();
                 for (key, value) in &plain_account.storage {
                     storage.insert(*key, *value);
                 }
@@ -394,7 +394,7 @@ fn validate_post_state(
             .account
             .as_ref()
             .map(|a| &a.storage)
-            .unwrap_or(&HashMap::new())
+            .unwrap_or(&HashMap::default())
             .iter()
         {
             let slot = *slot;
@@ -653,7 +653,7 @@ fn execute_blockchain_test(
     let mut state = State::builder().build();
 
     // Capture pre-state for debug info
-    let mut pre_state_debug = HashMap::new();
+    let mut pre_state_debug = HashMap::default();
 
     // Insert genesis state into database
     let genesis_state = test_case.pre.clone().into_genesis_state();

--- a/bins/revme/src/cmd/semantics/utils.rs
+++ b/bins/revme/src/cmd/semantics/utils.rs
@@ -119,9 +119,9 @@ pub(crate) fn extract_functions_from_source(
 ) -> Result<HashMap<String, Vec<String>>, Errors> {
     let content = fs::read_to_string(path)?;
 
-    let mut contract_functions: HashMap<String, Vec<String>> = HashMap::new();
+    let mut contract_functions: HashMap<String, Vec<String>> = HashMap::default();
     //parent --> child
-    let mut inheritance_map: HashMap<String, Vec<String>> = HashMap::new();
+    let mut inheritance_map: HashMap<String, Vec<String>> = HashMap::default();
     let mut current_contract = String::new();
     let mut collecting_functions = false;
 

--- a/crates/context/src/journal/test_flagged_storage.rs
+++ b/crates/context/src/journal/test_flagged_storage.rs
@@ -19,7 +19,7 @@ fn create_test_account(status: AccountStatus) -> Account {
         },
         transaction_id: 0,
         status,
-        storage: EvmStorage::new(),
+        storage: EvmStorage::default(),
     }
 }
 

--- a/crates/database/src/in_memory_db.rs
+++ b/crates/database/src/in_memory_db.rs
@@ -652,7 +652,7 @@ mod tests {
 
         let mut new_state = CacheDB::new(init_state);
         new_state
-            .replace_account_storage(account, [(key1, value1)].into())
+            .replace_account_storage(account, HashMap::from_iter([(key1, value1)]))
             .unwrap();
 
         assert_eq!(new_state.basic(account).unwrap().unwrap().nonce, nonce);

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -3,13 +3,14 @@ use revm::primitives::hardfork::SpecId::*;
 use revm::{
     context::host::LoadError,
     interpreter::{
+        _count, gas,
         gas::{
             CALL_STIPEND, COLD_SLOAD_COST_ADDITIONAL, CSTORE_FIXED_GAS, ISTANBUL_SLOAD_GAS,
             WARM_STORAGE_READ_COST,
         },
         interpreter_types::{InputsTr, InterpreterTypes, LoopControl, RuntimeFlag, StackTr},
         popn, popn_top, require_non_staticcall, Instruction, InstructionContext, InstructionResult,
-        Interpreter, InterpreterAction, _count, gas,
+        Interpreter, InterpreterAction,
     },
 };
 


### PR DESCRIPTION
seismic-alloy-core was bumped to 1.4.1 a while back but we forgot to update revm.

Note to auditors: merging this into the veridise-audit-fev-2026 branch since auditors are auditing the 1.4.1 rebase of seismic-alloy-core, so revm should have already been pointing to that commit.

Note: noticed we also forgot to bump seismic-foundry-fork-db repo to 1.4.1.