### PR TITLE
fix(handler): call discard_tx() on custom halt to reset warm slots

### DIFF
--- a/crates/seismic/src/handler.rs
+++ b/crates/seismic/src/handler.rs
@@ -65,8 +65,9 @@ where
                 if let Some(seismic_reason) =
                     SeismicHaltReason::try_from_error_string(&e.to_string())
                 {
-                    // Same as catch error, except don't discard tx
+                    // Same as catch error
                     evm.ctx().local_mut().clear();
+                    evm.ctx().journal_mut().discard_tx();
                     evm.frame_stack().clear();
                     evm.ctx().chain_mut().reset_rng();
 

--- a/crates/seismic/src/handler.rs
+++ b/crates/seismic/src/handler.rs
@@ -136,6 +136,7 @@ mod tests {
     use crate::{api::default_ctx::SeismicContext, DefaultSeismicContext, SeismicBuilder};
     use revm::{
         context::{result::EVMError, Context},
+        context_interface::context::ContextError,
         database_interface::EmptyDB,
         handler::EthFrame,
         interpreter::{CallOutcome, Gas, InstructionResult, InterpreterResult},
@@ -191,5 +192,59 @@ mod tests {
         assert_eq!(gas.remaining(), 0);
         assert_eq!(gas.spent(), 100);
         assert_eq!(gas.refunded(), 0);
+    }
+
+    /// Regression test: custom halt path must call discard_tx() so that
+    /// transaction_id advances and warm slot/account tracking is reset.
+    /// Without discard_tx(), slots warmed in a halted tx would remain warm
+    /// for the next tx, causing incorrect (cheaper) gas accounting.
+    #[test]
+    fn test_custom_halt_discards_tx_and_advances_transaction_id() {
+        let ctx = Context::seismic().modify_tx_chained(|tx| {
+            tx.base.gas_limit = 100;
+        });
+
+        let mut evm = ctx.build_seismic_evm();
+
+        let tx_id_before = evm.ctx().journal().inner.transaction_id;
+
+        // Inject a custom error that triggers the SeismicHaltReason path.
+        *evm.ctx().error() = Err(ContextError::Custom(
+            "InvalidPrivateStorageAccess".to_string(),
+        ));
+
+        let frame_result = FrameResult::Call(CallOutcome::new(
+            InterpreterResult {
+                result: InstructionResult::Stop,
+                output: Bytes::new(),
+                gas: Gas::new(90),
+            },
+            0..0,
+        ));
+
+        let mut handler =
+            SeismicHandler::<_, EVMError<_, InvalidTransaction>, EthFrame<EthInterpreter>>::new();
+
+        let result = handler.execution_result(&mut evm, frame_result).unwrap();
+
+        // Should produce a Halt with the correct reason.
+        assert!(
+            matches!(
+                result,
+                ExecutionResult::Halt {
+                    reason: SeismicHaltReason::InvalidPrivateStorageAccess,
+                    ..
+                }
+            ),
+            "Expected Halt with InvalidPrivateStorageAccess, got: {result:?}"
+        );
+
+        // transaction_id must have advanced, proving discard_tx() was called.
+        let tx_id_after = evm.ctx().journal().inner.transaction_id;
+        assert_eq!(
+            tx_id_after,
+            tx_id_before + 1,
+            "transaction_id should advance after custom halt (discard_tx must be called)"
+        );
     }
 }


### PR DESCRIPTION
Re-opening #200 with rebase merge (was accidentally squash-merged).

## Summary

Fixes Veridise audit issue VER-842: slot warmness persisting across transactions.

The custom halt path in `execution_result()` returned early without calling `discard_tx()`, so `transaction_id` was never advanced and warm/cold slot tracking carried over to subsequent transactions. This could cause undercharged gas for slots that should be cold.

- Add `discard_tx()` call to the `SeismicHaltReason` halt path, matching the cleanup in `catch_error()`
- Add regression test that asserts `transaction_id` advances after a custom halt

## Test plan

- [x] New test fails without the fix, passes with it
- [x] All existing handler tests pass