### PR TITLE
chore(deps): bump seismic-crypto to 26fdf9f (AesKeyDomain)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "seismic-crypto"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=8274f14cbbad76daadad3aaa1d6d0418b3eeffc0#8274f14cbbad76daadad3aaa1d6d0418b3eeffc0"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=26fdf9f2823459c05b0d70b6c528e12ae32f7e11#26fdf9f2823459c05b0d70b6c528e12ae32f7e11"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "seismic-crypto"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=26fdf9f2823459c05b0d70b6c528e12ae32f7e11#26fdf9f2823459c05b0d70b6c528e12ae32f7e11"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=e3df924cd4ce95d54c52bb9b15a7c8f81327a20f#e3df924cd4ce95d54c52bb9b15a7c8f81327a20f"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,5 +179,5 @@ inherits = "test"
 opt-level = 3
 
 [patch.crates-io]
-seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "8274f14cbbad76daadad3aaa1d6d0418b3eeffc0" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "26fdf9f2823459c05b0d70b6c528e12ae32f7e11" }
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,5 +179,5 @@ inherits = "test"
 opt-level = 3
 
 [patch.crates-io]
-seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "ffdc58acf2036a0bf773e05bf4c4bc5f938e5fa3" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "e3df924cd4ce95d54c52bb9b15a7c8f81327a20f" }
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,5 +179,5 @@ inherits = "test"
 opt-level = 3
 
 [patch.crates-io]
-seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "26fdf9f2823459c05b0d70b6c528e12ae32f7e11" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "ffdc58acf2036a0bf773e05bf4c4bc5f938e5fa3" }
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }

--- a/crates/seismic/src/precompiles/ecdh_derive_sym_key.rs
+++ b/crates/seismic/src/precompiles/ecdh_derive_sym_key.rs
@@ -5,6 +5,7 @@ use revm::precompile::{
 
 use seismic_crypto::{
     derive_aes_key, secp256k1::ecdh::SharedSecret, secp256k1::PublicKey, secp256k1::SecretKey,
+    AesKeyDomain,
 };
 
 /// Address of ECDH precompile.
@@ -62,6 +63,8 @@ const DERIVE_SYM_KEY_COST: u64 = SHARED_SECRET_COST + EXPAND_FIXED_COST;
 /// 1) Compute ECDH shared secret using `pk * sk`.
 /// 2) Derive a 32-byte AES key from the shared secret via `seismic_crypto::derive_aes_key`,
 ///    which internally runs HKDF-SHA256 (see separate doc for gas breakdown).
+///    That domain's HKDF label is consensus-frozen: contracts observe this
+///    output, so changing it would be a hard fork.
 ///
 /// Returns the 32-byte AES key if successful, or an error otherwise.
 ///
@@ -96,10 +99,10 @@ pub fn derive_symmetric_key(input: &[u8], gas_limit: u64) -> PrecompileResult {
 
     let shared_secret = SharedSecret::new(&public_key, &secret_key);
 
-    let aes_key = derive_aes_key(&shared_secret)
+    let aes_key = derive_aes_key(&shared_secret, AesKeyDomain::EcdhPrecompile)
         .map_err(|e| PrecompileError::Other(format!("aes derivation failed: {e}")))?;
 
-    // SAFETY: derive_aes_key always returns 32-byte AES-256 key
+    // SAFETY: derive_aes_key always returns a 32-byte AES-256 key
     #[allow(clippy::expect_used)]
     let output_32: [u8; 32] = aes_key.to_vec().try_into().expect("must be 32 bytes");
 


### PR DESCRIPTION
seismic-crypto's derive_aes_key now takes an AesKeyDomain; pass AesKeyDomain::EcdhPrecompile in the ECDH precompile. The precompile keeps the original "aes-gcm key" label (consensus-frozen — contracts observe its output), so its behaviour is unchanged.