### PR TITLE
fix: add block+tx accumulator to rng input

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - seismic
-      - veridise-audit-feb-2026
   pull_request:
-    branches:
-      - seismic
-      - veridise-audit-feb-2026
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/crates/seismic/src/chain/rng_container.rs
+++ b/crates/seismic/src/chain/rng_container.rs
@@ -3,24 +3,24 @@ use revm::{
     precompile::PrecompileError,
     primitives::{Bytes, B256},
 };
+
 /// Derives random bytes for the RNG precompile.
 ///
 /// Each call is fully stateless: a fresh `RootRng` is constructed from the
-/// provided key, domain separation data (tx_hash, gas_left) is appended,
-/// and bytes are derived via HKDF-SHA256.
-///
-/// - **Execution mode** (`live_key = Some(key)`): uses the enclave-provided key.
-///   Deterministic for the same (key, tx_hash, gas_left, pers).
-/// - **Simulation mode** (`live_key = None`): generates a random key via `OsRng`.
-///   Non-deterministic by design (each call gets a fresh random key).
+/// provided key, domain separation data (parent_block_hash, tx_hash_accumulator,
+/// tx_hash, gas_left) is appended, and bytes are derived via HKDF-SHA256.
 pub fn derive_rng_output(
     pers: &[u8],
     requested_output_len: usize,
     tx_hash: &B256,
     live_key: schnorrkel::Keypair,
+    parent_block_hash: &B256,
+    tx_hash_accumulator: &B256,
     total_gas_remaining: u64,
 ) -> Result<Bytes, PrecompileError> {
     let mut rng = RootRng::new(live_key);
+    rng.append_parent_block_hash(parent_block_hash);
+    rng.append_tx_hash_accumulator(tx_hash_accumulator);
     rng.append_tx(tx_hash);
     rng.append_gas_left(total_gas_remaining);
     let rng_bytes = rng.derive_bytes(pers, requested_output_len);

--- a/crates/seismic/src/chain/seismic_chain.rs
+++ b/crates/seismic/src/chain/seismic_chain.rs
@@ -247,7 +247,7 @@ mod tests {
         let mut expected_data = [0u8; 64];
         expected_data[..32].copy_from_slice(acc_after_tx1.as_ref());
         expected_data[32..].copy_from_slice(tx1.as_ref());
-        assert_eq!(acc_after_tx1_twice, keccak256(&expected_data));
+        assert_eq!(acc_after_tx1_twice, keccak256(expected_data));
     }
 
     #[test]

--- a/crates/seismic/src/chain/seismic_chain.rs
+++ b/crates/seismic/src/chain/seismic_chain.rs
@@ -84,7 +84,7 @@ impl SeismicChain {
         let mut data = [0u8; 64];
         data[..32].copy_from_slice(self.tx_hash_accumulator.as_ref());
         data[32..].copy_from_slice(tx_hash.as_ref());
-        self.tx_hash_accumulator = keccak256(&data);
+        self.tx_hash_accumulator = keccak256(data);
     }
 
     pub fn process_rng(

--- a/crates/seismic/src/chain/seismic_chain.rs
+++ b/crates/seismic/src/chain/seismic_chain.rs
@@ -1,6 +1,6 @@
 use revm::{
     precompile::PrecompileError,
-    primitives::{Bytes, B256},
+    primitives::{keccak256, Bytes, B256},
 };
 use schnorrkel::ExpansionMode;
 
@@ -8,7 +8,14 @@ use super::rng_container::derive_rng_output;
 
 #[derive(Clone, Debug)]
 pub struct SeismicChain {
+    // TODO: replace with plain [u8; 64] — we only use .secret.to_bytes() as HKDF input,
+    // no schnorrkel crypto. Kept as Keypair because seismic-enclave provisions it this way currently.
     live_rng_key: schnorrkel::Keypair,
+    /// Parent block hash for RNG domain separation. Set once at block start.
+    parent_block_hash: B256,
+    /// Running hash of prior transaction hashes in the current block.
+    /// Advanced after each committed transaction via `advance_tx_accumulator`.
+    tx_hash_accumulator: B256,
     /// Total remaining gas across all active call frames, set before precompile dispatch.
     gas_remaining_all_frames: u64,
 }
@@ -17,6 +24,8 @@ impl SeismicChain {
     pub fn new(root_vrf_key: schnorrkel::Keypair) -> Self {
         Self {
             live_rng_key: root_vrf_key,
+            parent_block_hash: B256::ZERO,
+            tx_hash_accumulator: B256::ZERO,
             gas_remaining_all_frames: 0,
         }
     }
@@ -26,6 +35,8 @@ impl SeismicChain {
             live_rng_key: schnorrkel::MiniSecretKey::generate()
                 .expand(ExpansionMode::Uniform)
                 .into(),
+            parent_block_hash: B256::ZERO,
+            tx_hash_accumulator: B256::ZERO,
             gas_remaining_all_frames: 0,
         }
     }
@@ -33,6 +44,8 @@ impl SeismicChain {
     pub fn with_live_rng_key(live_rng_key: schnorrkel::Keypair) -> Self {
         Self {
             live_rng_key,
+            parent_block_hash: B256::ZERO,
+            tx_hash_accumulator: B256::ZERO,
             gas_remaining_all_frames: 0,
         }
     }
@@ -49,6 +62,31 @@ impl SeismicChain {
         self.gas_remaining_all_frames = gas;
     }
 
+    pub fn parent_block_hash(&self) -> &B256 {
+        &self.parent_block_hash
+    }
+
+    pub fn set_parent_block_hash(&mut self, hash: B256) {
+        self.parent_block_hash = hash;
+    }
+
+    pub fn tx_hash_accumulator(&self) -> &B256 {
+        &self.tx_hash_accumulator
+    }
+
+    pub fn set_tx_hash_accumulator(&mut self, acc: B256) {
+        self.tx_hash_accumulator = acc;
+    }
+
+    /// Advance the tx hash accumulator by hashing in the given tx_hash.
+    /// Called after each committed transaction in a block.
+    pub fn advance_tx_accumulator(&mut self, tx_hash: &B256) {
+        let mut data = [0u8; 64];
+        data[..32].copy_from_slice(self.tx_hash_accumulator.as_ref());
+        data[32..].copy_from_slice(tx_hash.as_ref());
+        self.tx_hash_accumulator = keccak256(&data);
+    }
+
     pub fn process_rng(
         &self,
         pers: &[u8],
@@ -61,6 +99,8 @@ impl SeismicChain {
             requested_output_len,
             tx_hash,
             self.live_rng_key.clone(),
+            &self.parent_block_hash,
+            &self.tx_hash_accumulator,
             total_gas_remaining,
         )
     }
@@ -145,12 +185,15 @@ mod tests {
     }
 
     #[test]
-    fn test_simulation_mode_non_deterministic() {
-        // No live key = simulation mode (random key per call)
-        let chain1 = SeismicChain::with_random_rng_key();
-        let chain2 = SeismicChain::with_random_rng_key();
+    fn test_different_parent_block_hash_different_output() {
+        let keypair = get_unsecure_sample_schnorrkel_keypair();
+        let mut chain1 = SeismicChain::new(keypair.clone());
+        let mut chain2 = SeismicChain::new(keypair);
 
-        let tx_hash = B256::from([1u8; 32]);
+        chain1.set_parent_block_hash(B256::from([1u8; 32]));
+        chain2.set_parent_block_hash(B256::from([2u8; 32]));
+
+        let tx_hash = B256::from([0xAA; 32]);
         let pers = b"test_pers";
 
         let output1 = chain1.process_rng(pers, 32, &tx_hash, 1000).unwrap();
@@ -158,7 +201,76 @@ mod tests {
 
         assert_ne!(
             output1, output2,
-            "simulation mode should produce different output each call"
+            "different parent_block_hash should produce different RNG output"
+        );
+    }
+
+    #[test]
+    fn test_different_tx_hash_accumulator_different_output() {
+        let keypair = get_unsecure_sample_schnorrkel_keypair();
+        let mut chain1 = SeismicChain::new(keypair.clone());
+        let mut chain2 = SeismicChain::new(keypair);
+
+        chain1.set_tx_hash_accumulator(B256::from([1u8; 32]));
+        chain2.set_tx_hash_accumulator(B256::from([2u8; 32]));
+
+        let tx_hash = B256::from([0xAA; 32]);
+        let pers = b"test_pers";
+
+        let output1 = chain1.process_rng(pers, 32, &tx_hash, 1000).unwrap();
+        let output2 = chain2.process_rng(pers, 32, &tx_hash, 1000).unwrap();
+
+        assert_ne!(
+            output1, output2,
+            "different tx_hash_accumulator should produce different RNG output"
+        );
+    }
+
+    #[test]
+    fn test_advance_tx_accumulator() {
+        let keypair = get_unsecure_sample_schnorrkel_keypair();
+        let mut chain = SeismicChain::new(keypair);
+
+        assert_eq!(*chain.tx_hash_accumulator(), B256::ZERO);
+
+        let tx1 = B256::from([1u8; 32]);
+        chain.advance_tx_accumulator(&tx1);
+        let acc_after_tx1 = *chain.tx_hash_accumulator();
+        assert_ne!(acc_after_tx1, B256::ZERO);
+
+        // Advancing with same tx again should produce different accumulator
+        chain.advance_tx_accumulator(&tx1);
+        let acc_after_tx1_twice = *chain.tx_hash_accumulator();
+        assert_ne!(acc_after_tx1, acc_after_tx1_twice);
+
+        // Verify accumulator = keccak(prev || tx_hash)
+        let mut expected_data = [0u8; 64];
+        expected_data[..32].copy_from_slice(acc_after_tx1.as_ref());
+        expected_data[32..].copy_from_slice(tx1.as_ref());
+        assert_eq!(acc_after_tx1_twice, keccak256(&expected_data));
+    }
+
+    #[test]
+    fn test_accumulator_affects_rng_output() {
+        let keypair = get_unsecure_sample_schnorrkel_keypair();
+        let mut chain = SeismicChain::new(keypair);
+        chain.set_parent_block_hash(B256::from([0xFF; 32]));
+
+        let tx_hash = B256::from([0xAA; 32]);
+        let pers = b"test_pers";
+
+        // RNG output before any accumulator advance
+        let output_before = chain.process_rng(pers, 32, &tx_hash, 1000).unwrap();
+
+        // Advance accumulator (simulating a prior tx in the block)
+        chain.advance_tx_accumulator(&B256::from([0xBB; 32]));
+
+        // RNG output after accumulator advance — should differ
+        let output_after = chain.process_rng(pers, 32, &tx_hash, 1000).unwrap();
+
+        assert_ne!(
+            output_before, output_after,
+            "RNG output should differ after tx_hash_accumulator is advanced"
         );
     }
 }

--- a/crates/seismic/src/precompiles/rng/domain_sep_rng.rs
+++ b/crates/seismic/src/precompiles/rng/domain_sep_rng.rs
@@ -48,6 +48,18 @@ impl RootRng {
         Self::new(get_unsecure_sample_schnorrkel_keypair())
     }
 
+    /// Append the parent block hash to the domain separation data.
+    pub fn append_parent_block_hash(&mut self, hash: &B256) {
+        self.domain_data.extend_from_slice(b"block");
+        self.domain_data.extend_from_slice(hash.as_ref());
+    }
+
+    /// Append the transaction hash accumulator to the domain separation data.
+    pub fn append_tx_hash_accumulator(&mut self, acc: &B256) {
+        self.domain_data.extend_from_slice(b"acc");
+        self.domain_data.extend_from_slice(acc.as_ref());
+    }
+
     /// Append a transaction hash to the domain separation data.
     pub fn append_tx(&mut self, tx_hash: &B256) {
         self.domain_data.extend_from_slice(b"tx");


### PR DESCRIPTION
Meant to merge into #189 before merging that into veridise-audit-feb-2026 branch.

requested by auditors. This also makes our new stateless HKDF rng precompile behave like oasis' merlin transcript based one that we originally had mimicked.