### PR TITLE
ci: fix seismic branch CI

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -96,9 +96,7 @@ jobs:
       - name: Clone seismic-solidity repo
         run: |
           TEMP_DIR=$(mktemp -d)
-          # Temporarily checking out the test--new-storage-opcode-semantics branch that fixes storage opcode semantic tests.
-          # TODO(samlaf): switch back to seismic (default) branch after we merge https://github.com/SeismicSystems/seismic-solidity/pull/130
-          git clone -b test--new-storage-opcode-semantics https://github.com/SeismicSystems/seismic-solidity.git "$TEMP_DIR/seismic-solidity"
+          git clone https://github.com/SeismicSystems/seismic-solidity.git "$TEMP_DIR/seismic-solidity"
           echo "SEISMIC_SOLIDITY_PATH=$TEMP_DIR/seismic-solidity" >> $GITHUB_ENV
           echo "seismic-solidity cloned to: $TEMP_DIR/seismic-solidity"
       - name: Install latest ssolc release

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -3,13 +3,13 @@ use revm::primitives::hardfork::SpecId::*;
 use revm::{
     context::host::LoadError,
     interpreter::{
+        _count, gas,
         gas::{
             CALL_STIPEND, COLD_SLOAD_COST_ADDITIONAL, CSTORE_FIXED_GAS, ISTANBUL_SLOAD_GAS,
             WARM_STORAGE_READ_COST,
         },
         interpreter_types::{InputsTr, InterpreterTypes, RuntimeFlag, StackTr},
         popn, popn_top, require_non_staticcall, Instruction, InstructionContext, InstructionResult,
-        _count, gas,
     },
 };
 


### PR DESCRIPTION
## Summary
- Fix `cargo fmt` failure: reorder imports in `confidential_storage.rs` to match nightly rustfmt expectations
- Fix semantic test failure: clone seismic-solidity default branch instead of the now-stale `test--new-storage-opcode-semantics` branch (seismic-solidity#130 has been merged)

## Test plan
- [ ] CI passes on this PR (rustfmt + semantic tests)