### PR TITLE
fix(SeismicEvm): remove Deref to inner Evm

### DIFF
--- a/bins/revme/src/cmd/semantics/evm_handler.rs
+++ b/bins/revme/src/cmd/semantics/evm_handler.rs
@@ -139,7 +139,7 @@ impl EvmExecutor {
                     .build_seismic_evm_with_inspector(
                         TracerEip3155::new_stdout().without_summary(),
                     );
-                evm.inspect_tx(evm.tx.clone()).map_err(|err| {
+                evm.inspect_tx(evm.0.ctx.tx.clone()).map_err(|err| {
                     Errors::EVMError(format!("DEPLOY transaction error: {:?}", err.to_string()))
                 })?
             } else {
@@ -271,7 +271,7 @@ impl EvmExecutor {
                     .build_seismic_evm_with_inspector(TracerEip3155::new(Box::new(
                         std::io::stdout(),
                     )));
-                evm.inspect_tx(evm.tx.clone()).map_err(|err| {
+                evm.inspect_tx(evm.0.ctx.tx.clone()).map_err(|err| {
                     Errors::EVMError(format!(
                         "EVM transaction error: {:?}, for the file: {:?}",
                         err.to_string(),

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -487,7 +487,7 @@ fn debug_failed_test(ctx: DebugContext) {
     println!("\nState before: {:#?}", ctx.cache_state);
     println!(
         "\nState after: {:#?}",
-        evm.ctx.journaled_state.database.cache
+        evm.0.ctx.journaled_state.database.cache
     );
     println!("\nSpecification: {:?}", ctx.cfg.spec);
     println!("\nTx: {:#?}", ctx.tx);

--- a/crates/seismic/src/api/exec.rs
+++ b/crates/seismic/src/api/exec.rs
@@ -12,9 +12,12 @@ use revm::{
         result::{EVMError, ExecutionResult, HaltReason},
         Cfg, ContextTr, Database, JournalTr,
     },
-    handler::{EthFrame, Handler, PrecompileProvider},
-    inspector::{InspectCommitEvm, InspectEvm, Inspector, InspectorHandler, JournalExt},
+    handler::{system_call::SystemCallEvm, EthFrame, Handler, PrecompileProvider, SystemCallTx},
+    inspector::{
+        InspectCommitEvm, InspectEvm, InspectSystemCallEvm, Inspector, InspectorHandler, JournalExt,
+    },
     interpreter::{interpreter::EthInterpreter, InterpreterResult},
+    primitives::{Address, Bytes},
     state::EvmState,
     DatabaseCommit, ExecuteCommitEvm, ExecuteEvm,
 };
@@ -118,4 +121,49 @@ where
     INSP: Inspector<CTX, EthInterpreter>,
     PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
 {
+}
+
+impl<CTX, INSP, PRECOMPILE> SystemCallEvm
+    for SeismicEvm<CTX, INSP, SeismicInstructions<EthInterpreter, CTX>, PRECOMPILE>
+where
+    CTX: SeismicContextTr<Tx: SystemCallTx> + ContextSetters,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+    fn system_call_one_with_caller(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        self.0.ctx.set_tx(CTX::Tx::new_system_tx_with_caller(
+            caller,
+            system_contract_address,
+            data,
+        ));
+        let mut h = SeismicHandler::<_, _, EthFrame<EthInterpreter>>::new();
+        h.run_system_call(self)
+    }
+}
+
+impl<CTX, INSP, PRECOMPILE> InspectSystemCallEvm
+    for SeismicEvm<CTX, INSP, SeismicInstructions<EthInterpreter, CTX>, PRECOMPILE>
+where
+    CTX: SeismicContextTr<Journal: JournalExt, Tx: SystemCallTx> + ContextSetters,
+    INSP: Inspector<CTX, EthInterpreter>,
+    PRECOMPILE: PrecompileProvider<CTX, Output = InterpreterResult>,
+{
+    fn inspect_one_system_call_with_caller(
+        &mut self,
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Result<Self::ExecutionResult, Self::Error> {
+        self.0.ctx.set_tx(CTX::Tx::new_system_tx_with_caller(
+            caller,
+            system_contract_address,
+            data,
+        ));
+        let mut h = SeismicHandler::<_, _, EthFrame<EthInterpreter>>::new();
+        h.inspect_run_system_call(self)
+    }
 }

--- a/crates/seismic/src/evm.rs
+++ b/crates/seismic/src/evm.rs
@@ -37,20 +37,6 @@ impl<CTX: SeismicContextTr, INSP>
     }
 }
 
-impl<CTX, INSP, I, P, F> std::ops::Deref for SeismicEvm<CTX, INSP, I, P, F> {
-    type Target = Evm<CTX, INSP, I, P, F>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<CTX, INSP, I, P> std::ops::DerefMut for SeismicEvm<CTX, INSP, I, P> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
 impl<CTX: SeismicContextTr, I, INSP> SeismicEvm<CTX, INSP, I> {
     /// Create a new EVM instance with a given context, inspector, instruction set, and precompile provider.
     pub fn new_with_inspector(

--- a/crates/seismic/src/transaction/abstraction.rs
+++ b/crates/seismic/src/transaction/abstraction.rs
@@ -2,6 +2,7 @@ use auto_impl::auto_impl;
 use revm::{
     context::TxEnv,
     context_interface::transaction::Transaction,
+    handler::SystemCallTx,
     primitives::{Address, Bytes, TxKind, B256, U256},
 };
 
@@ -168,5 +169,19 @@ impl<T: Transaction> SeismicTxTr for SeismicTransaction<T> {
 
     fn rng_mode(&self) -> RngMode {
         self.rng_mode
+    }
+}
+
+impl<TX: Transaction + SystemCallTx> SystemCallTx for SeismicTransaction<TX> {
+    fn new_system_tx_with_caller(
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Self {
+        SeismicTransaction::new(TX::new_system_tx_with_caller(
+            caller,
+            system_contract_address,
+            data,
+        ))
     }
 }


### PR DESCRIPTION
Fixes veridise-825.

SeismicEvm implemented Deref/DerefMut to the inner Evm, which caused trait impls on Evm (e.g. SystemCallEvm) to be silently inherited via Deref coercion. This meant system calls bypassed SeismicHandler and routed through MainnetHandler instead, skipping any Seismic-specific cleanup logic (e.g. RNG state reset in execution_result()).
                                                                                                                                                                             
Removed the Deref/DerefMut impls and added explicit SystemCallEvm and InspectSystemCallEvm implementations that route through SeismicHandler, matching the pattern used by op-revm's OpEvm. Also added SystemCallTx impl for SeismicTransaction. This ensures all execution paths — regular transactions, inspected transactions, and system calls — go  through SeismicHandler consistently.
                  
Note that we are completly changing the RNG implementation to be stateless in #189, so the RNG bug that this PR fixes is not the main point. The main goal is to prevent such future bugs, and removing Deref is still the right structural fix — it prevents the entire class of silent trait fallthrough, so any future Seismic-specific state or cleanup added to SeismicHandler will automatically apply to all execution paths without needing to audit which traits are inherited.