### PR TITLE
fix: make 6 opcodes constant-time to prevent timing sidechannel attacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4827,6 +4827,7 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "auto_impl",
+ "codspeed-criterion-compat",
  "hkdf",
  "indicatif",
  "merlin",

--- a/crates/seismic/Cargo.toml
+++ b/crates/seismic/Cargo.toml
@@ -43,10 +43,15 @@ secp256k1 = { workspace = true, features = ["recovery"] }
 
 [dev-dependencies]
 anyhow.workspace = true
+criterion.workspace = true
 indicatif.workspace = true
 rstest.workspace = true
 alloy-sol-types.workspace = true
 serde_json = { workspace = true, features = ["alloc"] }
+
+[[bench]]
+name = "constant_time"
+harness = false
 
 [features]
 default = ["std", "c-kzg", "portable", "blst"]

--- a/crates/seismic/benches/constant_time.rs
+++ b/crates/seismic/benches/constant_time.rs
@@ -1,0 +1,256 @@
+//! Benchmarks comparing upstream (short-circuiting) vs constant-time comparison opcodes.
+//!
+//! Run with: cargo bench -p seismic-revm --bench constant_time
+//!
+//! Three input classes are tested for each opcode:
+//!   - **equal**: identical values (worst case for short-circuit — must check all limbs)
+//!   - **diff_first_limb**: differ in the most-significant limb (best case for short-circuit)
+//!   - **diff_last_limb**: differ only in the least-significant limb
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use revm::primitives::U256;
+
+// ---------------------------------------------------------------------------
+// Upstream (short-circuiting) comparison functions
+// ---------------------------------------------------------------------------
+
+mod upstream {
+    use core::cmp::Ordering;
+    use revm::primitives::U256;
+
+    pub(crate) fn eq(a: &U256, b: &U256) -> bool {
+        a == b
+    }
+
+    pub(crate) fn lt(a: &U256, b: &U256) -> bool {
+        a < b
+    }
+
+    fn i256_sign_raw(val: &U256) -> i8 {
+        if val.bit(U256::BITS - 1) {
+            -1
+        } else if val.is_zero() {
+            0
+        } else {
+            1
+        }
+    }
+
+    pub(crate) fn slt(a: &U256, b: &U256) -> bool {
+        let sa = i256_sign_raw(a);
+        let sb = i256_sign_raw(b);
+        match sa.cmp(&sb) {
+            Ordering::Equal => a.cmp(b) == Ordering::Less,
+            Ordering::Less => true,
+            Ordering::Greater => false,
+        }
+    }
+
+    pub(crate) fn iszero(a: &U256) -> bool {
+        a.is_zero()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constant-time comparison functions (same as in constant_time.rs)
+// ---------------------------------------------------------------------------
+
+mod ct {
+    use revm::primitives::U256;
+
+    #[inline]
+    pub(crate) fn eq(a: &U256, b: &U256) -> bool {
+        let al = a.as_limbs();
+        let bl = b.as_limbs();
+        let d0 = core::hint::black_box(al[0] ^ bl[0]);
+        let d1 = core::hint::black_box(al[1] ^ bl[1]);
+        let d2 = core::hint::black_box(al[2] ^ bl[2]);
+        let d3 = core::hint::black_box(al[3] ^ bl[3]);
+        (d0 | d1 | d2 | d3) == 0
+    }
+
+    #[inline]
+    fn lt_limbs(al: &[u64; 4], bl: &[u64; 4]) -> bool {
+        let mut borrow: u64 = 0;
+        for i in 0..4 {
+            let wide = core::hint::black_box(
+                (al[i] as u128)
+                    .wrapping_sub(bl[i] as u128)
+                    .wrapping_sub(borrow as u128),
+            );
+            borrow = (wide >> 127) as u64;
+        }
+        borrow != 0
+    }
+
+    #[inline]
+    pub(crate) fn lt(a: &U256, b: &U256) -> bool {
+        lt_limbs(a.as_limbs(), b.as_limbs())
+    }
+
+    #[inline]
+    pub(crate) fn slt(a: &U256, b: &U256) -> bool {
+        let al = a.as_limbs();
+        let bl = b.as_limbs();
+        let a_flipped = [al[0], al[1], al[2], al[3] ^ 0x8000_0000_0000_0000];
+        let b_flipped = [bl[0], bl[1], bl[2], bl[3] ^ 0x8000_0000_0000_0000];
+        lt_limbs(&a_flipped, &b_flipped)
+    }
+
+    #[inline]
+    pub(crate) fn iszero(a: &U256) -> bool {
+        let al = a.as_limbs();
+        let d = core::hint::black_box(al[0] | al[1] | al[2] | al[3]);
+        d == 0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test inputs
+// ---------------------------------------------------------------------------
+
+/// Two equal values (worst case for short-circuit, best case for CT since both
+/// do the same amount of work).
+fn equal_pair() -> (U256, U256) {
+    let v = U256::from_limbs([0xDEAD, 0xBEEF, 0xCAFE, 0xFACE]);
+    (v, v)
+}
+
+/// Differ in the most-significant limb (limb 3, checked first by short-circuit Ord).
+/// Best case for upstream LT/GT/SLT — the short-circuit exits after 1 limb.
+fn diff_first_limb() -> (U256, U256) {
+    (
+        U256::from_limbs([0xDEAD, 0xBEEF, 0xCAFE, 0x0001]),
+        U256::from_limbs([0xDEAD, 0xBEEF, 0xCAFE, 0x0002]),
+    )
+}
+
+/// Differ only in the least-significant limb (limb 0, checked last by short-circuit Ord).
+/// Worst case for upstream LT/GT — the short-circuit must check all 4 limbs.
+fn diff_last_limb() -> (U256, U256) {
+    (
+        U256::from_limbs([0x0001, 0xBEEF, 0xCAFE, 0xFACE]),
+        U256::from_limbs([0x0002, 0xBEEF, 0xCAFE, 0xFACE]),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_eq(c: &mut Criterion) {
+    let mut g = c.benchmark_group("eq");
+
+    let (a, b) = equal_pair();
+    g.bench_function("upstream/equal", |bench| {
+        bench.iter(|| upstream::eq(black_box(&a), black_box(&b)))
+    });
+    g.bench_function("ct/equal", |bench| {
+        bench.iter(|| ct::eq(black_box(&a), black_box(&b)))
+    });
+
+    let (a, b) = diff_first_limb();
+    g.bench_function("upstream/diff_msb", |bench| {
+        bench.iter(|| upstream::eq(black_box(&a), black_box(&b)))
+    });
+    g.bench_function("ct/diff_msb", |bench| {
+        bench.iter(|| ct::eq(black_box(&a), black_box(&b)))
+    });
+
+    let (a, b) = diff_last_limb();
+    g.bench_function("upstream/diff_lsb", |bench| {
+        bench.iter(|| upstream::eq(black_box(&a), black_box(&b)))
+    });
+    g.bench_function("ct/diff_lsb", |bench| {
+        bench.iter(|| ct::eq(black_box(&a), black_box(&b)))
+    });
+
+    g.finish();
+}
+
+fn bench_lt(c: &mut Criterion) {
+    let mut g = c.benchmark_group("lt");
+
+    let (a, b) = equal_pair();
+    g.bench_function("upstream/equal", |bench| {
+        bench.iter(|| upstream::lt(black_box(&a), black_box(&b)))
+    });
+    g.bench_function("ct/equal", |bench| {
+        bench.iter(|| ct::lt(black_box(&a), black_box(&b)))
+    });
+
+    let (a, b) = diff_first_limb();
+    g.bench_function("upstream/diff_msb", |bench| {
+        bench.iter(|| upstream::lt(black_box(&a), black_box(&b)))
+    });
+    g.bench_function("ct/diff_msb", |bench| {
+        bench.iter(|| ct::lt(black_box(&a), black_box(&b)))
+    });
+
+    let (a, b) = diff_last_limb();
+    g.bench_function("upstream/diff_lsb", |bench| {
+        bench.iter(|| upstream::lt(black_box(&a), black_box(&b)))
+    });
+    g.bench_function("ct/diff_lsb", |bench| {
+        bench.iter(|| ct::lt(black_box(&a), black_box(&b)))
+    });
+
+    g.finish();
+}
+
+fn bench_slt(c: &mut Criterion) {
+    let mut g = c.benchmark_group("slt");
+
+    let (a, b) = equal_pair();
+    g.bench_function("upstream/equal", |bench| {
+        bench.iter(|| upstream::slt(black_box(&a), black_box(&b)))
+    });
+    g.bench_function("ct/equal", |bench| {
+        bench.iter(|| ct::slt(black_box(&a), black_box(&b)))
+    });
+
+    // Signed: positive vs negative (different signs — upstream short-circuits immediately)
+    let pos = U256::from_limbs([1, 0, 0, 0]);
+    let neg = U256::from_limbs([0, 0, 0, 0x8000_0000_0000_0000]); // min negative
+    g.bench_function("upstream/diff_sign", |bench| {
+        bench.iter(|| upstream::slt(black_box(&pos), black_box(&neg)))
+    });
+    g.bench_function("ct/diff_sign", |bench| {
+        bench.iter(|| ct::slt(black_box(&pos), black_box(&neg)))
+    });
+
+    g.finish();
+}
+
+fn bench_iszero(c: &mut Criterion) {
+    let mut g = c.benchmark_group("iszero");
+
+    let zero = U256::ZERO;
+    g.bench_function("upstream/zero", |bench| {
+        bench.iter(|| upstream::iszero(black_box(&zero)))
+    });
+    g.bench_function("ct/zero", |bench| {
+        bench.iter(|| ct::iszero(black_box(&zero)))
+    });
+
+    let nonzero = U256::from_limbs([0, 0, 0, 1]); // only MSB limb is nonzero
+    g.bench_function("upstream/nonzero_msb", |bench| {
+        bench.iter(|| upstream::iszero(black_box(&nonzero)))
+    });
+    g.bench_function("ct/nonzero_msb", |bench| {
+        bench.iter(|| ct::iszero(black_box(&nonzero)))
+    });
+
+    let nonzero_lsb = U256::from_limbs([1, 0, 0, 0]); // only LSB limb is nonzero
+    g.bench_function("upstream/nonzero_lsb", |bench| {
+        bench.iter(|| upstream::iszero(black_box(&nonzero_lsb)))
+    });
+    g.bench_function("ct/nonzero_lsb", |bench| {
+        bench.iter(|| ct::iszero(black_box(&nonzero_lsb)))
+    });
+
+    g.finish();
+}
+
+criterion_group!(benches, bench_eq, bench_lt, bench_slt, bench_iszero);
+criterion_main!(benches);

--- a/crates/seismic/src/instructions.rs
+++ b/crates/seismic/src/instructions.rs
@@ -1,4 +1,5 @@
 pub mod confidential_storage;
+pub mod constant_time;
 pub mod instruction_provider;
 pub mod seismic_host;
 #[macro_use]

--- a/crates/seismic/src/instructions/constant_time.rs
+++ b/crates/seismic/src/instructions/constant_time.rs
@@ -207,10 +207,7 @@ mod tests {
     }
 
     // Helper to run a unary opcode on one value.
-    fn run_unary(
-        f: fn(InstructionContext<'_, DummyHost, EthInterpreter>),
-        a: U256,
-    ) -> U256 {
+    fn run_unary(f: fn(InstructionContext<'_, DummyHost, EthInterpreter>), a: U256) -> U256 {
         let mut interp = TestInterp::default();
         assert!(interp.stack.push(a));
         let ctx = InstructionContext {

--- a/crates/seismic/src/instructions/constant_time.rs
+++ b/crates/seismic/src/instructions/constant_time.rs
@@ -1,0 +1,363 @@
+//! Constant-time replacements for EVM comparison opcodes.
+//!
+//! Standard U256 comparisons (==, <, >) short-circuit on the first differing
+//! 64-bit limb, leaking partial information about confidential values through
+//! timing side channels. These replacements always process all 4 limbs.
+//!
+//! `core::hint::black_box` is applied to intermediate results to discourage
+//! the compiler from reassembling a short-circuit pattern. The `subtle` crate
+//! is often recommended for constant-time code, but since Rust 1.66 its
+//! optimization barrier is itself just `core::hint::black_box` (enabled via
+//! the `core_hint_black_box` feature flag; before 1.66 it used a volatile
+//! read). Using `black_box` directly avoids the extra dependency while
+//! providing the same underlying mechanism.
+//!
+//! Note that all of this is **best-effort**: `black_box` is a hint, not a
+//! guarantee, and the compiler or LLVM is free to ignore it. A true fix
+//! would require language-level secret types (RFC 2859) with backend support
+//! to preserve constant-time semantics across all optimization passes, but
+//! that RFC is currently postponed.
+//!
+//! ## Scope
+//!
+//! Only the 6 comparison/branch opcodes are replaced here (EQ, LT, GT, SLT,
+//! SGT, ISZERO). Other opcodes were audited and fall into three categories:
+//!
+//! **Already constant-time:** AND, OR, XOR, NOT, ADD, SUB, MUL — these are
+//! bitwise or wrapping-arithmetic operations that unconditionally process all
+//! 4 limbs with no data-dependent branches.
+//!
+//! **Variable-time but impractical to fix:** DIV, MOD, SDIV, SMOD, EXP,
+//! ADDMOD, MULMOD — multi-precision division and modular reduction are
+//! inherently variable-time. Constant-time alternatives exist but incur
+//! 10-100x overhead. EXP already leaks exponent size via gas cost.
+//! Developers should avoid these on secret values and use precompiles for
+//! cryptographic operations instead.
+//!
+//! **Minor leaks (1 bit):** SAR and SIGNEXTEND branch on the sign bit of the
+//! value. SHL, SHR, and BYTE branch on the index/shift amount (typically not
+//! secret). These could be made branchless cheaply but are lower priority.
+
+use revm::{
+    interpreter::{
+        _count,
+        interpreter_types::{InterpreterTypes, StackTr},
+        popn_top, Host, Instruction, InstructionContext,
+    },
+    primitives::U256,
+};
+
+// ---------------------------------------------------------------------------
+// Constant-time primitives
+// ---------------------------------------------------------------------------
+
+/// Constant-time equality: XOR all limbs, OR the diffs, compare once.
+#[inline]
+fn ct_eq(a: &U256, b: &U256) -> bool {
+    let al = a.as_limbs();
+    let bl = b.as_limbs();
+    let d0 = core::hint::black_box(al[0] ^ bl[0]);
+    let d1 = core::hint::black_box(al[1] ^ bl[1]);
+    let d2 = core::hint::black_box(al[2] ^ bl[2]);
+    let d3 = core::hint::black_box(al[3] ^ bl[3]);
+    (d0 | d1 | d2 | d3) == 0
+}
+
+/// Constant-time unsigned less-than on raw limbs (little-endian `[u64; 4]`).
+///
+/// Performs multi-limb subtraction `a - b` and returns `true` when the final
+/// borrow bit is set (i.e. `a < b`). Every limb is always visited.
+#[inline]
+fn ct_lt_limbs(al: &[u64; 4], bl: &[u64; 4]) -> bool {
+    let mut borrow: u64 = 0;
+    for i in 0..4 {
+        let wide = core::hint::black_box(
+            (al[i] as u128)
+                .wrapping_sub(bl[i] as u128)
+                .wrapping_sub(borrow as u128),
+        );
+        borrow = (wide >> 127) as u64;
+    }
+    borrow != 0
+}
+
+/// Constant-time unsigned less-than for U256.
+#[inline]
+fn ct_lt(a: &U256, b: &U256) -> bool {
+    ct_lt_limbs(a.as_limbs(), b.as_limbs())
+}
+
+/// Constant-time signed less-than for i256 (two's complement U256).
+///
+/// Flips the sign bit (bit 255) so that unsigned comparison on the
+/// transformed values gives the correct signed ordering.
+#[inline]
+fn ct_i256_lt(a: &U256, b: &U256) -> bool {
+    let al = a.as_limbs();
+    let bl = b.as_limbs();
+    let a_flipped = [al[0], al[1], al[2], al[3] ^ 0x8000_0000_0000_0000];
+    let b_flipped = [bl[0], bl[1], bl[2], bl[3] ^ 0x8000_0000_0000_0000];
+    ct_lt_limbs(&a_flipped, &b_flipped)
+}
+
+/// Constant-time is-zero: OR all limbs, compare once.
+#[inline]
+fn ct_is_zero(a: &U256) -> bool {
+    let al = a.as_limbs();
+    let d = core::hint::black_box(al[0] | al[1] | al[2] | al[3]);
+    d == 0
+}
+
+// ---------------------------------------------------------------------------
+// Opcode implementations (drop-in replacements for upstream bitwise::*)
+// ---------------------------------------------------------------------------
+
+/// Constant-time EQ (0x14).
+pub fn eq<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>) {
+    popn_top!([op1], op2, context.interpreter);
+    *op2 = U256::from(ct_eq(&op1, op2));
+}
+
+/// Constant-time LT (0x10).
+pub fn lt<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>) {
+    popn_top!([op1], op2, context.interpreter);
+    *op2 = U256::from(ct_lt(&op1, op2));
+}
+
+/// Constant-time GT (0x11).
+pub fn gt<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>) {
+    popn_top!([op1], op2, context.interpreter);
+    *op2 = U256::from(ct_lt(op2, &op1));
+}
+
+/// Constant-time SLT (0x12).
+pub fn slt<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>) {
+    popn_top!([op1], op2, context.interpreter);
+    *op2 = U256::from(ct_i256_lt(&op1, op2));
+}
+
+/// Constant-time SGT (0x13).
+pub fn sgt<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>) {
+    popn_top!([op1], op2, context.interpreter);
+    *op2 = U256::from(ct_i256_lt(op2, &op1));
+}
+
+/// Constant-time ISZERO (0x15).
+pub fn iszero<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>) {
+    popn_top!([], op1, context.interpreter);
+    *op1 = U256::from(ct_is_zero(op1));
+}
+
+// ---------------------------------------------------------------------------
+// Instruction constructors (same pattern as confidential_storage.rs)
+// ---------------------------------------------------------------------------
+
+/// Gas cost for the comparison opcodes (VERYLOW = 3).
+const VERYLOW: u64 = 3;
+
+pub fn ct_eq_instruction<WIRE: InterpreterTypes, H: Host + ?Sized>() -> Instruction<WIRE, H> {
+    Instruction::new(eq, VERYLOW)
+}
+
+pub fn ct_lt_instruction<WIRE: InterpreterTypes, H: Host + ?Sized>() -> Instruction<WIRE, H> {
+    Instruction::new(lt, VERYLOW)
+}
+
+pub fn ct_gt_instruction<WIRE: InterpreterTypes, H: Host + ?Sized>() -> Instruction<WIRE, H> {
+    Instruction::new(gt, VERYLOW)
+}
+
+pub fn ct_slt_instruction<WIRE: InterpreterTypes, H: Host + ?Sized>() -> Instruction<WIRE, H> {
+    Instruction::new(slt, VERYLOW)
+}
+
+pub fn ct_sgt_instruction<WIRE: InterpreterTypes, H: Host + ?Sized>() -> Instruction<WIRE, H> {
+    Instruction::new(sgt, VERYLOW)
+}
+
+pub fn ct_iszero_instruction<WIRE: InterpreterTypes, H: Host + ?Sized>() -> Instruction<WIRE, H> {
+    Instruction::new(iszero, VERYLOW)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use revm::{
+        interpreter::{host::DummyHost, interpreter::EthInterpreter, Interpreter},
+        primitives::uint,
+    };
+
+    type TestInterp = Interpreter<EthInterpreter>;
+
+    // Helper to run a binary comparison opcode on two values.
+    fn run_binary(
+        f: fn(InstructionContext<'_, DummyHost, EthInterpreter>),
+        a: U256,
+        b: U256,
+    ) -> U256 {
+        let mut interp = TestInterp::default();
+        assert!(interp.stack.push(b));
+        assert!(interp.stack.push(a));
+        let ctx = InstructionContext {
+            host: &mut DummyHost,
+            interpreter: &mut interp,
+        };
+        f(ctx);
+        interp.stack.pop().unwrap()
+    }
+
+    // Helper to run a unary opcode on one value.
+    fn run_unary(
+        f: fn(InstructionContext<'_, DummyHost, EthInterpreter>),
+        a: U256,
+    ) -> U256 {
+        let mut interp = TestInterp::default();
+        assert!(interp.stack.push(a));
+        let ctx = InstructionContext {
+            host: &mut DummyHost,
+            interpreter: &mut interp,
+        };
+        f(ctx);
+        interp.stack.pop().unwrap()
+    }
+
+    // ---- EQ ----
+
+    #[test]
+    fn test_eq_equal() {
+        uint! {
+            assert_eq!(run_binary(eq, 42_U256, 42_U256), 1_U256);
+            assert_eq!(run_binary(eq, 0_U256, 0_U256), 1_U256);
+            assert_eq!(run_binary(eq, U256::MAX, U256::MAX), 1_U256);
+        }
+    }
+
+    #[test]
+    fn test_eq_not_equal() {
+        uint! {
+            assert_eq!(run_binary(eq, 1_U256, 2_U256), 0_U256);
+            assert_eq!(run_binary(eq, 0_U256, 1_U256), 0_U256);
+        }
+    }
+
+    // ---- LT ----
+
+    #[test]
+    fn test_lt() {
+        uint! {
+            assert_eq!(run_binary(lt, 1_U256, 2_U256), 1_U256);
+            assert_eq!(run_binary(lt, 2_U256, 1_U256), 0_U256);
+            assert_eq!(run_binary(lt, 1_U256, 1_U256), 0_U256);
+            assert_eq!(run_binary(lt, 0_U256, U256::MAX), 1_U256);
+            assert_eq!(run_binary(lt, U256::MAX, 0_U256), 0_U256);
+        }
+    }
+
+    // ---- GT ----
+
+    #[test]
+    fn test_gt() {
+        uint! {
+            assert_eq!(run_binary(gt, 2_U256, 1_U256), 1_U256);
+            assert_eq!(run_binary(gt, 1_U256, 2_U256), 0_U256);
+            assert_eq!(run_binary(gt, 1_U256, 1_U256), 0_U256);
+        }
+    }
+
+    // ---- SLT (signed) ----
+
+    #[test]
+    fn test_slt() {
+        uint! {
+            // Positive comparisons
+            assert_eq!(run_binary(slt, 1_U256, 2_U256), 1_U256);
+            assert_eq!(run_binary(slt, 2_U256, 1_U256), 0_U256);
+
+            // -1 (0xFFF...F) < 0
+            assert_eq!(run_binary(slt, -1_U256, 0_U256), 1_U256);
+            // 0 < -1 is false
+            assert_eq!(run_binary(slt, 0_U256, -1_U256), 0_U256);
+
+            // -1 < -2 is false (-1 > -2)
+            assert_eq!(run_binary(slt, -1_U256, -2_U256), 0_U256);
+            // -2 < -1
+            assert_eq!(run_binary(slt, -2_U256, -1_U256), 1_U256);
+
+            // Equal
+            assert_eq!(run_binary(slt, -1_U256, -1_U256), 0_U256);
+        }
+    }
+
+    // ---- SGT (signed) ----
+
+    #[test]
+    fn test_sgt() {
+        uint! {
+            assert_eq!(run_binary(sgt, 2_U256, 1_U256), 1_U256);
+            assert_eq!(run_binary(sgt, 1_U256, 2_U256), 0_U256);
+            assert_eq!(run_binary(sgt, 0_U256, -1_U256), 1_U256);
+            assert_eq!(run_binary(sgt, -1_U256, 0_U256), 0_U256);
+        }
+    }
+
+    // ---- ISZERO ----
+
+    #[test]
+    fn test_iszero() {
+        uint! {
+            assert_eq!(run_unary(iszero, 0_U256), 1_U256);
+            assert_eq!(run_unary(iszero, 1_U256), 0_U256);
+            assert_eq!(run_unary(iszero, U256::MAX), 0_U256);
+        }
+    }
+
+    // ---- Edge cases: values that differ only in one limb ----
+    // These are the exact cases where short-circuiting leaks information.
+
+    #[test]
+    fn test_eq_single_limb_difference() {
+        // Differ only in limb 0 (least significant)
+        let a = U256::from_limbs([1, 0, 0, 0]);
+        let b = U256::from_limbs([2, 0, 0, 0]);
+        assert_eq!(run_binary(eq, a, b), U256::ZERO);
+
+        // Differ only in limb 3 (most significant)
+        let a = U256::from_limbs([0, 0, 0, 1]);
+        let b = U256::from_limbs([0, 0, 0, 2]);
+        assert_eq!(run_binary(eq, a, b), U256::ZERO);
+
+        // Match on limbs 0-2, differ on limb 3
+        let a = U256::from_limbs([42, 42, 42, 1]);
+        let b = U256::from_limbs([42, 42, 42, 2]);
+        assert_eq!(run_binary(eq, a, b), U256::ZERO);
+    }
+
+    #[test]
+    fn test_lt_boundary_values() {
+        // Values that share a prefix of matching limbs
+        let a = U256::from_limbs([0, 0, 0, 0]);
+        let b = U256::from_limbs([1, 0, 0, 0]);
+        assert_eq!(run_binary(lt, a, b), U256::from(1));
+
+        // Differ only in the most significant limb
+        let a = U256::from_limbs([0, 0, 0, 1]);
+        let b = U256::from_limbs([0, 0, 0, 2]);
+        assert_eq!(run_binary(lt, a, b), U256::from(1));
+
+        // Borrow propagation: a = 0, b = 1 (through all limbs)
+        let a = U256::from_limbs([0, 0, 0, 0]);
+        let b = U256::from_limbs([u64::MAX, u64::MAX, u64::MAX, u64::MAX]);
+        assert_eq!(run_binary(lt, a, b), U256::from(1));
+    }
+
+    #[test]
+    fn test_slt_sign_boundary() {
+        // Max positive vs min negative (in two's complement)
+        // 0x7FFF...F (max positive) vs 0x8000...0 (min negative)
+        let max_pos = U256::from_limbs([u64::MAX, u64::MAX, u64::MAX, 0x7FFF_FFFF_FFFF_FFFF]);
+        let min_neg = U256::from_limbs([0, 0, 0, 0x8000_0000_0000_0000]);
+        // max_pos > min_neg in signed
+        assert_eq!(run_binary(slt, max_pos, min_neg), U256::ZERO);
+        assert_eq!(run_binary(slt, min_neg, max_pos), U256::from(1));
+    }
+}

--- a/crates/seismic/src/instructions/constant_time.rs
+++ b/crates/seismic/src/instructions/constant_time.rs
@@ -70,10 +70,10 @@ fn ct_eq(a: &U256, b: &U256) -> bool {
 #[inline]
 fn ct_lt_limbs(al: &[u64; 4], bl: &[u64; 4]) -> bool {
     let mut borrow: u64 = 0;
-    for i in 0..4 {
+    for (&a, &b) in al.iter().zip(bl.iter()) {
         let wide = core::hint::black_box(
-            (al[i] as u128)
-                .wrapping_sub(bl[i] as u128)
+            (a as u128)
+                .wrapping_sub(b as u128)
                 .wrapping_sub(borrow as u128),
         );
         borrow = (wide >> 127) as u64;
@@ -180,6 +180,7 @@ pub fn ct_iszero_instruction<WIRE: InterpreterTypes, H: Host + ?Sized>() -> Inst
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use revm::{

--- a/crates/seismic/src/instructions/instruction_provider.rs
+++ b/crates/seismic/src/instructions/instruction_provider.rs
@@ -1,5 +1,5 @@
 use revm::{
-    bytecode::opcode::{SLOAD, SSTORE},
+    bytecode::opcode::{EQ, GT, ISZERO, LT, SGT, SLOAD, SLT, SSTORE},
     handler::instructions::InstructionProvider,
     interpreter::{
         instructions::{instruction_table, InstructionTable},
@@ -9,9 +9,15 @@ use revm::{
 use std::boxed::Box;
 
 use crate::{
-    instructions::confidential_storage::{
-        cload_instruction, cstore_instruction, seismic_sload_instruction,
-        seismic_sstore_instruction,
+    instructions::{
+        confidential_storage::{
+            cload_instruction, cstore_instruction, seismic_sload_instruction,
+            seismic_sstore_instruction,
+        },
+        constant_time::{
+            ct_eq_instruction, ct_gt_instruction, ct_iszero_instruction, ct_lt_instruction,
+            ct_sgt_instruction, ct_slt_instruction,
+        },
     },
     SeismicHost,
 };
@@ -46,6 +52,15 @@ where
         table[CSTORE as usize] = cstore_instruction();
         table[SLOAD as usize] = seismic_sload_instruction();
         table[SSTORE as usize] = seismic_sstore_instruction();
+
+        // Constant-time comparison opcodes to prevent timing side channels
+        // on confidential storage values.
+        table[EQ as usize] = ct_eq_instruction();
+        table[LT as usize] = ct_lt_instruction();
+        table[GT as usize] = ct_gt_instruction();
+        table[SLT as usize] = ct_slt_instruction();
+        table[SGT as usize] = ct_sgt_instruction();
+        table[ISZERO as usize] = ct_iszero_instruction();
 
         Self {
             instruction_table: Box::new(table),
@@ -215,6 +230,12 @@ mod tests {
                 && i != CSTORE as usize
                 && i != SLOAD as usize
                 && i != SSTORE as usize
+                && i != EQ as usize
+                && i != LT as usize
+                && i != GT as usize
+                && i != SLT as usize
+                && i != SGT as usize
+                && i != ISZERO as usize
             {
                 assert!(
                     custom_table[i].equal(&standard_table[i]),


### PR DESCRIPTION
Fixes veridise-916.

> Operations which handle values in non-constant time can leak information about confidential storage.
> 
> Ordinary equality/conditional branch primitives such as EQ + JUMPI use short-circuiting comparisons on the 256-bit values. For example, the snippet from eq() below, defining the EQ instruction, uses U256's default comparison operator. This checks arrays byte-by-byte, stopping early once one 64-bit limb is matched. Guessed values which have a correct first limb will take longer to run than guessed values which have an incorrect first limb. This allows attackers to brute force limb-by-limb, guessing 64-bit values instead of 256-bit ones.
                                                                                        
This PR replace EQ, LT, GT, SLT, SGT, and ISZERO with branchless implementations that always process all 4 U256 limbs.

Used core::hint::black_box as an optimization barrier hint directly instead of `subtle` since subtle uses black_box anyways since Rust 1.66, but happy to switch to subtle if anyone thinks there are benefits to doing so. Also worth noting that both of these are only best-effort hints, not true guarantee like RFC 2859 secret types would offer, but those are still not implemented and have even been [postponed](https://github.com/rust-lang/rfcs/pull/2859#issuecomment-701603058).

Overhead is ~2-3x per opcode (~1-2ns absolute), which is negligible (afaiu, havent benchmarked) compared to the interpreter loop overhead per opcode (gas accounting, stack bounds checks, indirect function call dispatch, PC advancement), let alone I/O-bound operations like SLOAD.

## Benchmarks

Also added a benchmark to confirm this. Results are from running on my macbook m1.

``` ┌────────┬─────────────┬──────────┬─────────┬──────────┬──────────────────┬────────────┐
  │ Opcode │    Case     │ Upstream │   CT    │ Slowdown │ Upstream varies? │ CT varies? │
  ├────────┼─────────────┼──────────┼─────────┼──────────┼──────────────────┼────────────┤                                                                                   
  │ EQ     │ equal       │ 0.93 ns  │ 2.39 ns │ 2.6x     │ no               │ no         │
  ├────────┼─────────────┼──────────┼─────────┼──────────┼──────────────────┼────────────┤                                                                                   
  │        │ diff_msb    │ 0.95 ns  │ 2.40 ns │ 2.5x     │ no               │ no         │                                                                                   
  ├────────┼─────────────┼──────────┼─────────┼──────────┼──────────────────┼────────────┤
  │        │ diff_lsb    │ 0.93 ns  │ 2.38 ns │ 2.6x     │ no               │ no         │                                                                                   
  ├────────┼─────────────┼──────────┼─────────┼──────────┼──────────────────┼────────────┤                                                                                   
  │ LT     │ equal       │ 1.31 ns  │ 3.14 ns │ 2.4x     │ —                │ no         │
  ├────────┼─────────────┼──────────┼─────────┼──────────┼──────────────────┼────────────┤                                                                                   
  │        │ diff_msb    │ 0.72 ns  │ 3.13 ns │ 4.4x     │ yes (fast)       │ no         │
  ├────────┼─────────────┼──────────┼─────────┼──────────┼──────────────────┼────────────┤                                                                                   
  │        │ diff_lsb    │ 1.41 ns  │ 3.11 ns │ 2.2x     │ yes (slow)       │ no         │
  ├────────┼─────────────┼──────────┼─────────┼──────────┼──────────────────┼────────────┤                                                                                   
  │ SLT    │ equal       │ 2.94 ns  │ 2.86 ns │ 1.0x     │ —                │ no         │
  ├────────┼─────────────┼──────────┼─────────┼──────────┼──────────────────┼────────────┤                                                                                   
  │        │ diff_sign   │ 1.84 ns  │ 2.92 ns │ 1.6x     │ yes (fast)       │ no         │
  ├────────┼─────────────┼──────────┼─────────┼──────────┼──────────────────┼────────────┤                                                                                   
  │ ISZERO │ zero        │ 0.61 ns  │ 1.47 ns │ 2.4x     │ no               │ no         │
  ├────────┼─────────────┼──────────┼─────────┼──────────┼──────────────────┼────────────┤                                                                                   
  │        │ nonzero_msb │ 0.61 ns  │ 1.47 ns │ 2.4x     │ no               │ no         │
  ├────────┼─────────────┼──────────┼─────────┼──────────┼──────────────────┼────────────┤                                                                                   
  │        │ nonzero_lsb │ 0.64 ns  │ 1.47 ns │ 2.3x     │ no               │ no         │
  └────────┴─────────────┴──────────┴─────────┴──────────┴──────────────────┴────────────┘
```