### PR TITLE
feat(seismic): add TXTYPE opcode (0xB2)

### DIFF
--- a/crates/seismic/src/instructions.rs
+++ b/crates/seismic/src/instructions.rs
@@ -2,5 +2,6 @@ pub mod confidential_storage;
 pub mod constant_time;
 pub mod instruction_provider;
 pub mod seismic_host;
+pub mod tx_info;
 #[macro_use]
 pub mod macros;

--- a/crates/seismic/src/instructions/confidential_storage.rs
+++ b/crates/seismic/src/instructions/confidential_storage.rs
@@ -470,6 +470,11 @@ mod tests {
 
         impl crate::instructions::seismic_host::SeismicHost for MockCstoreHost {
             type Db = EmptyDB;
+
+            fn tx_type(&self) -> u8 {
+                0
+            }
+
             #[allow(static_mut_refs)]
             fn ctx_error(
                 &mut self,
@@ -805,6 +810,10 @@ mod tests {
 
         impl crate::instructions::seismic_host::SeismicHost for MockStorageHost {
             type Db = EmptyDB;
+
+            fn tx_type(&self) -> u8 {
+                0
+            }
 
             #[allow(static_mut_refs)]
             fn ctx_error(

--- a/crates/seismic/src/instructions/instruction_provider.rs
+++ b/crates/seismic/src/instructions/instruction_provider.rs
@@ -167,10 +167,7 @@ mod tests {
             "CLOAD (0xB0) should be our cload handler"
         );
 
-        // Regression guard: TXTYPE (0xB2) must be an UNASSIGNED slot in the base
-        // upstream table. If a future revm bump assigns 0xB2, our override would
-        // silently shadow it (and the parity test's exclusion list would hide
-        // it). This test fails loudly in that case so the collision is caught.
+        // Guard: 0xB2 must stay unassigned upstream, else our override shadows it.
         let base_table = instruction_table::<EthInterpreter, SeismicDummyHost>();
         assert!(
             base_table[TXTYPE as usize].equal(&unknown_instruction),

--- a/crates/seismic/src/instructions/instruction_provider.rs
+++ b/crates/seismic/src/instructions/instruction_provider.rs
@@ -167,6 +167,16 @@ mod tests {
             "CLOAD (0xB0) should be our cload handler"
         );
 
+        // Regression guard: TXTYPE (0xB2) must be an UNASSIGNED slot in the base
+        // upstream table. If a future revm bump assigns 0xB2, our override would
+        // silently shadow it (and the parity test's exclusion list would hide
+        // it). This test fails loudly in that case so the collision is caught.
+        let base_table = instruction_table::<EthInterpreter, SeismicDummyHost>();
+        assert!(
+            base_table[TXTYPE as usize].equal(&unknown_instruction),
+            "0xB2 must be unassigned upstream; revm now defines it — TXTYPE would shadow the upstream opcode"
+        );
+
         // Verify SLOAD is our SLOAD
         assert!(
             table[SLOAD as usize].equal(&seismic_sload_instruction()),

--- a/crates/seismic/src/instructions/instruction_provider.rs
+++ b/crates/seismic/src/instructions/instruction_provider.rs
@@ -18,6 +18,7 @@ use crate::{
             ct_eq_instruction, ct_gt_instruction, ct_iszero_instruction, ct_lt_instruction,
             ct_sgt_instruction, ct_slt_instruction,
         },
+        tx_info::txtype_instruction,
     },
     SeismicHost,
 };
@@ -25,6 +26,8 @@ use crate::{
 /// Custom opcodes for CLOAD and CSTORE
 pub const CLOAD: u8 = 0xB0;
 pub const CSTORE: u8 = 0xB1;
+/// Pushes the EIP-2718 transaction-type byte (Seismic tx = `74`).
+pub const TXTYPE: u8 = 0xB2;
 
 /// Seismic instruction provider that adds our instruction set
 pub struct SeismicInstructions<WIRE: InterpreterTypes, HOST> {
@@ -50,6 +53,7 @@ where
         // NOTE: static_gas is 0 because gas is dynamic for these
         table[CLOAD as usize] = cload_instruction();
         table[CSTORE as usize] = cstore_instruction();
+        table[TXTYPE as usize] = txtype_instruction();
         table[SLOAD as usize] = seismic_sload_instruction();
         table[SSTORE as usize] = seismic_sstore_instruction();
 
@@ -147,6 +151,16 @@ mod tests {
             "CSTORE (0xB1) should be our cstore handler"
         );
 
+        // Verify TXTYPE is registered and is our txtype handler
+        assert!(
+            !table[TXTYPE as usize].equal(&unknown_instruction),
+            "TXTYPE (0xB2) should not be the unknown instruction"
+        );
+        assert!(
+            table[TXTYPE as usize].equal(&txtype_instruction()),
+            "TXTYPE (0xB2) should be our txtype handler"
+        );
+
         // Verify SSTORE is our SSTORE
         assert!(
             table[SSTORE as usize].equal(&seismic_sstore_instruction()),
@@ -228,6 +242,7 @@ mod tests {
         for i in 0..256 {
             if i != CLOAD as usize
                 && i != CSTORE as usize
+                && i != TXTYPE as usize
                 && i != SLOAD as usize
                 && i != SSTORE as usize
                 && i != EQ as usize

--- a/crates/seismic/src/instructions/seismic_host.rs
+++ b/crates/seismic/src/instructions/seismic_host.rs
@@ -1,6 +1,8 @@
 use revm::{
     context::{host::LoadError, journaled_state::AccountInfoLoad, ContextTr},
-    context_interface::{context::ContextError, journaled_state::AccountLoad, Database},
+    context_interface::{
+        context::ContextError, journaled_state::AccountLoad, transaction::Transaction, Database,
+    },
     database::EmptyDB,
     interpreter::{host::DummyHost, Host, SStoreResult, SelfDestructResult, StateLoad},
     primitives::{Address, Bytes, Log, StorageKey, StorageValue, B256, U256},
@@ -13,6 +15,11 @@ pub trait SeismicHost: Host {
     type Db: Database;
 
     fn ctx_error(&mut self) -> &mut Result<(), ContextError<<Self::Db as Database>::Error>>;
+
+    /// Transaction type byte (EIP-2718) of the currently executing transaction.
+    /// A Seismic (encrypted-calldata) transaction has type `74` (`0x4A`).
+    fn tx_type(&self) -> u8;
+
     fn set_ctx_error<E>(&mut self, error: E)
     where
         E: Into<ContextError<<Self::Db as Database>::Error>>,
@@ -30,11 +37,16 @@ where
     fn ctx_error(&mut self) -> &mut Result<(), ContextError<<Self::Db as Database>::Error>> {
         <Self as ContextTr>::error(self)
     }
+
+    fn tx_type(&self) -> u8 {
+        <Self as ContextTr>::tx(self).tx_type()
+    }
 }
 
 pub struct SeismicDummyHost {
     ctx_result: Result<(), ContextError<<EmptyDB as Database>::Error>>,
     dummy_host: DummyHost,
+    tx_type: u8,
 }
 
 impl Default for SeismicDummyHost {
@@ -42,6 +54,7 @@ impl Default for SeismicDummyHost {
         Self {
             ctx_result: Ok(()),
             dummy_host: DummyHost,
+            tx_type: 0,
         }
     }
 }
@@ -50,6 +63,12 @@ impl SeismicDummyHost {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Override the transaction type reported by [`SeismicHost::tx_type`].
+    pub fn with_tx_type(mut self, tx_type: u8) -> Self {
+        self.tx_type = tx_type;
+        self
+    }
 }
 
 impl SeismicHost for SeismicDummyHost {
@@ -57,6 +76,10 @@ impl SeismicHost for SeismicDummyHost {
 
     fn ctx_error(&mut self) -> &mut Result<(), ContextError<<Self::Db as Database>::Error>> {
         &mut self.ctx_result
+    }
+
+    fn tx_type(&self) -> u8 {
+        self.tx_type
     }
 }
 

--- a/crates/seismic/src/instructions/seismic_host.rs
+++ b/crates/seismic/src/instructions/seismic_host.rs
@@ -16,8 +16,7 @@ pub trait SeismicHost: Host {
 
     fn ctx_error(&mut self) -> &mut Result<(), ContextError<<Self::Db as Database>::Error>>;
 
-    /// Transaction type byte (EIP-2718) of the currently executing transaction.
-    /// A Seismic (encrypted-calldata) transaction has type `74` (`0x4A`).
+    /// EIP-2718 transaction-type byte of the current transaction (Seismic = 74).
     fn tx_type(&self) -> u8;
 
     fn set_ctx_error<E>(&mut self, error: E)

--- a/crates/seismic/src/instructions/tx_info.rs
+++ b/crates/seismic/src/instructions/tx_info.rs
@@ -1,0 +1,129 @@
+//! Instructions exposing transaction-level metadata to contract code.
+
+use crate::{check, SeismicHost};
+use revm::{
+    interpreter::{
+        gas,
+        interpreter_types::{InterpreterTypes, RuntimeFlag, StackTr},
+        push, Instruction, InstructionContext,
+    },
+    primitives::U256,
+};
+
+/// Implements the TXTYPE instruction (`0xB2`).
+///
+/// Pushes the EIP-2718 transaction-type byte of the currently executing
+/// transaction onto the stack. A Seismic (encrypted-calldata) transaction has
+/// type `74` (`0x4A`); standard transactions push their usual type (`0` legacy,
+/// `1` EIP-2930, `2` EIP-1559, ...).
+///
+/// Zero inputs, one output. Gated to the Mercury hardfork.
+pub fn txtype<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
+    context: InstructionContext<'_, H, WIRE>,
+) {
+    check!(context.interpreter, MERCURY);
+    gas!(context.interpreter, gas::BASE);
+    push!(context.interpreter, U256::from(context.host.tx_type()));
+}
+
+// NOTE: static_gas is 0 because gas is charged dynamically inside the handler,
+// matching the convention used by the other Seismic instructions.
+pub fn txtype_instruction<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>() -> Instruction<WIRE, H>
+{
+    Instruction::new(txtype, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic
+    )]
+
+    use super::*;
+    use crate::instructions::seismic_host::SeismicDummyHost;
+    use revm::interpreter::interpreter::{EthInterpreter, ExtBytecode};
+    use revm::interpreter::interpreter_types::LoopControl;
+    use revm::interpreter::{CallInput, InputsImpl, InstructionResult, Interpreter, SharedMemory};
+    use revm::primitives::hardfork::SpecId;
+    use revm::primitives::{Address, Bytes};
+    use revm::state::Bytecode;
+
+    // Seismic transaction type (0x4A). Kept local to avoid a dependency on the
+    // seismic-alloy consensus crate; the semantic `== 74` comparison lives in
+    // the std-lib helper, not in the EVM.
+    const SEISMIC_TX_TYPE_ID: u8 = 74;
+
+    fn build_interpreter(spec_id: SpecId) -> Interpreter<EthInterpreter> {
+        Interpreter::<EthInterpreter>::new(
+            SharedMemory::new(),
+            ExtBytecode::new(Bytecode::new_raw(Bytes::from(&[0x00][..]))),
+            InputsImpl {
+                target_address: Address::ZERO,
+                caller_address: Address::ZERO,
+                input: CallInput::Bytes(Bytes::default()),
+                call_value: U256::ZERO,
+                bytecode_address: None,
+            },
+            false,
+            spec_id,
+            u64::MAX,
+        )
+    }
+
+    #[test]
+    fn test_txtype_before_mercury() {
+        // SpecId < Mercury => the check should fail with NotActivated.
+        let mut host = SeismicDummyHost::new().with_tx_type(SEISMIC_TX_TYPE_ID);
+        let mut interpreter = build_interpreter(SpecId::LONDON);
+        let context = InstructionContext {
+            interpreter: &mut interpreter,
+            host: &mut host,
+        };
+
+        txtype(context);
+
+        assert_eq!(
+            interpreter.bytecode.instruction_result(),
+            Some(InstructionResult::NotActivated)
+        );
+    }
+
+    #[test]
+    fn test_txtype_pushes_seismic_tx_type() {
+        let mut host = SeismicDummyHost::new().with_tx_type(SEISMIC_TX_TYPE_ID);
+        let mut interpreter = build_interpreter(SpecId::MERCURY);
+        let context = InstructionContext {
+            interpreter: &mut interpreter,
+            host: &mut host,
+        };
+
+        txtype(context);
+
+        assert_ne!(
+            interpreter.bytecode.instruction_result(),
+            Some(InstructionResult::NotActivated)
+        );
+        assert_eq!(
+            interpreter.stack.pop().unwrap(),
+            U256::from(SEISMIC_TX_TYPE_ID)
+        );
+    }
+
+    #[test]
+    fn test_txtype_pushes_standard_tx_type() {
+        // A standard (EIP-1559) transaction reports its own type byte.
+        let mut host = SeismicDummyHost::new().with_tx_type(2);
+        let mut interpreter = build_interpreter(SpecId::MERCURY);
+        let context = InstructionContext {
+            interpreter: &mut interpreter,
+            host: &mut host,
+        };
+
+        txtype(context);
+
+        assert_eq!(interpreter.stack.pop().unwrap(), U256::from(2));
+    }
+}

--- a/crates/seismic/src/instructions/tx_info.rs
+++ b/crates/seismic/src/instructions/tx_info.rs
@@ -127,3 +127,81 @@ mod tests {
         assert_eq!(interpreter.stack.pop().unwrap(), U256::from(2));
     }
 }
+
+/// End-to-end tests that run TXTYPE through the full Seismic EVM, exercising the
+/// production `SeismicHost::tx_type` blanket impl (`ctx.tx().tx_type()`) — the
+/// path the unit tests above do not cover, since they use a mock host.
+#[cfg(test)]
+mod e2e_tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::panic
+    )]
+
+    use crate::{DefaultSeismicContext, SeismicBuilder};
+    use revm::{
+        bytecode::opcode,
+        database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET},
+        primitives::{TxKind, U256},
+        state::Bytecode,
+        Context, ExecuteEvm,
+    };
+
+    use super::super::instruction_provider::TXTYPE;
+
+    /// Deploys a contract that returns the current transaction type, runs a
+    /// transaction of the given `tx_type` against it, and returns the value the
+    /// contract observed via the TXTYPE opcode.
+    fn observed_tx_type(tx_type: u8) -> U256 {
+        // TXTYPE; PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN
+        // -> stores the tx-type byte at mem[0..32] and returns it.
+        let code = [
+            TXTYPE,
+            opcode::PUSH1,
+            0x00,
+            opcode::MSTORE,
+            opcode::PUSH1,
+            0x20,
+            opcode::PUSH1,
+            0x00,
+            opcode::RETURN,
+        ];
+
+        // seismic_with_random_rng_key() defaults the spec to Mercury, so TXTYPE
+        // is activated.
+        let ctx = Context::seismic_with_random_rng_key()
+            .modify_tx_chained(|tx| {
+                tx.base.tx_type = tx_type;
+                tx.base.kind = TxKind::Call(BENCH_TARGET);
+                tx.base.caller = BENCH_CALLER;
+                tx.base.gas_limit = 100_000;
+            })
+            .with_db(BenchmarkDB::new_bytecode(Bytecode::new_legacy(
+                code.to_vec().into(),
+            )));
+
+        let mut evm = ctx.build_seismic_evm();
+        let out = evm.replay().unwrap();
+        assert!(
+            out.result.is_success(),
+            "execution should succeed: {:#?}",
+            out.result
+        );
+        U256::from_be_slice(out.result.into_output().unwrap().as_ref())
+    }
+
+    #[test]
+    fn txtype_reports_seismic_type_end_to_end() {
+        // Seismic (encrypted-calldata) transaction: type 74 (0x4A).
+        assert_eq!(observed_tx_type(74), U256::from(74));
+    }
+
+    #[test]
+    fn txtype_reports_standard_types_end_to_end() {
+        // Standard transaction types flow through unchanged.
+        assert_eq!(observed_tx_type(0), U256::from(0)); // legacy
+        assert_eq!(observed_tx_type(2), U256::from(2)); // EIP-1559
+    }
+}

--- a/crates/seismic/src/instructions/tx_info.rs
+++ b/crates/seismic/src/instructions/tx_info.rs
@@ -57,6 +57,10 @@ mod tests {
     const SEISMIC_TX_TYPE_ID: u8 = 74;
 
     fn build_interpreter(spec_id: SpecId) -> Interpreter<EthInterpreter> {
+        build_interpreter_with_gas(spec_id, u64::MAX)
+    }
+
+    fn build_interpreter_with_gas(spec_id: SpecId, gas_limit: u64) -> Interpreter<EthInterpreter> {
         Interpreter::<EthInterpreter>::new(
             SharedMemory::new(),
             ExtBytecode::new(Bytecode::new_raw(Bytes::from(&[0x00][..]))),
@@ -69,7 +73,7 @@ mod tests {
             },
             false,
             spec_id,
-            u64::MAX,
+            gas_limit,
         )
     }
 
@@ -126,6 +130,108 @@ mod tests {
 
         assert_eq!(interpreter.stack.pop().unwrap(), U256::from(2));
     }
+
+    #[test]
+    fn test_txtype_is_faithful_byte_mover() {
+        // TXTYPE pushes whatever byte the tx reports, with no clamping or
+        // validation — every value in [0, 255], including unknown types.
+        for ty in [0u8, 1, 2, 3, 4, 42, 74, 0xFF] {
+            let mut host = SeismicDummyHost::new().with_tx_type(ty);
+            let mut interpreter = build_interpreter(SpecId::MERCURY);
+            let context = InstructionContext {
+                interpreter: &mut interpreter,
+                host: &mut host,
+            };
+
+            txtype(context);
+
+            assert_eq!(
+                interpreter.stack.pop().unwrap(),
+                U256::from(ty),
+                "type {ty}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_txtype_charges_exactly_base_gas() {
+        let mut host = SeismicDummyHost::new().with_tx_type(SEISMIC_TX_TYPE_ID);
+        let mut interpreter = build_interpreter(SpecId::MERCURY);
+        let context = InstructionContext {
+            interpreter: &mut interpreter,
+            host: &mut host,
+        };
+
+        txtype(context);
+
+        // TXTYPE is priced at gas::BASE (2), matching CHAINID and other
+        // tx/context reads. Charged exactly once.
+        assert_eq!(interpreter.gas.spent(), 2);
+    }
+
+    #[test]
+    fn test_txtype_succeeds_at_exact_gas() {
+        // Exactly BASE (2) gas is enough.
+        let mut host = SeismicDummyHost::new().with_tx_type(SEISMIC_TX_TYPE_ID);
+        let mut interpreter = build_interpreter_with_gas(SpecId::MERCURY, 2);
+        let context = InstructionContext {
+            interpreter: &mut interpreter,
+            host: &mut host,
+        };
+
+        txtype(context);
+
+        assert_ne!(
+            interpreter.bytecode.instruction_result(),
+            Some(InstructionResult::OutOfGas)
+        );
+        assert_eq!(
+            interpreter.stack.pop().unwrap(),
+            U256::from(SEISMIC_TX_TYPE_ID)
+        );
+    }
+
+    #[test]
+    fn test_txtype_out_of_gas() {
+        // One gas short of BASE => OutOfGas, and nothing is pushed.
+        let mut host = SeismicDummyHost::new().with_tx_type(SEISMIC_TX_TYPE_ID);
+        let mut interpreter = build_interpreter_with_gas(SpecId::MERCURY, 1);
+        let context = InstructionContext {
+            interpreter: &mut interpreter,
+            host: &mut host,
+        };
+
+        txtype(context);
+
+        assert_eq!(
+            interpreter.bytecode.instruction_result(),
+            Some(InstructionResult::OutOfGas)
+        );
+        assert_eq!(interpreter.stack.len(), 0);
+    }
+
+    #[test]
+    fn test_txtype_stack_overflow() {
+        // With a full (1024) stack, TXTYPE must halt with StackOverflow rather
+        // than panic, and must not grow the stack.
+        let mut host = SeismicDummyHost::new().with_tx_type(SEISMIC_TX_TYPE_ID);
+        let mut interpreter = build_interpreter(SpecId::MERCURY);
+        for _ in 0..1024 {
+            assert!(interpreter.stack.push(U256::ZERO));
+        }
+        let context = InstructionContext {
+            interpreter: &mut interpreter,
+            host: &mut host,
+        };
+
+        txtype(context);
+
+        assert_eq!(
+            interpreter.bytecode.instruction_result(),
+            Some(InstructionResult::StackOverflow)
+        );
+        assert_eq!(interpreter.stack.len(), 1024);
+    }
 }
 
 /// End-to-end tests that run TXTYPE through the full Seismic EVM, exercising the
@@ -143,13 +249,27 @@ mod e2e_tests {
     use crate::{DefaultSeismicContext, SeismicBuilder};
     use revm::{
         bytecode::opcode,
-        database::{BenchmarkDB, BENCH_CALLER, BENCH_TARGET},
-        primitives::{TxKind, U256},
-        state::Bytecode,
+        database::{BenchmarkDB, InMemoryDB, BENCH_CALLER, BENCH_TARGET},
+        primitives::{address, Address, TxKind, U256},
+        state::{AccountInfo, Bytecode},
         Context, ExecuteEvm,
     };
 
     use super::super::instruction_provider::TXTYPE;
+
+    // Callee runtime code: TXTYPE; PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN
+    // -> returns the observed tx-type byte as 32 bytes.
+    const CALLEE_CODE: [u8; 9] = [
+        TXTYPE,
+        opcode::PUSH1,
+        0x00,
+        opcode::MSTORE,
+        opcode::PUSH1,
+        0x20,
+        opcode::PUSH1,
+        0x00,
+        opcode::RETURN,
+    ];
 
     /// Deploys a contract that returns the current transaction type, runs a
     /// transaction of the given `tx_type` against it, and returns the value the
@@ -200,8 +320,111 @@ mod e2e_tests {
 
     #[test]
     fn txtype_reports_standard_types_end_to_end() {
-        // Standard transaction types flow through unchanged.
-        assert_eq!(observed_tx_type(0), U256::from(0)); // legacy
-        assert_eq!(observed_tx_type(2), U256::from(2)); // EIP-1559
+        // Standard types that validate cleanly with a bare tx env flow through
+        // unchanged. (Types 3/4 need blob/auth-list fields to pass tx
+        // validation, which is unrelated to TXTYPE; the byte-mover property for
+        // arbitrary values is covered by the unit test above.)
+        for ty in [0u8, 1, 2] {
+            assert_eq!(observed_tx_type(ty), U256::from(ty), "tx_type {ty}");
+        }
+    }
+
+    /// Runs a transaction of type `tx_type` where the entrypoint contract reaches
+    /// TXTYPE through a nested frame built from `caller_code`, and returns the
+    /// type observed inside that nested frame.
+    fn observed_tx_type_nested(caller_code: Vec<u8>, tx_type: u8) -> U256 {
+        let callee = address!("00000000000000000000000000000000000000cc");
+        let caller = address!("00000000000000000000000000000000000000ca");
+        let sender = BENCH_CALLER;
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            callee,
+            AccountInfo {
+                code: Some(Bytecode::new_legacy(CALLEE_CODE.to_vec().into())),
+                ..Default::default()
+            },
+        );
+        db.insert_account_info(
+            caller,
+            AccountInfo {
+                code: Some(Bytecode::new_legacy(caller_code.into())),
+                ..Default::default()
+            },
+        );
+        db.insert_account_info(
+            sender,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000u64),
+                ..Default::default()
+            },
+        );
+
+        let ctx = Context::seismic_with_random_rng_key()
+            .modify_tx_chained(|tx| {
+                tx.base.tx_type = tx_type;
+                tx.base.kind = TxKind::Call(caller);
+                tx.base.caller = sender;
+                tx.base.gas_limit = 1_000_000;
+                tx.base.gas_price = 0;
+            })
+            .with_db(db);
+
+        let mut evm = ctx.build_seismic_evm();
+        let out = evm.replay().unwrap();
+        assert!(
+            out.result.is_success(),
+            "nested execution should succeed: {:#?}",
+            out.result
+        );
+        U256::from_be_slice(out.result.into_output().unwrap().as_ref())
+    }
+
+    // Builds caller code that forwards to `callee` via `call_op` (CALL or
+    // DELEGATECALL) and returns the 32-byte result. CALL takes a value arg,
+    // DELEGATECALL does not, so the value push is included only for CALL.
+    fn nested_caller_code(callee: Address, call_op: u8) -> Vec<u8> {
+        let mut code = vec![
+            opcode::PUSH1,
+            0x20, // retSize
+            opcode::PUSH1,
+            0x00, // retOffset
+            opcode::PUSH1,
+            0x00, // argsSize
+            opcode::PUSH1,
+            0x00, // argsOffset
+        ];
+        if call_op == opcode::CALL {
+            code.extend_from_slice(&[opcode::PUSH1, 0x00]); // value
+        }
+        code.push(opcode::PUSH20);
+        code.extend_from_slice(callee.as_slice()); // 20-byte address
+        code.extend_from_slice(&[
+            opcode::GAS,
+            call_op,
+            opcode::POP, // discard success flag
+            opcode::PUSH1,
+            0x20,
+            opcode::PUSH1,
+            0x00,
+            opcode::RETURN,
+        ]);
+        code
+    }
+
+    #[test]
+    fn txtype_is_tx_level_through_call() {
+        // A callee reached via CALL still observes the outer transaction's type,
+        // not a frame-local value.
+        let callee = address!("00000000000000000000000000000000000000cc");
+        let code = nested_caller_code(callee, opcode::CALL);
+        assert_eq!(observed_tx_type_nested(code, 74), U256::from(74));
+    }
+
+    #[test]
+    fn txtype_is_tx_level_through_delegatecall() {
+        let callee = address!("00000000000000000000000000000000000000cc");
+        let code = nested_caller_code(callee, opcode::DELEGATECALL);
+        assert_eq!(observed_tx_type_nested(code, 74), U256::from(74));
     }
 }

--- a/crates/seismic/src/instructions/tx_info.rs
+++ b/crates/seismic/src/instructions/tx_info.rs
@@ -10,14 +10,7 @@ use revm::{
     primitives::U256,
 };
 
-/// Implements the TXTYPE instruction (`0xB2`).
-///
-/// Pushes the EIP-2718 transaction-type byte of the currently executing
-/// transaction onto the stack. A Seismic (encrypted-calldata) transaction has
-/// type `74` (`0x4A`); standard transactions push their usual type (`0` legacy,
-/// `1` EIP-2930, `2` EIP-1559, ...).
-///
-/// Zero inputs, one output. Gated to the Mercury hardfork.
+/// TXTYPE (`0xB2`): pushes the EIP-2718 transaction-type byte. Mercury-gated.
 pub fn txtype<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
     context: InstructionContext<'_, H, WIRE>,
 ) {
@@ -26,8 +19,6 @@ pub fn txtype<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>(
     push!(context.interpreter, U256::from(context.host.tx_type()));
 }
 
-// NOTE: static_gas is 0 because gas is charged dynamically inside the handler,
-// matching the convention used by the other Seismic instructions.
 pub fn txtype_instruction<WIRE: InterpreterTypes, H: SeismicHost + ?Sized>() -> Instruction<WIRE, H>
 {
     Instruction::new(txtype, 0)
@@ -51,9 +42,6 @@ mod tests {
     use revm::primitives::{Address, Bytes};
     use revm::state::Bytecode;
 
-    // Seismic transaction type (0x4A). Kept local to avoid a dependency on the
-    // seismic-alloy consensus crate; the semantic `== 74` comparison lives in
-    // the std-lib helper, not in the EVM.
     const SEISMIC_TX_TYPE_ID: u8 = 74;
 
     fn build_interpreter(spec_id: SpecId) -> Interpreter<EthInterpreter> {
@@ -79,7 +67,6 @@ mod tests {
 
     #[test]
     fn test_txtype_before_mercury() {
-        // SpecId < Mercury => the check should fail with NotActivated.
         let mut host = SeismicDummyHost::new().with_tx_type(SEISMIC_TX_TYPE_ID);
         let mut interpreter = build_interpreter(SpecId::LONDON);
         let context = InstructionContext {
@@ -118,7 +105,6 @@ mod tests {
 
     #[test]
     fn test_txtype_pushes_standard_tx_type() {
-        // A standard (EIP-1559) transaction reports its own type byte.
         let mut host = SeismicDummyHost::new().with_tx_type(2);
         let mut interpreter = build_interpreter(SpecId::MERCURY);
         let context = InstructionContext {
@@ -133,8 +119,6 @@ mod tests {
 
     #[test]
     fn test_txtype_is_faithful_byte_mover() {
-        // TXTYPE pushes whatever byte the tx reports, with no clamping or
-        // validation — every value in [0, 255], including unknown types.
         for ty in [0u8, 1, 2, 3, 4, 42, 74, 0xFF] {
             let mut host = SeismicDummyHost::new().with_tx_type(ty);
             let mut interpreter = build_interpreter(SpecId::MERCURY);
@@ -164,14 +148,11 @@ mod tests {
 
         txtype(context);
 
-        // TXTYPE is priced at gas::BASE (2), matching CHAINID and other
-        // tx/context reads. Charged exactly once.
         assert_eq!(interpreter.gas.spent(), 2);
     }
 
     #[test]
     fn test_txtype_succeeds_at_exact_gas() {
-        // Exactly BASE (2) gas is enough.
         let mut host = SeismicDummyHost::new().with_tx_type(SEISMIC_TX_TYPE_ID);
         let mut interpreter = build_interpreter_with_gas(SpecId::MERCURY, 2);
         let context = InstructionContext {
@@ -193,7 +174,6 @@ mod tests {
 
     #[test]
     fn test_txtype_out_of_gas() {
-        // One gas short of BASE => OutOfGas, and nothing is pushed.
         let mut host = SeismicDummyHost::new().with_tx_type(SEISMIC_TX_TYPE_ID);
         let mut interpreter = build_interpreter_with_gas(SpecId::MERCURY, 1);
         let context = InstructionContext {
@@ -212,8 +192,6 @@ mod tests {
 
     #[test]
     fn test_txtype_stack_overflow() {
-        // With a full (1024) stack, TXTYPE must halt with StackOverflow rather
-        // than panic, and must not grow the stack.
         let mut host = SeismicDummyHost::new().with_tx_type(SEISMIC_TX_TYPE_ID);
         let mut interpreter = build_interpreter(SpecId::MERCURY);
         for _ in 0..1024 {
@@ -234,9 +212,7 @@ mod tests {
     }
 }
 
-/// End-to-end tests that run TXTYPE through the full Seismic EVM, exercising the
-/// production `SeismicHost::tx_type` blanket impl (`ctx.tx().tx_type()`) — the
-/// path the unit tests above do not cover, since they use a mock host.
+/// End-to-end tests exercising the production `ctx.tx().tx_type()` path.
 #[cfg(test)]
 mod e2e_tests {
     #![allow(
@@ -257,8 +233,7 @@ mod e2e_tests {
 
     use super::super::instruction_provider::TXTYPE;
 
-    // Callee runtime code: TXTYPE; PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN
-    // -> returns the observed tx-type byte as 32 bytes.
+    // TXTYPE; PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN
     const CALLEE_CODE: [u8; 9] = [
         TXTYPE,
         opcode::PUSH1,
@@ -271,12 +246,8 @@ mod e2e_tests {
         opcode::RETURN,
     ];
 
-    /// Deploys a contract that returns the current transaction type, runs a
-    /// transaction of the given `tx_type` against it, and returns the value the
-    /// contract observed via the TXTYPE opcode.
     fn observed_tx_type(tx_type: u8) -> U256 {
         // TXTYPE; PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN
-        // -> stores the tx-type byte at mem[0..32] and returns it.
         let code = [
             TXTYPE,
             opcode::PUSH1,
@@ -289,8 +260,6 @@ mod e2e_tests {
             opcode::RETURN,
         ];
 
-        // seismic_with_random_rng_key() defaults the spec to Mercury, so TXTYPE
-        // is activated.
         let ctx = Context::seismic_with_random_rng_key()
             .modify_tx_chained(|tx| {
                 tx.base.tx_type = tx_type;
@@ -314,24 +283,18 @@ mod e2e_tests {
 
     #[test]
     fn txtype_reports_seismic_type_end_to_end() {
-        // Seismic (encrypted-calldata) transaction: type 74 (0x4A).
         assert_eq!(observed_tx_type(74), U256::from(74));
     }
 
     #[test]
     fn txtype_reports_standard_types_end_to_end() {
-        // Standard types that validate cleanly with a bare tx env flow through
-        // unchanged. (Types 3/4 need blob/auth-list fields to pass tx
-        // validation, which is unrelated to TXTYPE; the byte-mover property for
-        // arbitrary values is covered by the unit test above.)
+        // Types 3/4 need blob/auth-list fields to pass tx validation; byte-mover
+        // coverage for arbitrary values is in the unit test above.
         for ty in [0u8, 1, 2] {
             assert_eq!(observed_tx_type(ty), U256::from(ty), "tx_type {ty}");
         }
     }
 
-    /// Runs a transaction of type `tx_type` where the entrypoint contract reaches
-    /// TXTYPE through a nested frame built from `caller_code`, and returns the
-    /// type observed inside that nested frame.
     fn observed_tx_type_nested(caller_code: Vec<u8>, tx_type: u8) -> U256 {
         let callee = address!("00000000000000000000000000000000000000cc");
         let caller = address!("00000000000000000000000000000000000000ca");
@@ -380,9 +343,7 @@ mod e2e_tests {
         U256::from_be_slice(out.result.into_output().unwrap().as_ref())
     }
 
-    // Builds caller code that forwards to `callee` via `call_op` (CALL or
-    // DELEGATECALL) and returns the 32-byte result. CALL takes a value arg,
-    // DELEGATECALL does not, so the value push is included only for CALL.
+    // CALL/DELEGATECALL to `callee`, returning its 32-byte result (CALL has a value arg).
     fn nested_caller_code(callee: Address, call_op: u8) -> Vec<u8> {
         let mut code = vec![
             opcode::PUSH1,
@@ -414,8 +375,6 @@ mod e2e_tests {
 
     #[test]
     fn txtype_is_tx_level_through_call() {
-        // A callee reached via CALL still observes the outer transaction's type,
-        // not a frame-local value.
         let callee = address!("00000000000000000000000000000000000000cc");
         let code = nested_caller_code(callee, opcode::CALL);
         assert_eq!(observed_tx_type_nested(code, 74), U256::from(74));


### PR DESCRIPTION
## Summary

Adds a new EVM opcode `TXTYPE` (`0xB2`) that pushes the EIP-2718 transaction-type byte of the currently executing transaction onto the stack. A Seismic (encrypted-calldata) transaction reports `74` (`0x4A`); standard transactions report their usual type (`0` legacy, `1` EIP-2930, `2` EIP-1559, ...).

This lets contract code determine whether it is running inside a Seismic transaction. The `== 74` comparison is intentionally left to a std-lib helper on the Solidity side — revm stays a faithful byte-mover and bakes in no semantics.

- Zero inputs, one output; gated to the Mercury hardfork; costs `gas::BASE` (2), same as `CHAINID`.
- Reads `ctx.tx().tx_type()`, so it is transaction-level: nested `CALL`/`DELEGATECALL`/`STATICCALL`/`CREATE` frames all observe the outer transaction's type (like `ORIGIN`).

Design note: exposing the type byte deliberately pierces the EIP-2718 "keep the type opaque to contracts" preference, which the EIP itself sanctions via "if a transaction type needs to supply additional information to contracts, they will need a new opcode." We expose the byte; the boolean "is seismic" convenience lives in the std lib.

## Changes

- `instructions/tx_info.rs` (new) — `txtype` handler + factory.
- `instructions/seismic_host.rs` — `tx_type()` added to the `SeismicHost` trait, blanket impl (`ctx.tx().tx_type()`), and `SeismicDummyHost`.
- `instructions/instruction_provider.rs` — `TXTYPE = 0xB2` const + table registration.
- `instructions.rs` — module registration.

## BREAKING CHANGE

`SeismicHost` gained a required method `fn tx_type(&self) -> u8`. Any downstream custom `Host` implementation of `SeismicHost` must add it.

## Testing

`cargo test -p seismic-revm` (112 pass), full workspace green, `cargo fmt --all --check` and CI strict clippy clean.

Coverage:
- Unit: Mercury gate (pre-Mercury -> `NotActivated`), value push for seismic/standard types, faithful byte-mover across all values incl. unknown types, exact `BASE` gas, gas boundary (2 ok / 1 `OutOfGas`), stack overflow (`StackOverflow`, no panic).
- End-to-end through the full Seismic EVM (exercises the production `ctx.tx().tx_type()` path): seismic (74) and standard (0/1/2) types; nested `CALL` and `DELEGATECALL` confirming the tx-level semantic through real child frames.
- Regression guard asserting `0xB2` stays unassigned upstream, so a future revm bump that defines it fails loudly instead of silently shadowing.

Two independent adversarial reviews (gas, tx-type source across frame types, opcode collision, stack/overflow, spec gating, information leakage, conversion) found no consensus bug, panic, leak, or vulnerability.

## Out of scope / follow-ups

- The `seismic-solidity` compiler side (`txtype()` Yul builtin + std-lib `isSeismicTx()` helper) is a separate change.
- The `TxSeismic -> tx_type = 74` conversion (and standard-tx never mapping to 74) lives in `seismic-evm`/`seismic-reth` and should be asserted there — that boundary is where "is it really an encrypted tx" is established. revm faithfully surfaces whatever the tx carries.
- Consistent with CLOAD/CSTORE, `0xB2` is not added to the shared `bytecode/opcode.rs` metadata, so `OpCode::new(0xB2)` / EIP-3155 traces treat it as unknown. This does not affect execution.
