### PR TITLE
refactor(seismic)!: take the RNG key as raw HKDF ikm bytes, not a schnorrkel keypair

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -94,9 +94,7 @@ jobs:
       - name: Clone seismic-solidity repo
         run: |
           TEMP_DIR=$(mktemp -d)
-          # Temporarily checking out the test--new-storage-opcode-semantics branch that fixes storage opcode semantic tests.
-          # TODO(samlaf): switch back to seismic (default) branch after we merge https://github.com/SeismicSystems/seismic-solidity/pull/251
-          git clone -b test--update-rng-precompile-semantic-test https://github.com/SeismicSystems/seismic-solidity.git "$TEMP_DIR/seismic-solidity"
+          git clone https://github.com/SeismicSystems/seismic-solidity.git "$TEMP_DIR/seismic-solidity"
           echo "SEISMIC_SOLIDITY_PATH=$TEMP_DIR/seismic-solidity" >> $GITHUB_ENV
           echo "seismic-solidity cloned to: $TEMP_DIR/seismic-solidity"
       - name: Install latest ssolc release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,12 +1288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,16 +1462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "console"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,16 +1518,6 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2253,10 +2227,6 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-dependencies = [
- "gloo-timers",
- "send_wrapper",
-]
 
 [[package]]
 name = "futures-util"
@@ -2349,52 +2319,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "gloo-net"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils",
- "http",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "gmp-mpfr-sys"
 version = "1.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,25 +2337,6 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.11.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -2581,12 +2486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,34 +2501,15 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -2952,28 +2832,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,178 +2839,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonrpsee"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3f48dc3e6b8bd21e15436c1ddd0bc22a6a54e8ec46fedd6adf3425f396ec6a"
-dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-http-client",
- "jsonrpsee-proc-macros",
- "jsonrpsee-server",
- "jsonrpsee-types",
- "jsonrpsee-wasm-client",
- "jsonrpsee-ws-client",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf36eb27f8e13fa93dcb50ccb44c417e25b818cfa1a481b5470cd07b19c60b98"
-dependencies = [
- "base64",
- "futures-channel",
- "futures-util",
- "gloo-net",
- "http",
- "jsonrpsee-core",
- "pin-project",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "soketto",
- "thiserror 2.0.16",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-timer",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "jsonrpsee-types",
- "parking_lot",
- "pin-project",
- "rand 0.9.2",
- "rustc-hash",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
- "tokio",
- "tokio-stream",
- "tower",
- "tracing",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
-dependencies = [
- "base64",
- "http-body",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "rustls",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
- "tokio",
- "tower",
- "url",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da3f8ab5ce1bb124b6d082e62dffe997578ceaf0aeb9f3174a214589dc00f07"
-dependencies = [
- "heck",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "jsonrpsee-server"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c51b7c290bb68ce3af2d029648148403863b982f138484a73f02a9dd52dbd7f"
-dependencies = [
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "pin-project",
- "route-recognizer",
- "serde",
- "serde_json",
- "soketto",
- "thiserror 2.0.16",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
-dependencies = [
- "http",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "jsonrpsee-wasm-client"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7902885de4779f711a95d82c8da2d7e5f9f3a7c7cfa44d51c067fd1c29d72a3c"
-dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "tower",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
-dependencies = [
- "http",
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "tower",
- "url",
 ]
 
 [[package]]
@@ -3307,7 +2993,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4380,20 +4066,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.16",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "ripemd"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4411,12 +4083,6 @@ dependencies = [
  "bytes",
  "rustc-hex",
 ]
-
-[[package]]
-name = "route-recognizer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rstest"
@@ -4546,77 +4212,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
-dependencies = [
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework 3.5.1",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework 3.5.1",
- "security-framework-sys",
- "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -4775,20 +4376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4805,20 +4393,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "seismic-enclave"
+name = "seismic-crypto"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=f90b02f38a6190e8b2ff2d051d9043f3480cd3ac#f90b02f38a6190e8b2ff2d051d9043f3480cd3ac"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=8274f14cbbad76daadad3aaa1d6d0418b3eeffc0#8274f14cbbad76daadad3aaa1d6d0418b3eeffc0"
 dependencies = [
  "aes-gcm",
  "anyhow",
  "hkdf",
- "jsonrpsee",
  "rand 0.9.2",
  "schnorrkel",
  "secp256k1 0.30.0",
  "serde",
  "sha2",
- "tracing",
 ]
 
 [[package]]
@@ -4832,11 +4418,11 @@ dependencies = [
  "hkdf",
  "indicatif",
  "once_cell",
+ "rand 0.9.2",
  "revm",
  "rstest",
- "schnorrkel",
  "secp256k1 0.31.1",
- "seismic-enclave",
+ "seismic-crypto",
  "serde",
  "serde_json",
  "sha2",
@@ -4868,12 +4454,6 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
-
-[[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
@@ -4972,17 +4552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5068,22 +4637,6 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "soketto"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
-dependencies = [
- "base64",
- "bytes",
- "futures",
- "http",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
 ]
 
 [[package]]
@@ -5401,16 +4954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5430,7 +4973,6 @@ checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -5618,12 +5160,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unty"
@@ -5839,24 +5375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.4",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5948,24 +5466,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -5980,21 +5480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6032,12 +5517,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6050,12 +5529,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6065,12 +5538,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6098,12 +5565,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6113,12 +5574,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6134,12 +5589,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6149,12 +5598,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 seismic-revm = { path = "crates/seismic" }
-seismic-enclave = { version = "0.1.0" }
+seismic-crypto = { version = "0.1.0" }
 cargo_metadata = "0.18"
 
 # revm
@@ -179,5 +179,5 @@ inherits = "test"
 opt-level = 3
 
 [patch.crates-io]
-seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "f90b02f38a6190e8b2ff2d051d9043f3480cd3ac" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "8274f14cbbad76daadad3aaa1d6d0418b3eeffc0" }
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }

--- a/bins/revme/src/cmd/semantics/evm_handler.rs
+++ b/bins/revme/src/cmd/semantics/evm_handler.rs
@@ -7,9 +7,7 @@ use revm::{
     primitives::{Address, Bytes, FixedBytes, Log, TxKind, U256},
     Context, DatabaseCommit, DatabaseRef, ExecuteEvm, InspectEvm, MainBuilder, MainContext,
 };
-use seismic_revm::{
-    precompiles::rng::domain_sep_rng::SchnorrkelKeypair, DefaultSeismicContext, SeismicBuilder,
-};
+use seismic_revm::{DefaultSeismicContext, SeismicBuilder};
 use std::str::FromStr;
 
 use crate::cmd::semantics::{test_cases::TestStep, utils::verify_emitted_events};
@@ -20,6 +18,10 @@ use super::{
     utils::{verify_expected_balances, verify_storage_empty},
     Errors,
 };
+
+/// Fixed rng key for the test EVM: semantic-test expectation comments record
+/// exact outputs, so RNG-precompile results must be deterministic across runs.
+const FIXED_TEST_RNG_IKM: [u8; 64] = [0; 64];
 
 #[derive(Debug, Clone)]
 pub(crate) struct EvmConfig {
@@ -128,36 +130,34 @@ impl EvmExecutor {
             .map_or(0, |account| account.nonce);
         let deploy_out = if self.evm_version == EVMVersion::Mercury {
             if trace {
-                let mut evm = Context::seismic_with_rng_key(
-                    SchnorrkelKeypair::from_bytes(&[0; 96]).expect("safe"),
-                )
-                .with_db(self.db.clone())
-                .modify_tx_chained(|tx| {
-                    tx.base.caller = self.config.caller;
-                    tx.base.kind = TxKind::Create;
-                    tx.base.data = deploy_data.clone();
-                    tx.base.value = value;
-                    tx.base.nonce = nonce;
-                })
-                .modify_cfg_chained(|cfg| cfg.spec = self.evm_version.to_seismic_spec_id())
-                .build_seismic_evm_with_inspector(TracerEip3155::new_stdout().without_summary());
+                let mut evm = Context::seismic_with_rng_key(FIXED_TEST_RNG_IKM)
+                    .with_db(self.db.clone())
+                    .modify_tx_chained(|tx| {
+                        tx.base.caller = self.config.caller;
+                        tx.base.kind = TxKind::Create;
+                        tx.base.data = deploy_data.clone();
+                        tx.base.value = value;
+                        tx.base.nonce = nonce;
+                    })
+                    .modify_cfg_chained(|cfg| cfg.spec = self.evm_version.to_seismic_spec_id())
+                    .build_seismic_evm_with_inspector(
+                        TracerEip3155::new_stdout().without_summary(),
+                    );
                 evm.inspect_tx(evm.0.ctx.tx.clone()).map_err(|err| {
                     Errors::EVMError(format!("DEPLOY transaction error: {:?}", err.to_string()))
                 })?
             } else {
-                let mut evm = Context::seismic_with_rng_key(
-                    SchnorrkelKeypair::from_bytes(&[0; 96]).expect("safe"),
-                )
-                .with_db(self.db.clone())
-                .modify_tx_chained(|tx| {
-                    tx.base.caller = self.config.caller;
-                    tx.base.kind = TxKind::Create;
-                    tx.base.data = deploy_data.clone();
-                    tx.base.value = value;
-                    tx.base.nonce = nonce;
-                })
-                .modify_cfg_chained(|cfg| cfg.spec = self.evm_version.to_seismic_spec_id())
-                .build_seismic_evm();
+                let mut evm = Context::seismic_with_rng_key(FIXED_TEST_RNG_IKM)
+                    .with_db(self.db.clone())
+                    .modify_tx_chained(|tx| {
+                        tx.base.caller = self.config.caller;
+                        tx.base.kind = TxKind::Create;
+                        tx.base.data = deploy_data.clone();
+                        tx.base.value = value;
+                        tx.base.nonce = nonce;
+                    })
+                    .modify_cfg_chained(|cfg| cfg.spec = self.evm_version.to_seismic_spec_id())
+                    .build_seismic_evm();
                 evm.replay().map_err(|err| {
                     Errors::EVMError(format!("DEPLOY transaction error: {:?}", err.to_string()))
                 })?
@@ -247,34 +247,34 @@ impl EvmExecutor {
             .map_or(0, |account| account.nonce);
         let out = if self.evm_version == EVMVersion::Mercury {
             if trace {
-                let mut evm = Context::seismic_with_rng_key(
-                    SchnorrkelKeypair::from_bytes(&[0; 96]).expect("safe"),
-                )
-                .with_db(self.db.clone())
-                .modify_tx_chained(|tx| {
-                    tx.base.caller = self.config.caller;
-                    tx.base.kind = TxKind::Call(self.config.env_contract_address);
-                    tx.base.data = input_data.clone();
-                    tx.base.value = value;
-                    if self.evm_version >= EVMVersion::Cancun {
-                        tx.base.blob_hashes = self.config.blob_hashes.clone();
-                        tx.base.max_fee_per_blob_gas = self.config.max_blob_fee;
-                    }
-                    tx.base.gas_limit = self.config.gas_limit;
-                    tx.base.gas_price = self.config.gas_price;
-                    tx.base.gas_priority_fee = self.config.gas_priority_fee;
-                    tx.base.nonce = nonce;
-                })
-                .modify_block_chained(|block| {
-                    block.prevrandao = Some(self.config.block_prevrandao);
-                    block.difficulty = self.config.block_difficulty.into();
-                    block.gas_limit = self.config.block_gas_limit;
-                    block.basefee = self.config.block_basefee;
-                    block.number = self.config.block_number;
-                    block.timestamp = self.config.timestamp;
-                })
-                .modify_cfg_chained(|cfg| cfg.spec = self.evm_version.to_seismic_spec_id())
-                .build_seismic_evm_with_inspector(TracerEip3155::new(Box::new(std::io::stdout())));
+                let mut evm = Context::seismic_with_rng_key(FIXED_TEST_RNG_IKM)
+                    .with_db(self.db.clone())
+                    .modify_tx_chained(|tx| {
+                        tx.base.caller = self.config.caller;
+                        tx.base.kind = TxKind::Call(self.config.env_contract_address);
+                        tx.base.data = input_data.clone();
+                        tx.base.value = value;
+                        if self.evm_version >= EVMVersion::Cancun {
+                            tx.base.blob_hashes = self.config.blob_hashes.clone();
+                            tx.base.max_fee_per_blob_gas = self.config.max_blob_fee;
+                        }
+                        tx.base.gas_limit = self.config.gas_limit;
+                        tx.base.gas_price = self.config.gas_price;
+                        tx.base.gas_priority_fee = self.config.gas_priority_fee;
+                        tx.base.nonce = nonce;
+                    })
+                    .modify_block_chained(|block| {
+                        block.prevrandao = Some(self.config.block_prevrandao);
+                        block.difficulty = self.config.block_difficulty.into();
+                        block.gas_limit = self.config.block_gas_limit;
+                        block.basefee = self.config.block_basefee;
+                        block.number = self.config.block_number;
+                        block.timestamp = self.config.timestamp;
+                    })
+                    .modify_cfg_chained(|cfg| cfg.spec = self.evm_version.to_seismic_spec_id())
+                    .build_seismic_evm_with_inspector(TracerEip3155::new(Box::new(
+                        std::io::stdout(),
+                    )));
                 evm.inspect_tx(evm.0.ctx.tx.clone()).map_err(|err| {
                     Errors::EVMError(format!(
                         "EVM transaction error: {:?}, for the file: {:?}",
@@ -283,34 +283,32 @@ impl EvmExecutor {
                     ))
                 })?
             } else {
-                let mut evm = Context::seismic_with_rng_key(
-                    SchnorrkelKeypair::from_bytes(&[0; 96]).expect("safe"),
-                )
-                .with_db(self.db.clone())
-                .modify_tx_chained(|tx| {
-                    tx.base.caller = self.config.caller;
-                    tx.base.kind = TxKind::Call(self.config.env_contract_address);
-                    tx.base.data = input_data.clone();
-                    tx.base.value = value;
-                    if self.evm_version >= EVMVersion::Cancun {
-                        tx.base.blob_hashes = self.config.blob_hashes.clone();
-                        tx.base.max_fee_per_blob_gas = self.config.max_blob_fee;
-                    }
-                    tx.base.gas_limit = self.config.gas_limit;
-                    tx.base.gas_price = self.config.gas_price;
-                    tx.base.nonce = nonce;
-                    tx.base.gas_priority_fee = self.config.gas_priority_fee;
-                })
-                .modify_block_chained(|block| {
-                    block.prevrandao = Some(self.config.block_prevrandao);
-                    block.difficulty = self.config.block_difficulty.into();
-                    block.gas_limit = self.config.block_gas_limit;
-                    block.basefee = self.config.block_basefee;
-                    block.number = self.config.block_number;
-                    block.timestamp = self.config.timestamp;
-                })
-                .modify_cfg_chained(|cfg| cfg.spec = self.evm_version.to_seismic_spec_id())
-                .build_seismic_evm();
+                let mut evm = Context::seismic_with_rng_key(FIXED_TEST_RNG_IKM)
+                    .with_db(self.db.clone())
+                    .modify_tx_chained(|tx| {
+                        tx.base.caller = self.config.caller;
+                        tx.base.kind = TxKind::Call(self.config.env_contract_address);
+                        tx.base.data = input_data.clone();
+                        tx.base.value = value;
+                        if self.evm_version >= EVMVersion::Cancun {
+                            tx.base.blob_hashes = self.config.blob_hashes.clone();
+                            tx.base.max_fee_per_blob_gas = self.config.max_blob_fee;
+                        }
+                        tx.base.gas_limit = self.config.gas_limit;
+                        tx.base.gas_price = self.config.gas_price;
+                        tx.base.nonce = nonce;
+                        tx.base.gas_priority_fee = self.config.gas_priority_fee;
+                    })
+                    .modify_block_chained(|block| {
+                        block.prevrandao = Some(self.config.block_prevrandao);
+                        block.difficulty = self.config.block_difficulty.into();
+                        block.gas_limit = self.config.block_gas_limit;
+                        block.basefee = self.config.block_basefee;
+                        block.number = self.config.block_number;
+                        block.timestamp = self.config.timestamp;
+                    })
+                    .modify_cfg_chained(|cfg| cfg.spec = self.evm_version.to_seismic_spec_id())
+                    .build_seismic_evm();
                 evm.replay().map_err(|err| {
                     Errors::EVMError(format!(
                         "EVM transaction error: {:?}, for the file: {:?}",

--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -17,8 +17,7 @@ use revm::{
     Context, ExecuteCommitEvm,
 };
 use seismic_revm::{
-    precompiles::rng::domain_sep_rng::SchnorrkelKeypair, DefaultSeismicContext, SeismicBuilder,
-    SeismicSpecId as SpecId, SeismicTransaction,
+    DefaultSeismicContext, SeismicBuilder, SeismicSpecId as SpecId, SeismicTransaction,
 };
 use serde_json::json;
 use statetest_types::{SpecName, Test, TestSuite, TestUnit};
@@ -36,6 +35,10 @@ use std::{
 };
 use thiserror::Error;
 use walkdir::{DirEntry, WalkDir};
+
+/// Fixed rng key for state-test execution; Ethereum state tests never call
+/// the RNG precompile, so the value is arbitrary.
+const FIXED_TEST_RNG_IKM: [u8; 64] = [0; 64];
 
 /// Error that occurs during test execution
 #[derive(Debug, Error)]
@@ -474,13 +477,12 @@ fn debug_failed_test(ctx: DebugContext) {
         .with_bundle_update()
         .build();
 
-    let mut evm =
-        Context::seismic_with_rng_key(SchnorrkelKeypair::from_bytes(&[0; 96]).expect("safe"))
-            .with_db(&mut state)
-            .with_block(ctx.block)
-            .with_tx(ctx.tx)
-            .with_cfg(ctx.cfg)
-            .build_seismic_evm_with_inspector(TracerEip3155::buffered(stderr()).without_summary());
+    let mut evm = Context::seismic_with_rng_key(FIXED_TEST_RNG_IKM)
+        .with_db(&mut state)
+        .with_block(ctx.block)
+        .with_tx(ctx.tx)
+        .with_cfg(ctx.cfg)
+        .build_seismic_evm_with_inspector(TracerEip3155::buffered(stderr()).without_summary());
 
     let exec_result = evm.inspect_tx_commit(ctx.tx);
 

--- a/crates/seismic/Cargo.toml
+++ b/crates/seismic/Cargo.toml
@@ -32,10 +32,10 @@ once_cell = { version = "1.21", features = ["alloc"] }
 # Optional
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 
-# seismic 
-schnorrkel = { version = "0.11.2", default-features = false }
+# seismic
 hkdf = { version = "0.12", default-features = false }
-seismic-enclave = { workspace = true}
+rand.workspace = true
+seismic-crypto = { workspace = true }
 sha2 = { workspace = true } 
 secp256k1 = { workspace = true, features = ["recovery"] }
 

--- a/crates/seismic/src/api/default_ctx.rs
+++ b/crates/seismic/src/api/default_ctx.rs
@@ -19,8 +19,8 @@ pub type SeismicContext<DB> = Context<
 pub trait DefaultSeismicContext {
     /// Create a context that uses a random rng key for precompile everytime.
     fn seismic_with_random_rng_key() -> SeismicContext<EmptyDB>;
-    /// Create a context with a specific RNG keypair.
-    fn seismic_with_rng_key(rng_keypair: schnorrkel::Keypair) -> SeismicContext<EmptyDB>;
+    /// Create a context with specific RNG input key material.
+    fn seismic_with_rng_key(rng_ikm: [u8; 64]) -> SeismicContext<EmptyDB>;
 }
 
 impl DefaultSeismicContext for SeismicContext<EmptyDB> {
@@ -31,11 +31,11 @@ impl DefaultSeismicContext for SeismicContext<EmptyDB> {
             .with_chain(SeismicChain::with_random_rng_key())
     }
 
-    fn seismic_with_rng_key(rng_keypair: schnorrkel::Keypair) -> Self {
+    fn seismic_with_rng_key(rng_ikm: [u8; 64]) -> Self {
         Context::mainnet()
             .with_tx(SeismicTransaction::default())
             .with_cfg(CfgEnv::new_with_spec(SeismicSpecId::MERCURY))
-            .with_chain(SeismicChain::with_live_rng_key(rng_keypair))
+            .with_chain(SeismicChain::with_live_rng_key(rng_ikm))
     }
 }
 

--- a/crates/seismic/src/chain/rng_container.rs
+++ b/crates/seismic/src/chain/rng_container.rs
@@ -13,7 +13,7 @@ pub fn derive_rng_output(
     pers: &[u8],
     requested_output_len: usize,
     tx_hash: &B256,
-    live_key: schnorrkel::Keypair,
+    live_key: [u8; 64],
     parent_block_hash: &B256,
     tx_hash_accumulator: &B256,
     total_gas_remaining: u64,

--- a/crates/seismic/src/chain/seismic_chain.rs
+++ b/crates/seismic/src/chain/seismic_chain.rs
@@ -1,16 +1,15 @@
+use rand::RngCore;
 use revm::{
     precompile::PrecompileError,
     primitives::{keccak256, Bytes, B256},
 };
-use schnorrkel::ExpansionMode;
 
 use super::rng_container::derive_rng_output;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SeismicChain {
-    // TODO: replace with plain [u8; 64] — we only use .secret.to_bytes() as HKDF input,
-    // no schnorrkel crypto. Kept as Keypair because seismic-enclave provisions it this way currently.
-    live_rng_key: schnorrkel::Keypair,
+    /// HKDF input key material for the RNG precompile (64 bytes).
+    live_rng_key: [u8; 64],
     /// Parent block hash for RNG domain separation. Set once at block start.
     parent_block_hash: B256,
     /// Running hash of prior transaction hashes in the current block.
@@ -22,10 +21,22 @@ pub struct SeismicChain {
     used_erc20_gas: bool,
 }
 
+/// Redacted: `live_rng_key` seeds every RNG-precompile output.
+impl core::fmt::Debug for SeismicChain {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SeismicChain")
+            .field("parent_block_hash", &self.parent_block_hash)
+            .field("tx_hash_accumulator", &self.tx_hash_accumulator)
+            .field("gas_remaining_all_frames", &self.gas_remaining_all_frames)
+            .field("used_erc20_gas", &self.used_erc20_gas)
+            .finish_non_exhaustive()
+    }
+}
+
 impl SeismicChain {
-    pub fn new(root_vrf_key: schnorrkel::Keypair) -> Self {
+    pub fn new(rng_ikm: [u8; 64]) -> Self {
         Self {
-            live_rng_key: root_vrf_key,
+            live_rng_key: rng_ikm,
             parent_block_hash: B256::ZERO,
             tx_hash_accumulator: B256::ZERO,
             gas_remaining_all_frames: 0,
@@ -33,11 +44,15 @@ impl SeismicChain {
         }
     }
 
+    /// A chain seeded with a fresh random rng key, for execution contexts that
+    /// run without provisioned network keys (sforge, sanvil, state tests).
+    /// Consensus nodes inject their network's key instead — RNG-precompile
+    /// outputs are consensus-visible.
     pub fn with_random_rng_key() -> Self {
+        let mut random_ikm = [0u8; 64];
+        rand::rng().fill_bytes(&mut random_ikm);
         Self {
-            live_rng_key: schnorrkel::MiniSecretKey::generate()
-                .expand(ExpansionMode::Uniform)
-                .into(),
+            live_rng_key: random_ikm,
             parent_block_hash: B256::ZERO,
             tx_hash_accumulator: B256::ZERO,
             gas_remaining_all_frames: 0,
@@ -45,7 +60,7 @@ impl SeismicChain {
         }
     }
 
-    pub fn with_live_rng_key(live_rng_key: schnorrkel::Keypair) -> Self {
+    pub fn with_live_rng_key(live_rng_key: [u8; 64]) -> Self {
         Self {
             live_rng_key,
             parent_block_hash: B256::ZERO,
@@ -55,8 +70,8 @@ impl SeismicChain {
         }
     }
 
-    pub fn set_rng_key(&mut self, root_vrf_key: schnorrkel::Keypair) {
-        self.live_rng_key = root_vrf_key;
+    pub fn set_rng_key(&mut self, rng_ikm: [u8; 64]) {
+        self.live_rng_key = rng_ikm;
     }
 
     pub fn gas_remaining_all_frames(&self) -> u64 {
@@ -115,7 +130,7 @@ impl SeismicChain {
             pers,
             requested_output_len,
             tx_hash,
-            self.live_rng_key.clone(),
+            self.live_rng_key,
             &self.parent_block_hash,
             &self.tx_hash_accumulator,
             total_gas_remaining,
@@ -128,12 +143,12 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
-    use seismic_enclave::get_unsecure_sample_schnorrkel_keypair;
+    use seismic_crypto::get_unsecure_sample_schnorrkel_keypair;
 
     #[test]
     fn test_execution_mode_same_inputs_same_output() {
-        let keypair = get_unsecure_sample_schnorrkel_keypair();
-        let chain = SeismicChain::new(keypair);
+        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let chain = SeismicChain::new(ikm);
 
         let tx_hash = B256::from([1u8; 32]);
         let pers = b"test_pers";
@@ -149,8 +164,8 @@ mod tests {
 
     #[test]
     fn test_execution_mode_different_pers_different_output() {
-        let keypair = get_unsecure_sample_schnorrkel_keypair();
-        let chain = SeismicChain::new(keypair);
+        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let chain = SeismicChain::new(ikm);
 
         let tx_hash = B256::from([1u8; 32]);
 
@@ -165,8 +180,8 @@ mod tests {
 
     #[test]
     fn test_execution_mode_different_tx_hash_different_output() {
-        let keypair = get_unsecure_sample_schnorrkel_keypair();
-        let chain = SeismicChain::new(keypair);
+        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let chain = SeismicChain::new(ikm);
 
         let pers = b"test_pers";
 
@@ -185,9 +200,9 @@ mod tests {
 
     #[test]
     fn test_execution_mode_deterministic_across_chains() {
-        let keypair = get_unsecure_sample_schnorrkel_keypair();
-        let chain1 = SeismicChain::new(keypair.clone());
-        let chain2 = SeismicChain::new(keypair);
+        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let chain1 = SeismicChain::new(ikm);
+        let chain2 = SeismicChain::new(ikm);
 
         let tx_hash = B256::from([1u8; 32]);
         let pers = b"test_pers";
@@ -203,9 +218,9 @@ mod tests {
 
     #[test]
     fn test_different_parent_block_hash_different_output() {
-        let keypair = get_unsecure_sample_schnorrkel_keypair();
-        let mut chain1 = SeismicChain::new(keypair.clone());
-        let mut chain2 = SeismicChain::new(keypair);
+        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let mut chain1 = SeismicChain::new(ikm);
+        let mut chain2 = SeismicChain::new(ikm);
 
         chain1.set_parent_block_hash(B256::from([1u8; 32]));
         chain2.set_parent_block_hash(B256::from([2u8; 32]));
@@ -224,9 +239,9 @@ mod tests {
 
     #[test]
     fn test_different_tx_hash_accumulator_different_output() {
-        let keypair = get_unsecure_sample_schnorrkel_keypair();
-        let mut chain1 = SeismicChain::new(keypair.clone());
-        let mut chain2 = SeismicChain::new(keypair);
+        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let mut chain1 = SeismicChain::new(ikm);
+        let mut chain2 = SeismicChain::new(ikm);
 
         chain1.set_tx_hash_accumulator(B256::from([1u8; 32]));
         chain2.set_tx_hash_accumulator(B256::from([2u8; 32]));
@@ -245,8 +260,8 @@ mod tests {
 
     #[test]
     fn test_advance_tx_accumulator() {
-        let keypair = get_unsecure_sample_schnorrkel_keypair();
-        let mut chain = SeismicChain::new(keypair);
+        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let mut chain = SeismicChain::new(ikm);
 
         assert_eq!(*chain.tx_hash_accumulator(), B256::ZERO);
 
@@ -269,8 +284,8 @@ mod tests {
 
     #[test]
     fn test_accumulator_affects_rng_output() {
-        let keypair = get_unsecure_sample_schnorrkel_keypair();
-        let mut chain = SeismicChain::new(keypair);
+        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let mut chain = SeismicChain::new(ikm);
         chain.set_parent_block_hash(B256::from([0xFF; 32]));
 
         let tx_hash = B256::from([0xAA; 32]);

--- a/crates/seismic/src/evm.rs
+++ b/crates/seismic/src/evm.rs
@@ -360,7 +360,7 @@ mod tests {
         spec: SeismicSpecId,
         bytes_requested: u32,
         personalization: Vec<u8>,
-        keypair: schnorrkel::Keypair,
+        rng_ikm: [u8; 64],
     ) -> Context<
         BlockEnv,
         SeismicTransaction<TxEnv>,
@@ -379,7 +379,7 @@ mod tests {
         let total_gas =
             initial_gas + calculate_gas_cost(bytes_requested as usize, personalization.len());
 
-        Context::seismic_with_rng_key(keypair)
+        Context::seismic_with_rng_key(rng_ikm)
             .modify_tx_chained(|tx| {
                 tx.base.kind = TxKind::Call(u64_to_address(rng::precompile::RNG_ADDRESS));
                 tx.base.data = input;
@@ -390,18 +390,18 @@ mod tests {
 
     #[test]
     fn test_rng_precompile_expected_output() {
-        use seismic_enclave::get_unsecure_sample_schnorrkel_keypair;
+        use seismic_crypto::get_unsecure_sample_schnorrkel_keypair;
 
         let bytes_requested: u32 = 32;
         let personalization = vec![0xAA, 0xBB, 0xCC, 0xDD];
-        let keypair = get_unsecure_sample_schnorrkel_keypair();
+        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
 
         // Get EVM output
         let ctx = rng_test_tx(
             SeismicSpecId::MERCURY,
             bytes_requested,
             personalization.clone(),
-            keypair.clone(),
+            ikm,
         );
 
         let mut evm = ctx.build_seismic_evm();
@@ -421,7 +421,7 @@ mod tests {
             SeismicSpecId::MERCURY,
             bytes_requested,
             personalization,
-            keypair,
+            ikm,
         );
         let mut evm2 = ctx2.build_seismic_evm();
         let output2 = evm2.replay().unwrap();

--- a/crates/seismic/src/precompiles.rs
+++ b/crates/seismic/src/precompiles.rs
@@ -260,12 +260,12 @@ mod tests {
 
     #[test]
     fn test_seismic_precompiles_rng() {
-        use seismic_enclave::get_unsecure_sample_schnorrkel_keypair;
+        use seismic_crypto::get_unsecure_sample_schnorrkel_keypair;
 
         let mut precompiles =
             SeismicPrecompiles::<SeismicContext<EmptyDB>>::new_with_spec(SeismicSpecId::MERCURY);
-        let keypair = get_unsecure_sample_schnorrkel_keypair();
-        let mut context = SeismicContext::<EmptyDB>::seismic_with_rng_key(keypair);
+        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let mut context = SeismicContext::<EmptyDB>::seismic_with_rng_key(ikm);
         let rng_address = *precompiles
             .stateful_precompiles
             .addresses()

--- a/crates/seismic/src/precompiles/aes/aes_gcm_dec.rs
+++ b/crates/seismic/src/precompiles/aes/aes_gcm_dec.rs
@@ -6,7 +6,7 @@ use super::common::{
     calculate_cost, parse_aes_key, validate_gas_limit, validate_input_length, validate_nonce_length,
 };
 
-use seismic_enclave::aes_decrypt;
+use seismic_crypto::aes_decrypt;
 
 /* --------------------------------------------------------------------------
 Constants & Setup

--- a/crates/seismic/src/precompiles/aes/aes_gcm_enc.rs
+++ b/crates/seismic/src/precompiles/aes/aes_gcm_enc.rs
@@ -6,7 +6,7 @@ use super::common::{
     calculate_cost, parse_aes_key, validate_gas_limit, validate_input_length, validate_nonce_length,
 };
 
-use seismic_enclave::aes_encrypt;
+use seismic_crypto::aes_encrypt;
 
 /* --------------------------------------------------------------------------
 Constants & Setup

--- a/crates/seismic/src/precompiles/ecdh_derive_sym_key.rs
+++ b/crates/seismic/src/precompiles/ecdh_derive_sym_key.rs
@@ -3,7 +3,7 @@ use revm::precompile::{
     u64_to_address, Precompile, PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult,
 };
 
-use seismic_enclave::{
+use seismic_crypto::{
     derive_aes_key, secp256k1::ecdh::SharedSecret, secp256k1::PublicKey, secp256k1::SecretKey,
 };
 
@@ -60,7 +60,7 @@ const DERIVE_SYM_KEY_COST: u64 = SHARED_SECRET_COST + EXPAND_FIXED_COST;
 ///
 /// Steps:
 /// 1) Compute ECDH shared secret using `pk * sk`.
-/// 2) Derive a 32-byte AES key from the shared secret via `seismic_enclave::derive_aes_key`,
+/// 2) Derive a 32-byte AES key from the shared secret via `seismic_crypto::derive_aes_key`,
 ///    which internally runs HKDF-SHA256 (see separate doc for gas breakdown).
 ///
 /// Returns the 32-byte AES key if successful, or an error otherwise.

--- a/crates/seismic/src/precompiles/rng/domain_sep_rng.rs
+++ b/crates/seismic/src/precompiles/rng/domain_sep_rng.rs
@@ -1,9 +1,9 @@
-//! Domain-separated RNG using HKDF-SHA256 with a Schnorrkel key.
+//! Domain-separated RNG using HKDF-SHA256.
 //!
 //! For each precompile call, random bytes are derived via:
 //! ```text
 //! HKDF-SHA256(
-//!   ikm  = schnorrkel_keypair.secret.to_bytes(),  // 64-byte expanded secret key
+//!   ikm  = rng_ikm,  // the node's 64-byte rng key material
 //!   salt = b"seismic rng context",
 //!   info = domain_data || b"pers" || pers
 //! ) → output bytes
@@ -13,8 +13,7 @@
 //! then derives output. There is no persistent state between calls.
 use hkdf::Hkdf;
 use revm::primitives::B256;
-pub use schnorrkel::keys::Keypair as SchnorrkelKeypair;
-use seismic_enclave::get_unsecure_sample_schnorrkel_keypair;
+use seismic_crypto::get_unsecure_sample_schnorrkel_keypair;
 use sha2::Sha256;
 
 /// RNG domain separation salt.
@@ -25,27 +24,26 @@ const RNG_SALT: &[u8] = b"seismic rng context";
 /// Constructed fresh for each precompile call. Domain separation data
 /// (tx hash, gas left) is appended before derivation.
 pub struct RootRng {
-    /// The 64-byte expanded secret key from the schnorrkel keypair.
+    /// The 64-byte HKDF input key material.
     key_bytes: [u8; 64],
     /// Accumulated domain separation info (tx hashes, gas values, etc.).
     domain_data: Vec<u8>,
 }
 
 impl RootRng {
-    /// Create a new root RNG from a schnorrkel keypair.
-    pub fn new(keypair: SchnorrkelKeypair) -> Self {
-        let key_bytes = keypair.secret.to_bytes();
+    /// Create a new root RNG from 64 bytes of HKDF input key material.
+    pub fn new(rng_ikm: [u8; 64]) -> Self {
         Self {
-            key_bytes,
+            key_bytes: rng_ikm,
             domain_data: Vec::new(),
         }
     }
 
-    /// A default RNG for testing that loads a sample keypair.
+    /// A default RNG for testing that loads a sample key.
     /// We do not implement the Default trait because
     /// it might be misleading or error-prone.
     pub fn test_default() -> Self {
-        Self::new(get_unsecure_sample_schnorrkel_keypair())
+        Self::new(get_unsecure_sample_schnorrkel_keypair().secret.to_bytes())
     }
 
     /// Append the parent block hash to the domain separation data.

--- a/crates/seismic/src/precompiles/rng/precompile.rs
+++ b/crates/seismic/src/precompiles/rng/precompile.rs
@@ -12,7 +12,7 @@ use crate::{
 Constants & Setup
 -------------------------------------------------------------------------- */
 
-// The RNG precompile derives random bytes via HKDF-SHA256 using a schnorrkel key.
+// The RNG precompile derives random bytes via HKDF-SHA256 from the node's rng key.
 // Each call is stateless: the same (key, tx_hash, gas_left, pers) always produces
 // the same output. Domain separation comes from tx_hash and gas_left appended
 // to the HKDF info parameter.
@@ -56,7 +56,7 @@ Precompile Logic
 /// We interpret the input as a `[u8]` slice of bytes used as personalization
 /// for the RNG derivation.
 ///
-/// Using HKDF-SHA256 with the schnorrkel keypair as input key material,
+/// Using HKDF-SHA256 with the node's rng key as input key material,
 /// and domain separation data (tx_hash, gas_left) plus personalization as the
 /// HKDF info parameter, we derive the requested number of random bytes.
 ///

--- a/crates/seismic/src/precompiles/rng/test.rs
+++ b/crates/seismic/src/precompiles/rng/test.rs
@@ -7,8 +7,8 @@
 
 use super::*;
 use domain_sep_rng::RootRng;
+use rand::RngCore;
 use revm::primitives::B256;
-use schnorrkel::{keys::Keypair as SchnorrkelKeypair, ExpansionMode};
 use std::str::FromStr;
 
 fn hex_to_hash_bytes(input: &str) -> B256 {
@@ -102,15 +102,13 @@ fn test_rng_gas_domain_separation() {
 
 #[test]
 fn test_rng_different_keys_different_output() {
-    let keypair1: SchnorrkelKeypair = schnorrkel::MiniSecretKey::generate()
-        .expand(ExpansionMode::Uniform)
-        .into();
-    let keypair2: SchnorrkelKeypair = schnorrkel::MiniSecretKey::generate()
-        .expand(ExpansionMode::Uniform)
-        .into();
+    let mut ikm1 = [0u8; 64];
+    rand::rng().fill_bytes(&mut ikm1);
+    let mut ikm2 = [0u8; 64];
+    rand::rng().fill_bytes(&mut ikm2);
 
-    let root_rng1 = RootRng::new(keypair1);
-    let root_rng2 = RootRng::new(keypair2);
+    let root_rng1 = RootRng::new(ikm1);
+    let root_rng2 = RootRng::new(ikm2);
 
     let bytes1 = root_rng1.derive_bytes(&[], 32);
     let bytes2 = root_rng2.derive_bytes(&[], 32);


### PR DESCRIPTION
Since the RNG precompile's HKDF refactor (#189), the keypair serves only as HKDF input key material (`secret.to_bytes()`) — no schnorrkel cryptography happens anywhere in the VM — so the API now carries the 64 bytes directly: `SeismicChain::new` / `with_live_rng_key` / `set_rng_key`, `RootRng::new`, and `seismic_with_rng_key` all take `[u8; 64]`, and the `SchnorrkelKeypair` re-export is gone. Callers pass the same bytes they previously wrapped in a keypair, so RNG-precompile outputs (consensus-visible) are unchanged. This matches the custodian IPC, which ships exactly these bytes as `RngIkmBytes`
(SeismicSystems/enclave#218), so the key material flows as the same 64 bytes end to end.

- `schnorrkel` drops out of the crate. `with_random_rng_key()` fills the ikm from `rand` — for execution contexts that run without provisioned network keys (sforge, sanvil, state tests); consensus nodes inject their network's key instead.
- `SeismicChain`'s `Debug` is redacted: `live_rng_key` seeds every RNG-precompile output.
- revme pins its test ikm as named constants (`FIXED_TEST_RNG_IKM`, all-zero): the semantics runner needs deterministic RNG output — expectation comments record exact values, and the constant is byte-identical to the old `Keypair::from_bytes(&[0; 96])` secret half, so no expectations change — and Ethereum state tests never call the RNG precompile.
- The `seismic-enclave` facade dependency is replaced by the narrow `seismic-crypto` crate behind it (AES/ECDH helpers used by the precompiles, sample keys used by tests), dropping the facade's JSON-RPC surface from revm's dependency graph. The ECDH precompile names the key types via the `seismic_crypto::secp256k1` re-export (SeismicSystems/enclave#219).