### PR TITLE
fix: veridise-843: Removing access lists

### DIFF
--- a/crates/ee-tests/src/revm_tests.rs
+++ b/crates/ee-tests/src/revm_tests.rs
@@ -4,8 +4,9 @@ use crate::TestdataConfig;
 use revm::{
     bytecode::opcode,
     context::{ContextTr, TxEnv},
+    context_interface::transaction::{AccessList, AccessListItem},
     database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET},
-    primitives::{address, b256, hardfork::SpecId, Bytes, TxKind, KECCAK_EMPTY, U256},
+    primitives::{address, b256, hardfork::SpecId, Bytes, TxKind, B256, KECCAK_EMPTY, U256},
     state::{AccountStatus, Bytecode},
     Context, ExecuteEvm, MainBuilder, MainContext,
 };
@@ -282,4 +283,59 @@ fn test_disable_balance_check() {
     let returned_balance = U256::from_be_slice(result.output().unwrap().as_ref());
     let expected_balance = U256::ZERO;
     assert_eq!(returned_balance, expected_balance);
+}
+
+/// SEISMIC: Verifies that EIP-2930 access lists are ignored.
+///
+/// Access lists normally pre-warm storage slots so that subsequent SLOADs cost
+/// WARM_STORAGE_READ_COST (100) instead of COLD_SLOAD_COST (2100). Since Seismic
+/// ignores access lists to prevent metadata leakage of private storage keys,
+/// a transaction with an access list should use exactly the same gas as one without.
+#[test]
+fn test_access_list_ignored() {
+    // Bytecode: SLOAD slot 0, discard result, stop.
+    // PUSH1 0x00  SLOAD  POP  STOP
+    const SLOAD_BYTECODE: &[u8] = &[opcode::PUSH1, 0x00, opcode::SLOAD, opcode::POP, opcode::STOP];
+
+    // --- Run without access list ---
+    let mut evm_no_al = Context::mainnet()
+        .modify_cfg_chained(|cfg| cfg.spec = SpecId::BERLIN)
+        .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy(
+            SLOAD_BYTECODE.into(),
+        )))
+        .build_mainnet();
+
+    let result_no_al = evm_no_al
+        .transact_one(TxEnv::builder_for_bench().build_fill())
+        .unwrap();
+    assert!(result_no_al.is_success());
+
+    // --- Run with access list that includes BENCH_TARGET + slot 0 ---
+    let mut evm_with_al = Context::mainnet()
+        .modify_cfg_chained(|cfg| cfg.spec = SpecId::BERLIN)
+        .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy(
+            SLOAD_BYTECODE.into(),
+        )))
+        .build_mainnet();
+
+    let result_with_al = evm_with_al
+        .transact_one(
+            TxEnv::builder_for_bench()
+                .access_list(AccessList(vec![AccessListItem {
+                    address: BENCH_TARGET,
+                    storage_keys: vec![B256::ZERO],
+                }]))
+                .build_fill(),
+        )
+        .unwrap();
+    assert!(result_with_al.is_success());
+
+    // Both transactions should use identical gas because the access list is ignored.
+    // On standard Ethereum, the access-list tx would use less gas (warm SLOAD = 100
+    // vs cold SLOAD = 2100), plus the intrinsic access-list gas charges.
+    assert_eq!(
+        result_no_al.gas_used(),
+        result_with_al.gas_used(),
+        "access list should have no effect on gas usage"
+    );
 }

--- a/crates/ee-tests/src/revm_tests.rs
+++ b/crates/ee-tests/src/revm_tests.rs
@@ -295,7 +295,13 @@ fn test_disable_balance_check() {
 fn test_access_list_ignored() {
     // Bytecode: SLOAD slot 0, discard result, stop.
     // PUSH1 0x00  SLOAD  POP  STOP
-    const SLOAD_BYTECODE: &[u8] = &[opcode::PUSH1, 0x00, opcode::SLOAD, opcode::POP, opcode::STOP];
+    const SLOAD_BYTECODE: &[u8] = &[
+        opcode::PUSH1,
+        0x00,
+        opcode::SLOAD,
+        opcode::POP,
+        opcode::STOP,
+    ];
 
     // --- Run without access list ---
     let mut evm_no_al = Context::mainnet()

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -4,7 +4,7 @@
 
 use crate::{EvmTr, PrecompileProvider};
 use bytecode::Bytecode;
-use context_interface::transaction::{AccessListItemTr, AuthorizationTr};
+use context_interface::transaction::AuthorizationTr;
 use context_interface::ContextTr;
 use context_interface::{
     journaled_state::JournalTr,
@@ -13,7 +13,6 @@ use context_interface::{
     Block, Cfg, Database,
 };
 use core::cmp::Ordering;
-use primitives::StorageKey;
 use primitives::{eip7702, hardfork::SpecId, KECCAK_EMPTY, U256};
 use state::AccountInfo;
 use std::boxed::Box;
@@ -49,19 +48,11 @@ pub fn load_accounts<
         context.journal_mut().warm_coinbase_account(coinbase);
     }
 
-    // Load access list
-    let (tx, journal) = context.tx_journal_mut();
-    // legacy is only tx type that does not have access list.
-    if tx.tx_type() != TransactionType::Legacy {
-        if let Some(access_list) = tx.access_list() {
-            for item in access_list {
-                journal.warm_account_and_storage(
-                    *item.address(),
-                    item.storage_slots().map(|i| StorageKey::from_be_bytes(i.0)),
-                )?;
-            }
-        }
-    }
+    // SEISMIC: Access lists are intentionally ignored to prevent metadata leakage.
+    // EIP-2930 access lists reveal which storage keys a transaction intends to access,
+    // which can expose sensitive access patterns for private storage slots.
+    // The access_list field is retained on transactions for Ethereum compatibility,
+    // but its contents are never applied.
 
     Ok(())
 }

--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -1,7 +1,7 @@
 use super::constants::*;
 use crate::{num_words, tri, SStoreResult, SelfDestructResult, StateLoad};
 use context_interface::{
-    journaled_state::AccountLoad, transaction::AccessListItemTr as _, Transaction, TransactionType,
+    journaled_state::AccountLoad, Transaction,
 };
 use primitives::{eip7702, hardfork::SpecId, U256};
 
@@ -450,22 +450,10 @@ pub fn calculate_initial_tx_gas(
 /// - Intrinsic gas
 /// - Number of tokens in calldata
 pub fn calculate_initial_tx_gas_for_tx(tx: impl Transaction, spec: SpecId) -> InitialAndFloorGas {
-    let mut accounts = 0;
-    let mut storages = 0;
-    // legacy is only tx type that does not have access list.
-    if tx.tx_type() != TransactionType::Legacy {
-        (accounts, storages) = tx
-            .access_list()
-            .map(|al| {
-                al.fold((0, 0), |(mut num_accounts, mut num_storage_slots), item| {
-                    num_accounts += 1;
-                    num_storage_slots += item.storage_slots().count();
-
-                    (num_accounts, num_storage_slots)
-                })
-            })
-            .unwrap_or_default();
-    }
+    // SEISMIC: Access lists are ignored to prevent metadata leakage of private storage keys.
+    // No gas is charged for access list entries since they are not applied.
+    let accounts = 0;
+    let storages = 0;
 
     // Access initcodes only if tx is Eip7873.
     // TODO(EOF) Tx type is removed

--- a/crates/interpreter/src/gas/calc.rs
+++ b/crates/interpreter/src/gas/calc.rs
@@ -1,8 +1,6 @@
 use super::constants::*;
 use crate::{num_words, tri, SStoreResult, SelfDestructResult, StateLoad};
-use context_interface::{
-    journaled_state::AccountLoad, Transaction,
-};
+use context_interface::{journaled_state::AccountLoad, Transaction};
 use primitives::{eip7702, hardfork::SpecId, U256};
 
 /// `SSTORE` opcode refund calculation.


### PR DESCRIPTION
Veradise audit finding 843: "Observers can infer sensitive access patterns by inspecting access lists. This may reveal which private slots are accessed, when they are accessed, and how frequently they are used. Over time, this can expose contract business logic, user behavior patterns, and correlations between transactions, even if plaintext storage values are never revealed."

To fix this we have decided to make access lists do nothing. Due to our increased node requirements compared to ethereum we can handle the extra work and we are not very concerned with the gas optimizations of access lists at the moment. To stay compatible with ethereum transactions we will keep the field but make them do nothing so they do not reveal sensitive data