### PR TITLE
feat(auth-list): apply_eip7702_auth_list for all txs that have one

### DIFF
--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -176,8 +176,8 @@ pub fn apply_eip7702_auth_list<
     context: &mut CTX,
 ) -> Result<u64, ERROR> {
     let tx = context.tx();
-    // Return if there is no auth list.
-    if tx.tx_type() != TransactionType::Eip7702 {
+    // Return if there is no auth list (7702 or Seismic tx).
+    if tx.authorization_list_len() == 0 {
         return Ok(0);
     }
 

--- a/crates/handler/src/pre_execution.rs
+++ b/crates/handler/src/pre_execution.rs
@@ -7,10 +7,8 @@ use bytecode::Bytecode;
 use context_interface::transaction::AuthorizationTr;
 use context_interface::ContextTr;
 use context_interface::{
-    journaled_state::JournalTr,
-    result::InvalidTransaction,
-    transaction::{Transaction, TransactionType},
-    Block, Cfg, Database,
+    journaled_state::JournalTr, result::InvalidTransaction, transaction::Transaction, Block, Cfg,
+    Database,
 };
 use core::cmp::Ordering;
 use primitives::{eip7702, hardfork::SpecId, KECCAK_EMPTY, U256};


### PR DESCRIPTION
Group of related PRs:
- https://github.com/SeismicSystems/seismic-alloy/pull/82
- https://github.com/SeismicSystems/seismic-evm/pull/40
- https://github.com/SeismicSystems/seismic-reth/pull/332

Before the function was gating and only allowing 7702 txs to have an auth list. Made it more generic such that any tx with an auth_list will now run the function. In particular, our TxSeismic changes to add an auth_list will now work. See
https://github.com/SeismicSystems/seismic-alloy/pull/82

Interestingly, we don't even need to update our seismic-alloy commit given that this change is generic.