### PR TITLE
refactor: SeismicHaltReason->SeismicRevertReason + remove halt machinery

### DIFF
--- a/bins/revme/src/cmd/semantics/evm_handler.rs
+++ b/bins/revme/src/cmd/semantics/evm_handler.rs
@@ -15,7 +15,7 @@ use crate::cmd::semantics::{test_cases::TestStep, utils::verify_emitted_events};
 use super::{
     compiler_evm_versions::EVMVersion,
     test_cases::{ExpectedOutputs, TestCase},
-    utils::{mainnet_to_seismic, verify_expected_balances, verify_storage_empty},
+    utils::{verify_expected_balances, verify_storage_empty},
     Errors,
 };
 
@@ -190,7 +190,7 @@ impl EvmExecutor {
                     Errors::EVMError(format!("DEPLOY transaction error: {:?}", err.to_string()))
                 })?
             };
-            mainnet_to_seismic(raw)
+            raw
         };
 
         let (contract_address, logs) = match deploy_out.clone().result {
@@ -385,7 +385,7 @@ impl EvmExecutor {
                     ))
                 })?
             };
-            mainnet_to_seismic(raw)
+            raw
         };
 
         let logs = match out.clone().result {

--- a/bins/revme/src/cmd/semantics/utils.rs
+++ b/bins/revme/src/cmd/semantics/utils.rs
@@ -358,4 +358,3 @@ pub(crate) fn bytes_to_fixed(bytes: Bytes) -> FixedBytes<32> {
     fixed.copy_from_slice(slice);
     fixed.into()
 }
-

--- a/bins/revme/src/cmd/semantics/utils.rs
+++ b/bins/revme/src/cmd/semantics/utils.rs
@@ -1,9 +1,7 @@
-use context::result::{ExecutionResult, HaltReason, ResultAndState};
 use log::error;
 use primitives::HashMap;
 use revm::database::{CacheDB, EmptyDB};
 use revm::primitives::{Address, Bytes, FixedBytes, Log, LogData, U256};
-use seismic_revm::SeismicHaltReason;
 
 use crate::cmd::semantics::Errors;
 use std::{
@@ -361,29 +359,3 @@ pub(crate) fn bytes_to_fixed(bytes: Bytes) -> FixedBytes<32> {
     fixed.into()
 }
 
-pub fn mainnet_to_seismic(raw: ResultAndState<HaltReason>) -> ResultAndState<SeismicHaltReason> {
-    let ResultAndState { result, state } = raw;
-    let result = match result {
-        ExecutionResult::Success {
-            reason,
-            output,
-            logs,
-            gas_used,
-            gas_refunded,
-        } => ExecutionResult::Success {
-            reason,
-            output,
-            logs,
-            gas_used,
-            gas_refunded,
-        },
-        ExecutionResult::Revert { output, gas_used } => {
-            ExecutionResult::Revert { output, gas_used }
-        }
-        ExecutionResult::Halt { reason, gas_used } => ExecutionResult::Halt {
-            reason: SeismicHaltReason::from(reason),
-            gas_used,
-        },
-    };
-    ResultAndState { result, state }
-}

--- a/bins/revme/src/cmd/statetest/merkle_trie.rs
+++ b/bins/revme/src/cmd/statetest/merkle_trie.rs
@@ -1,12 +1,12 @@
 use std::convert::Infallible;
 
 use alloy_rlp::{RlpEncodable, RlpMaxEncodedLen};
+use context::result::HaltReason;
 use context::result::{EVMError, ExecutionResult, InvalidTransaction};
 use database::{EmptyDB, PlainAccount, State};
 use hash_db::Hasher;
 use plain_hasher::PlainHasher;
 use revm::primitives::{keccak256, Address, Log, B256, U256};
-use context::result::HaltReason;
 use triehash::sec_trie_root;
 
 pub struct TestValidationResult {

--- a/bins/revme/src/cmd/statetest/merkle_trie.rs
+++ b/bins/revme/src/cmd/statetest/merkle_trie.rs
@@ -6,7 +6,7 @@ use database::{EmptyDB, PlainAccount, State};
 use hash_db::Hasher;
 use plain_hasher::PlainHasher;
 use revm::primitives::{keccak256, Address, Log, B256, U256};
-use seismic_revm::SeismicHaltReason as HaltReason;
+use context::result::HaltReason;
 use triehash::sec_trie_root;
 
 pub struct TestValidationResult {

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -5,6 +5,7 @@ use database::State;
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use inspector::{inspectors::TracerEip3155, InspectCommitEvm};
 use primitives::U256;
+use revm::context_interface::result::HaltReason;
 use revm::{
     context::{block::BlockEnv, cfg::CfgEnv},
     context_interface::{
@@ -15,7 +16,6 @@ use revm::{
     primitives::{Bytes, B256},
     Context, ExecuteCommitEvm,
 };
-use revm::context_interface::result::HaltReason;
 use seismic_revm::{
     DefaultSeismicContext, SeismicBuilder, SeismicSpecId as SpecId, SeismicTransaction,
 };
@@ -223,10 +223,7 @@ fn check_evm_execution(
     test: &Test,
     expected_output: Option<&Bytes>,
     test_name: &str,
-    exec_result: &Result<
-        ExecutionResult<HaltReason>,
-        EVMError<Infallible, InvalidTransaction>,
-    >,
+    exec_result: &Result<ExecutionResult<HaltReason>, EVMError<Infallible, InvalidTransaction>>,
     db: &mut State<EmptyDB>,
     spec: SpecId,
     print_json_outcome: bool,

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -15,9 +15,9 @@ use revm::{
     primitives::{Bytes, B256},
     Context, ExecuteCommitEvm,
 };
+use revm::context_interface::result::HaltReason;
 use seismic_revm::{
-    DefaultSeismicContext, SeismicBuilder, SeismicHaltReason, SeismicHaltReason as HaltReason,
-    SeismicSpecId as SpecId, SeismicTransaction,
+    DefaultSeismicContext, SeismicBuilder, SeismicSpecId as SpecId, SeismicTransaction,
 };
 use serde_json::json;
 use statetest_types::{SpecName, Test, TestSuite, TestUnit};
@@ -224,7 +224,7 @@ fn check_evm_execution(
     expected_output: Option<&Bytes>,
     test_name: &str,
     exec_result: &Result<
-        ExecutionResult<SeismicHaltReason>,
+        ExecutionResult<HaltReason>,
         EVMError<Infallible, InvalidTransaction>,
     >,
     db: &mut State<EmptyDB>,

--- a/crates/seismic/src/api/exec.rs
+++ b/crates/seismic/src/api/exec.rs
@@ -1,7 +1,7 @@
 use crate::{
     evm::SeismicEvm, handler::SeismicHandler,
     instructions::instruction_provider::SeismicInstructions, transaction::abstraction::SeismicTxTr,
-    SeismicChain, SeismicHaltReason, SeismicSpecId,
+    SeismicChain, SeismicSpecId,
 };
 use revm::{
     context::{
@@ -9,7 +9,7 @@ use revm::{
         ContextSetters,
     },
     context_interface::{
-        result::{EVMError, ExecutionResult},
+        result::{EVMError, ExecutionResult, HaltReason},
         Cfg, ContextTr, Database, JournalTr,
     },
     handler::{EthFrame, Handler, PrecompileProvider},
@@ -53,7 +53,7 @@ where
     type Block = <CTX as ContextTr>::Block;
     type State = EvmState;
     type Error = SeismicError<CTX>;
-    type ExecutionResult = ExecutionResult<SeismicHaltReason>;
+    type ExecutionResult = ExecutionResult<HaltReason>;
 
     fn set_block(&mut self, block: Self::Block) {
         self.0.ctx.set_block(block);

--- a/crates/seismic/src/evm.rs
+++ b/crates/seismic/src/evm.rs
@@ -195,7 +195,7 @@ mod tests {
     use crate::precompiles::rng::precompile::{calculate_fill_cost, calculate_init_cost};
     use crate::transaction::abstraction::SeismicTransaction;
     use crate::{
-        DefaultSeismicContext, SeismicBuilder, SeismicChain, SeismicContext, SeismicHaltReason,
+        DefaultSeismicContext, SeismicBuilder, SeismicChain, SeismicContext, SeismicRevertReason,
         SeismicSpecId,
     };
     use anyhow::bail;
@@ -299,8 +299,8 @@ mod tests {
     }
 
     fn assert_storage_access_reverts(
-        result: &ResultAndState<SeismicHaltReason>,
-        expected_reason: SeismicHaltReason,
+        result: &ResultAndState,
+        expected_reason: SeismicRevertReason,
     ) {
         match &result.result {
             ExecutionResult::Revert { output, .. } => {
@@ -333,7 +333,7 @@ mod tests {
 
         let result = evm.replay()?;
 
-        assert_storage_access_reverts(&result, SeismicHaltReason::InvalidPublicStorageAccess);
+        assert_storage_access_reverts(&result, SeismicRevertReason::InvalidPublicStorageAccess);
         Ok(())
     }
 
@@ -355,7 +355,7 @@ mod tests {
 
         let result = evm.replay()?;
 
-        assert_storage_access_reverts(&result, SeismicHaltReason::InvalidPrivateStorageAccess);
+        assert_storage_access_reverts(&result, SeismicRevertReason::InvalidPrivateStorageAccess);
         Ok(())
     }
 

--- a/crates/seismic/src/handler.rs
+++ b/crates/seismic/src/handler.rs
@@ -1,11 +1,14 @@
 //!Handler related to Seismic chain
-use crate::{api::exec::SeismicContextTr, SeismicHaltReason};
+use crate::api::exec::SeismicContextTr;
 use revm::{
     context::{
         result::{ExecutionResult, InvalidTransaction},
-        ContextTr, JournalTr, LocalContextTr, Transaction,
+        ContextTr, JournalTr, LocalContextTr,
     },
-    context_interface::{context::ContextError, result::FromStringError},
+    context_interface::{
+        context::ContextError,
+        result::{FromStringError, HaltReason},
+    },
     handler::{
         handler::EvmTrError, post_execution, EthFrame, EvmTr, FrameResult, FrameTr, Handler,
         MainnetHandler,
@@ -42,17 +45,14 @@ where
 {
     type Evm = EVM;
     type Error = ERROR;
-    type HaltReason = SeismicHaltReason;
+    type HaltReason = HaltReason;
 
     /// Processes the final execution output.
     ///
-    /// This method, retrieves the final state from the journal, converts internal results to the external output format.
-    /// Internal state is cleared and EVM is prepared for the next transaction.
-    ///
-    /// Seismic Addendum
-    /// Given that we can't yet pass instruction_result which aren't in the InstructionResult enum,
-    /// We leverage context_error to bubble up our instruction set specific errors! We also clear
-    /// the rng state on returns that won't go through catch_error.
+    /// This method retrieves the final state from the journal, converts internal results
+    /// to the external output format. Internal state is cleared and EVM is prepared for
+    /// the next transaction. We also clear the rng state on returns that won't go through
+    /// catch_error.
     #[inline]
     fn execution_result(
         &mut self,
@@ -62,20 +62,6 @@ where
         match core::mem::replace(evm.ctx().error(), Ok(())) {
             Err(ContextError::Db(e)) => return Err(e.into()),
             Err(ContextError::Custom(e)) => {
-                if let Some(seismic_reason) =
-                    SeismicHaltReason::try_from_error_string(&e.to_string())
-                {
-                    // Same as catch error
-                    evm.ctx().local_mut().clear();
-                    evm.ctx().journal_mut().discard_tx();
-                    evm.frame_stack().clear();
-                    evm.ctx().chain_mut().reset_rng();
-
-                    return Ok(ExecutionResult::Halt {
-                        reason: seismic_reason,
-                        gas_used: evm.ctx().tx().gas_limit(),
-                    });
-                }
                 return Err(Self::Error::from_string(e));
             }
             Ok(_) => (),
@@ -195,12 +181,12 @@ mod tests {
         assert_eq!(gas.refunded(), 0);
     }
 
-    /// Regression test: custom halt path must call discard_tx() so that
+    /// Regression test: catch_error must call discard_tx() so that
     /// transaction_id advances and warm slot/account tracking is reset.
-    /// Without discard_tx(), slots warmed in a halted tx would remain warm
+    /// Without discard_tx(), slots warmed in a failed tx would remain warm
     /// for the next tx, causing incorrect (cheaper) gas accounting.
     #[test]
-    fn test_custom_halt_discards_tx_and_advances_transaction_id() {
+    fn test_catch_error_discards_tx_and_advances_transaction_id() {
         let ctx = Context::seismic().modify_tx_chained(|tx| {
             tx.base.gas_limit = 100;
         });
@@ -209,9 +195,9 @@ mod tests {
 
         let tx_id_before = evm.ctx().journal().inner.transaction_id;
 
-        // Inject a custom error that triggers the SeismicHaltReason path.
+        // Inject a context error that triggers the catch_error path.
         *evm.ctx().error() = Err(ContextError::Custom(
-            "InvalidPrivateStorageAccess".to_string(),
+            "some error".to_string(),
         ));
 
         let frame_result = FrameResult::Call(CallOutcome::new(
@@ -226,26 +212,17 @@ mod tests {
         let mut handler =
             SeismicHandler::<_, EVMError<_, InvalidTransaction>, EthFrame<EthInterpreter>>::new();
 
-        let result = handler.execution_result(&mut evm, frame_result).unwrap();
-
-        // Should produce a Halt with the correct reason.
-        assert!(
-            matches!(
-                result,
-                ExecutionResult::Halt {
-                    reason: SeismicHaltReason::InvalidPrivateStorageAccess,
-                    ..
-                }
-            ),
-            "Expected Halt with InvalidPrivateStorageAccess, got: {result:?}"
-        );
+        // execution_result returns Err for context errors, which the
+        // execution loop passes to catch_error.
+        let err = handler.execution_result(&mut evm, frame_result).unwrap_err();
+        let _ = handler.catch_error(&mut evm, err);
 
         // transaction_id must have advanced, proving discard_tx() was called.
         let tx_id_after = evm.ctx().journal().inner.transaction_id;
         assert_eq!(
             tx_id_after,
             tx_id_before + 1,
-            "transaction_id should advance after custom halt (discard_tx must be called)"
+            "transaction_id should advance after catch_error (discard_tx must be called)"
         );
     }
 }

--- a/crates/seismic/src/handler.rs
+++ b/crates/seismic/src/handler.rs
@@ -196,9 +196,7 @@ mod tests {
         let tx_id_before = evm.ctx().journal().inner.transaction_id;
 
         // Inject a context error that triggers the catch_error path.
-        *evm.ctx().error() = Err(ContextError::Custom(
-            "some error".to_string(),
-        ));
+        *evm.ctx().error() = Err(ContextError::Custom("some error".to_string()));
 
         let frame_result = FrameResult::Call(CallOutcome::new(
             InterpreterResult {
@@ -214,7 +212,9 @@ mod tests {
 
         // execution_result returns Err for context errors, which the
         // execution loop passes to catch_error.
-        let err = handler.execution_result(&mut evm, frame_result).unwrap_err();
+        let err = handler
+            .execution_result(&mut evm, frame_result)
+            .unwrap_err();
         let _ = handler.catch_error(&mut evm, err);
 
         // transaction_id must have advanced, proving discard_tx() was called.

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -1,4 +1,4 @@
-use crate::{check, SeismicHaltReason, SeismicHost};
+use crate::{check, SeismicHost, SeismicRevertReason};
 use revm::primitives::hardfork::SpecId::*;
 use revm::{
     context::host::LoadError,
@@ -19,9 +19,9 @@ use revm::{
 /// Unlike `halt_fatal()`, this produces a regular revert that callers can catch
 /// and handle. The reason is included in the revert output bytes, similar to
 /// Solidity's `revert CustomError()`.
-fn halt_with_revert_reason<WIRE: InterpreterTypes>(
+fn revert_with_reason<WIRE: InterpreterTypes>(
     interpreter: &mut Interpreter<WIRE>,
-    reason: SeismicHaltReason,
+    reason: SeismicRevertReason,
 ) {
     interpreter
         .bytecode
@@ -65,9 +65,9 @@ pub fn sload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
                     gas!(context.interpreter, COLD_SLOAD_COST_ADDITIONAL);
                 }
                 if storage.is_private {
-                    halt_with_revert_reason(
+                    revert_with_reason(
                         context.interpreter,
-                        SeismicHaltReason::InvalidPrivateStorageAccess,
+                        SeismicRevertReason::InvalidPrivateStorageAccess,
                     );
                     return;
                 }
@@ -82,9 +82,9 @@ pub fn sload<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
             return context.interpreter.halt_fatal();
         };
         if storage.is_private {
-            halt_with_revert_reason(
+            revert_with_reason(
                 context.interpreter,
-                SeismicHaltReason::InvalidPrivateStorageAccess,
+                SeismicRevertReason::InvalidPrivateStorageAccess,
             );
             return;
         }
@@ -168,9 +168,9 @@ pub fn sstore<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
 
     // Privacy check: SSTORE cannot write to private slots
     if state_load.data.present_value.is_private {
-        halt_with_revert_reason(
+        revert_with_reason(
             context.interpreter,
-            SeismicHaltReason::InvalidPrivateStorageAccess,
+            SeismicRevertReason::InvalidPrivateStorageAccess,
         );
         return;
     }
@@ -240,9 +240,9 @@ pub fn cstore<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
             if !state_load.data.present_value.is_private
                 && !state_load.data.present_value.value.is_zero()
             {
-                halt_with_revert_reason(
+                revert_with_reason(
                     context.interpreter,
-                    SeismicHaltReason::InvalidPublicStorageAccess,
+                    SeismicRevertReason::InvalidPublicStorageAccess,
                 );
             }
         }
@@ -751,7 +751,7 @@ mod tests {
     /// | CSTORE(y) | (y, private) | HALT        | (y, private) | (y, private) |
     mod semantics_tests {
         use super::*;
-        use crate::SeismicHaltReason;
+        use crate::SeismicRevertReason;
         use revm::context::host::LoadError;
         use revm::context_interface::journaled_state::{AccountInfoLoad, AccountLoad, StateLoad};
         use revm::database::EmptyDB;
@@ -763,7 +763,7 @@ mod tests {
         /// Asserts that the interpreter reverted with the expected reason in output bytes.
         fn assert_revert_with_reason(
             interp: &mut Interpreter<EthInterpreter>,
-            expected: SeismicHaltReason,
+            expected: SeismicRevertReason,
         ) {
             assert_eq!(
                 interp.bytecode.instruction_result(),
@@ -1032,7 +1032,7 @@ mod tests {
                 host: &mut host,
             });
 
-            assert_revert_with_reason(&mut interp, SeismicHaltReason::InvalidPrivateStorageAccess);
+            assert_revert_with_reason(&mut interp, SeismicRevertReason::InvalidPrivateStorageAccess);
         }
 
         #[test]
@@ -1047,7 +1047,7 @@ mod tests {
                 host: &mut host,
             });
 
-            assert_revert_with_reason(&mut interp, SeismicHaltReason::InvalidPrivateStorageAccess);
+            assert_revert_with_reason(&mut interp, SeismicRevertReason::InvalidPrivateStorageAccess);
         }
 
         // CLOAD tests
@@ -1163,7 +1163,7 @@ mod tests {
                 host: &mut host,
             });
 
-            assert_revert_with_reason(&mut interp, SeismicHaltReason::InvalidPrivateStorageAccess);
+            assert_revert_with_reason(&mut interp, SeismicRevertReason::InvalidPrivateStorageAccess);
         }
 
         #[test]
@@ -1179,7 +1179,7 @@ mod tests {
                 host: &mut host,
             });
 
-            assert_revert_with_reason(&mut interp, SeismicHaltReason::InvalidPrivateStorageAccess);
+            assert_revert_with_reason(&mut interp, SeismicRevertReason::InvalidPrivateStorageAccess);
         }
 
         // CSTORE tests
@@ -1213,7 +1213,7 @@ mod tests {
                 host: &mut host,
             });
 
-            assert_revert_with_reason(&mut interp, SeismicHaltReason::InvalidPublicStorageAccess);
+            assert_revert_with_reason(&mut interp, SeismicRevertReason::InvalidPublicStorageAccess);
         }
 
         #[test]

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -1032,7 +1032,10 @@ mod tests {
                 host: &mut host,
             });
 
-            assert_revert_with_reason(&mut interp, SeismicRevertReason::InvalidPrivateStorageAccess);
+            assert_revert_with_reason(
+                &mut interp,
+                SeismicRevertReason::InvalidPrivateStorageAccess,
+            );
         }
 
         #[test]
@@ -1047,7 +1050,10 @@ mod tests {
                 host: &mut host,
             });
 
-            assert_revert_with_reason(&mut interp, SeismicRevertReason::InvalidPrivateStorageAccess);
+            assert_revert_with_reason(
+                &mut interp,
+                SeismicRevertReason::InvalidPrivateStorageAccess,
+            );
         }
 
         // CLOAD tests
@@ -1163,7 +1169,10 @@ mod tests {
                 host: &mut host,
             });
 
-            assert_revert_with_reason(&mut interp, SeismicRevertReason::InvalidPrivateStorageAccess);
+            assert_revert_with_reason(
+                &mut interp,
+                SeismicRevertReason::InvalidPrivateStorageAccess,
+            );
         }
 
         #[test]
@@ -1179,7 +1188,10 @@ mod tests {
                 host: &mut host,
             });
 
-            assert_revert_with_reason(&mut interp, SeismicRevertReason::InvalidPrivateStorageAccess);
+            assert_revert_with_reason(
+                &mut interp,
+                SeismicRevertReason::InvalidPrivateStorageAccess,
+            );
         }
 
         // CSTORE tests

--- a/crates/seismic/src/lib.rs
+++ b/crates/seismic/src/lib.rs
@@ -22,6 +22,6 @@ pub use api::{
 pub use chain::seismic_chain::SeismicChain;
 pub use evm::SeismicEvm;
 pub use instructions::seismic_host::SeismicHost;
-pub use result::SeismicHaltReason;
+pub use result::SeismicRevertReason;
 pub use spec::*;
 pub use transaction::abstraction::SeismicTransaction;

--- a/crates/seismic/src/result.rs
+++ b/crates/seismic/src/result.rs
@@ -1,78 +1,46 @@
 use core::fmt;
-use std::convert::Infallible;
 
-use revm::{
-    context_interface::{context::ContextError, result::HaltReason},
-    primitives::Bytes,
-};
+use revm::primitives::Bytes;
 
+/// Seismic-specific EVM revert reasons.
+///
+/// These are injected as standard EVM reverts (`InstructionResult::Revert`) with
+/// the reason encoded in the revert output bytes. This means:
+///
+/// - **Callers can catch them**: an outer contract using try/catch will see a revert
+///   with `revert_bytes()` as output, rather than a halt which returns no data.
+/// - **RPC surfaces them clearly**: `eth_call` returns `"execution reverted: <reason>"`
+///   with the reason bytes as data, giving developers a clear error message.
+/// - **Gas is preserved**: only gas actually consumed is charged, unlike a halt which
+///   burns all gas allocated to the frame.
+///
+/// See `revert_with_reason()` in `confidential_storage.rs` for the injection point.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum SeismicHaltReason {
-    Base(HaltReason),
-    /// Invalid Private Storage Access: Cannot access private storage with public instructions
+pub enum SeismicRevertReason {
+    /// SLOAD/SSTORE on a private storage slot.
     InvalidPrivateStorageAccess,
-    /// Invalid Public Storage Access: Cannot access public storage with private instructions
+    /// CSTORE on a non-zero public storage slot.
     InvalidPublicStorageAccess,
 }
 
-impl SeismicHaltReason {
+impl SeismicRevertReason {
     /// Returns the reason encoded as bytes for inclusion in revert output.
     pub fn revert_bytes(&self) -> Bytes {
         match self {
             Self::InvalidPublicStorageAccess => Bytes::from_static(b"InvalidPublicStorageAccess"),
-            Self::InvalidPrivateStorageAccess => Bytes::from_static(b"InvalidPrivateStorageAccess"),
-            Self::Base(_) => Bytes::new(),
-        }
-    }
-
-    pub fn try_from_error_string(error_str: &str) -> Option<Self> {
-        match () {
-            _ if error_str.contains("InvalidPublicStorageAccess") => {
-                Some(Self::InvalidPublicStorageAccess)
+            Self::InvalidPrivateStorageAccess => {
+                Bytes::from_static(b"InvalidPrivateStorageAccess")
             }
-            _ if error_str.contains("InvalidPrivateStorageAccess") => {
-                Some(Self::InvalidPrivateStorageAccess)
-            }
-            _ => None,
-        }
-    }
-
-    pub fn try_from_error_string_exact(error_str: &str) -> Option<Self> {
-        match error_str {
-            "FatalExternalError: InvalidPublicStorageAccess" => {
-                Some(Self::InvalidPublicStorageAccess)
-            }
-            "FatalExternalError: InvalidPrivateStorageAccess" => {
-                Some(Self::InvalidPrivateStorageAccess)
-            }
-            _ => None,
         }
     }
 }
 
-impl From<HaltReason> for SeismicHaltReason {
-    fn from(value: HaltReason) -> Self {
-        Self::Base(value)
-    }
-}
-
-impl fmt::Display for SeismicHaltReason {
+impl fmt::Display for SeismicRevertReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SeismicHaltReason::Base(_) => write!(f, "Base error"),
-            SeismicHaltReason::InvalidPrivateStorageAccess => {
-                write!(f, "InvalidPrivateStorageAccess")
-            }
-            SeismicHaltReason::InvalidPublicStorageAccess => {
-                write!(f, "InvalidPublicStorageAccess")
-            }
+            Self::InvalidPrivateStorageAccess => write!(f, "InvalidPrivateStorageAccess"),
+            Self::InvalidPublicStorageAccess => write!(f, "InvalidPublicStorageAccess"),
         }
-    }
-}
-
-impl From<SeismicHaltReason> for ContextError<Infallible> {
-    fn from(reason: SeismicHaltReason) -> Self {
-        ContextError::Custom(reason.to_string())
     }
 }

--- a/crates/seismic/src/result.rs
+++ b/crates/seismic/src/result.rs
@@ -29,9 +29,7 @@ impl SeismicRevertReason {
     pub fn revert_bytes(&self) -> Bytes {
         match self {
             Self::InvalidPublicStorageAccess => Bytes::from_static(b"InvalidPublicStorageAccess"),
-            Self::InvalidPrivateStorageAccess => {
-                Bytes::from_static(b"InvalidPrivateStorageAccess")
-            }
+            Self::InvalidPrivateStorageAccess => Bytes::from_static(b"InvalidPrivateStorageAccess"),
         }
     }
 }


### PR DESCRIPTION
Privacy violations (SLOAD/SSTORE on private slots, CSTORE on non-zero public slots) were changed from transaction-level halts to standard EVM reverts in https://github.com/SeismicSystems/seismic-revm/pull/193, but the error types and handler plumbing still treated them as halts. This cleans that up.

This will also bubble up to cleaner semantics in seismic-reth (no need for a similar api-level SeismicApiHaltError or whatever its called).