### PR TITLE
fix(seismic): stop discarding precompiles injected into SeismicPrecompiles

### DIFF
--- a/crates/seismic/src/precompiles.rs
+++ b/crates/seismic/src/precompiles.rs
@@ -35,12 +35,22 @@ use revm::{
     primitives::{Address, Bytes},
 };
 use std::string::String;
-use std::{boxed::Box, sync::OnceLock};
+use std::{
+    boxed::Box,
+    collections::HashMap,
+    sync::{Mutex, OnceLock},
+};
 
 #[derive(Debug, Clone)]
 pub struct SeismicPrecompiles<CTX: SeismicContextTr> {
     pub(crate) inner: EthPrecompiles,
     stateful_precompiles: StatefulPrecompiles<CTX>,
+    /// Spec the current precompile set was built for.
+    ///
+    /// Tracked so [`PrecompileProvider::set_spec`] can skip rebuilding when the spec is
+    /// unchanged. Rebuilding discards anything added via
+    /// [`SeismicPrecompiles::apply_precompile`].
+    spec: SeismicSpecId,
 }
 
 impl<CTX: SeismicContextTr> SeismicPrecompiles<CTX> {
@@ -52,6 +62,7 @@ impl<CTX: SeismicContextTr> SeismicPrecompiles<CTX> {
                 spec: <CTX::Cfg as Cfg>::Spec::MERCURY.into(),
             },
             stateful_precompiles: precompiles.1,
+            spec: SeismicSpecId::MERCURY,
         }
     }
 
@@ -63,15 +74,15 @@ impl<CTX: SeismicContextTr> SeismicPrecompiles<CTX> {
         }
     }
 
+    /// Extends the active precompile set with `p`.
+    ///
+    /// The merged set is leaked to satisfy the `&'static` bound [`EthPrecompiles`] requires,
+    /// so this is a setup-time API: call it while building an EVM, not per transaction.
     pub fn apply_precompile(&mut self, p: Precompile) {
-        static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
-        let precompiles = INSTANCE.get_or_init(|| {
-            let mut precompiles = self.inner.precompiles.clone();
-            precompiles.extend([p]);
-            precompiles
-        });
+        let mut precompiles = self.inner.precompiles.clone();
+        precompiles.extend([p]);
         self.inner = EthPrecompiles {
-            precompiles,
+            precompiles: Box::leak(Box::new(precompiles)),
             spec: <CTX::Cfg as Cfg>::Spec::MERCURY.into(),
         };
     }
@@ -81,29 +92,63 @@ impl<CTX: SeismicContextTr> SeismicPrecompiles<CTX> {
 pub fn mercury_with_extra<CTX: SeismicContextTr>(
     extra: Option<&'static Precompiles>,
 ) -> (&'static Precompiles, StatefulPrecompiles<CTX>) {
-    // Store only the stateless precompiles in the static OnceBox
-    static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
-
-    let regular_precompiles = INSTANCE.get_or_init(|| {
-        let mut precompiles = Precompiles::prague().clone();
-        if let Some(extra) = extra {
-            precompiles.extend(extra.inner().clone().into_values());
+    let regular_precompiles = match extra {
+        // No runtime input, so a single process-wide set is correct. This is the path
+        // `mercury` takes, which `set_spec` reaches on every transaction.
+        None => {
+            // Store only the stateless precompiles in the static OnceBox
+            static INSTANCE: OnceBox<Precompiles> = OnceBox::new();
+            INSTANCE.get_or_init(|| Box::new(build_mercury_precompiles(None)))
         }
-        precompiles.extend([
-            secp256r1::P256VERIFY,
-            ecdh_derive_sym_key::ECDH,
-            hkdf_derive_sym_key::HKDF,
-            aes::aes_gcm_enc::AES_GCM_ENC,
-            aes::aes_gcm_dec::AES_GCM_DEC,
-            secp256k1_sign::SECP256K1_SIGN,
-        ]);
-        Box::new(precompiles)
-    });
+        // `extra` is a runtime argument, so it cannot share one cached set: the first
+        // caller's extras would be served to every later caller, and every later caller's
+        // own extras would be silently dropped. Memoize per distinct `extra` instead.
+        Some(extra) => build_mercury_precompiles_with_extra(extra),
+    };
 
     //TODO: check how expensive is the below instead of a single init! issue with generics
     let mut stateful_precompiles = StatefulPrecompiles::new();
     stateful_precompiles.extend(rng::precompile::rng_precompile_iter::<CTX>().map(|p| (p.0, p.1)));
     (regular_precompiles, stateful_precompiles)
+}
+
+/// Builds the MERCURY precompile set, optionally extended with `extra`.
+fn build_mercury_precompiles(extra: Option<&'static Precompiles>) -> Precompiles {
+    let mut precompiles = Precompiles::prague().clone();
+    if let Some(extra) = extra {
+        precompiles.extend(extra.inner().clone().into_values());
+    }
+    precompiles.extend([
+        secp256r1::P256VERIFY,
+        ecdh_derive_sym_key::ECDH,
+        hkdf_derive_sym_key::HKDF,
+        aes::aes_gcm_enc::AES_GCM_ENC,
+        aes::aes_gcm_dec::AES_GCM_DEC,
+        secp256k1_sign::SECP256K1_SIGN,
+    ]);
+    precompiles
+}
+
+/// Returns the MERCURY precompile set extended with `extra`, memoized per distinct `extra`.
+///
+/// Keyed by the address of `extra`, so repeated calls with the same set reuse one allocation
+/// instead of leaking a new one each time.
+fn build_mercury_precompiles_with_extra(extra: &'static Precompiles) -> &'static Precompiles {
+    static CACHE: OnceLock<Mutex<HashMap<usize, &'static Precompiles>>> = OnceLock::new();
+
+    let mut cache = CACHE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let key = core::ptr::from_ref(extra) as usize;
+    if let Some(cached) = cache.get(&key).copied() {
+        return cached;
+    }
+
+    let built: &'static Precompiles = Box::leak(Box::new(build_mercury_precompiles(Some(extra))));
+    cache.insert(key, built);
+    built
 }
 
 /// Returns precompiles for MERCURY spec.
@@ -120,6 +165,12 @@ where
 
     #[inline]
     fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) -> bool {
+        // Only rebuild on an actual spec change. `set_spec` runs before every transaction,
+        // and rebuilding discards precompiles installed via `apply_precompile`.
+        // Mirrors `EthPrecompiles::set_spec`.
+        if spec == self.spec {
+            return false;
+        }
         *self = Self::new_with_spec(spec);
         true
     }

--- a/crates/seismic/tests/mercury_extra_after_plain.rs
+++ b/crates/seismic/tests/mercury_extra_after_plain.rs
@@ -1,0 +1,79 @@
+//! Extras must be honored even when the plain precompile set was built first.
+//!
+//! This is the opposite ordering to `mercury_extra_isolation.rs`, and because the cache under
+//! test is process-wide it needs its own test binary: a plain `mercury()` runs *before*
+//! `mercury_with_extra(Some(..))`.
+
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+use revm::{
+    database::EmptyDB,
+    precompile::{
+        u64_to_address, Precompile, PrecompileId, PrecompileOutput, PrecompileResult, Precompiles,
+    },
+    primitives::Bytes,
+};
+use seismic_revm::{
+    precompiles::{mercury, mercury_with_extra},
+    SeismicContext,
+};
+use std::{borrow::Cow, sync::OnceLock};
+
+type Ctx = SeismicContext<EmptyDB>;
+
+const CUSTOM_ADDRESS: u64 = 0x5201;
+
+fn echo(input: &[u8], _gas_limit: u64) -> PrecompileResult {
+    Ok(PrecompileOutput::new(0, Bytes::copy_from_slice(input)))
+}
+
+const CUSTOM: Precompile = Precompile::new(
+    PrecompileId::Custom(Cow::Borrowed("test_after_plain")),
+    u64_to_address(CUSTOM_ADDRESS),
+    echo,
+);
+
+fn extra_set() -> &'static Precompiles {
+    static EXTRA: OnceLock<Precompiles> = OnceLock::new();
+    EXTRA.get_or_init(|| {
+        let mut precompiles = Precompiles::prague().clone();
+        precompiles.extend([CUSTOM]);
+        precompiles
+    })
+}
+
+/// Requesting extras must work regardless of what was built earlier in the process.
+///
+/// Before the fix the first call — here the plain one — initialized the shared cache, and
+/// every later `Some(extra)` silently got that cached set back with its own extras dropped.
+#[test]
+fn extras_are_honored_after_the_plain_set_was_built() {
+    let plain = mercury::<Ctx>().0;
+    assert!(
+        !plain.contains(&u64_to_address(CUSTOM_ADDRESS)),
+        "precondition: the plain set has no custom precompile"
+    );
+
+    let with_extra = mercury_with_extra::<Ctx>(Some(extra_set())).0;
+    assert!(
+        with_extra.contains(&u64_to_address(CUSTOM_ADDRESS)),
+        "extras must be honored even when the plain set was built first"
+    );
+
+    // Extending must not drop the stock precompiles.
+    assert!(
+        with_extra.contains(&u64_to_address(101)),
+        "the Seismic precompiles must survive the extension"
+    );
+}
+
+/// Repeated calls with the same `extra` must reuse one set instead of leaking a new one.
+#[test]
+fn repeated_calls_with_the_same_extra_are_memoized() {
+    let first = mercury_with_extra::<Ctx>(Some(extra_set())).0;
+    let second = mercury_with_extra::<Ctx>(Some(extra_set())).0;
+    assert!(
+        core::ptr::eq(first, second),
+        "the same extra set must map to the same cached precompile set"
+    );
+}

--- a/crates/seismic/tests/mercury_extra_isolation.rs
+++ b/crates/seismic/tests/mercury_extra_isolation.rs
@@ -1,0 +1,69 @@
+//! A caller's extra precompiles must not leak into everybody else's precompile set.
+//!
+//! Ordering matters here, and the cache under test is process-wide, so this scenario needs a
+//! test binary of its own: `mercury_with_extra(Some(..))` runs *before* any plain `mercury()`.
+
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+use revm::{
+    database::EmptyDB,
+    precompile::{
+        u64_to_address, Precompile, PrecompileId, PrecompileOutput, PrecompileResult, Precompiles,
+    },
+    primitives::Bytes,
+};
+use seismic_revm::{
+    precompiles::{mercury, mercury_with_extra},
+    SeismicContext,
+};
+use std::{borrow::Cow, sync::OnceLock};
+
+type Ctx = SeismicContext<EmptyDB>;
+
+const CUSTOM_ADDRESS: u64 = 0x5101;
+
+fn echo(input: &[u8], _gas_limit: u64) -> PrecompileResult {
+    Ok(PrecompileOutput::new(0, Bytes::copy_from_slice(input)))
+}
+
+const CUSTOM: Precompile = Precompile::new(
+    PrecompileId::Custom(Cow::Borrowed("test_isolation")),
+    u64_to_address(CUSTOM_ADDRESS),
+    echo,
+);
+
+fn extra_set() -> &'static Precompiles {
+    static EXTRA: OnceLock<Precompiles> = OnceLock::new();
+    EXTRA.get_or_init(|| {
+        let mut precompiles = Precompiles::prague().clone();
+        precompiles.extend([CUSTOM]);
+        precompiles
+    })
+}
+
+/// Building a set *with* extras must not change what plain `mercury()` returns afterwards.
+///
+/// Before the fix both calls shared one `OnceBox` whose initializer captured the `extra`
+/// argument. Whoever called first decided the contents for the entire process, so this
+/// ordering handed the custom precompile to every ordinary EVM — `set_spec` calls `mercury()`
+/// before every transaction.
+#[test]
+fn plain_mercury_does_not_inherit_another_callers_extras() {
+    let with_extra = mercury_with_extra::<Ctx>(Some(extra_set())).0;
+    assert!(
+        with_extra.contains(&u64_to_address(CUSTOM_ADDRESS)),
+        "precondition: extras are honored when requested"
+    );
+
+    let plain = mercury::<Ctx>().0;
+    assert!(
+        !plain.contains(&u64_to_address(CUSTOM_ADDRESS)),
+        "mercury() must not serve another caller's extra precompiles"
+    );
+
+    // The stock set is still intact.
+    assert!(
+        plain.contains(&u64_to_address(101)),
+        "mercury() must still contain the Seismic precompiles"
+    );
+}

--- a/crates/seismic/tests/precompile_extension.rs
+++ b/crates/seismic/tests/precompile_extension.rs
@@ -1,0 +1,117 @@
+//! Custom precompiles installed on a [`SeismicPrecompiles`] must stay installed.
+//!
+//! `anvil` injects precompiles this way (see `crates/anvil/src/evm.rs` in seismic-foundry),
+//! looping over a `PrecompileFactory`'s set and calling `apply_precompile` once per entry.
+
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+use revm::{
+    database::EmptyDB,
+    handler::PrecompileProvider,
+    precompile::{
+        u64_to_address, Precompile, PrecompileId, PrecompileOutput, PrecompileResult, Precompiles,
+    },
+    primitives::Bytes,
+};
+use seismic_revm::{precompiles::SeismicPrecompiles, SeismicContext, SeismicSpecId};
+use std::borrow::Cow;
+
+type Ctx = SeismicContext<EmptyDB>;
+
+const CUSTOM_A_ADDRESS: u64 = 0x5001;
+const CUSTOM_B_ADDRESS: u64 = 0x5002;
+const CUSTOM_C_ADDRESS: u64 = 0x5003;
+
+fn echo(input: &[u8], _gas_limit: u64) -> PrecompileResult {
+    Ok(PrecompileOutput::new(0, Bytes::copy_from_slice(input)))
+}
+
+const CUSTOM_A: Precompile = Precompile::new(
+    PrecompileId::Custom(Cow::Borrowed("test_custom_a")),
+    u64_to_address(CUSTOM_A_ADDRESS),
+    echo,
+);
+
+const CUSTOM_B: Precompile = Precompile::new(
+    PrecompileId::Custom(Cow::Borrowed("test_custom_b")),
+    u64_to_address(CUSTOM_B_ADDRESS),
+    echo,
+);
+
+const CUSTOM_C: Precompile = Precompile::new(
+    PrecompileId::Custom(Cow::Borrowed("test_custom_c")),
+    u64_to_address(CUSTOM_C_ADDRESS),
+    echo,
+);
+
+/// `apply_precompile` must install the precompile it is handed, every time.
+///
+/// Before the fix a process-wide `OnceLock` memoized the *first* merged set ever built, so
+/// the second call in this loop re-applied `CUSTOM_A` and dropped `CUSTOM_B` on the floor.
+#[test]
+fn apply_precompile_installs_every_precompile() {
+    let mut precompiles = SeismicPrecompiles::<Ctx>::new_with_spec(SeismicSpecId::MERCURY);
+
+    for precompile in [CUSTOM_A, CUSTOM_B] {
+        precompiles.apply_precompile(precompile);
+    }
+
+    assert!(
+        PrecompileProvider::<Ctx>::contains(&precompiles, &u64_to_address(CUSTOM_A_ADDRESS)),
+        "first injected precompile must be present"
+    );
+    assert!(
+        PrecompileProvider::<Ctx>::contains(&precompiles, &u64_to_address(CUSTOM_B_ADDRESS)),
+        "second injected precompile must be present, not silently replaced by the first"
+    );
+}
+
+/// The stock Seismic precompiles must survive an injection.
+#[test]
+fn apply_precompile_keeps_the_builtin_set() {
+    let mut precompiles = SeismicPrecompiles::<Ctx>::new_with_spec(SeismicSpecId::MERCURY);
+    precompiles.apply_precompile(CUSTOM_A);
+
+    // ECDH lives at 0x65 and is part of the Mercury set.
+    assert!(
+        PrecompileProvider::<Ctx>::contains(&precompiles, &u64_to_address(101)),
+        "injecting a precompile must not drop the Seismic precompiles"
+    );
+    assert!(
+        PrecompileProvider::<Ctx>::contains(&precompiles, &u64_to_address(1)),
+        "injecting a precompile must not drop the Ethereum precompiles"
+    );
+}
+
+/// `set_spec` runs before *every* transaction (`handler::pre_execution::load_accounts`).
+/// An unchanged spec must therefore not rebuild the set, or injected precompiles would be
+/// wiped by the first transaction the node executes.
+#[test]
+fn set_spec_preserves_injected_precompiles() {
+    let mut precompiles = SeismicPrecompiles::<Ctx>::new_with_spec(SeismicSpecId::MERCURY);
+    precompiles.apply_precompile(CUSTOM_C);
+    assert!(
+        PrecompileProvider::<Ctx>::contains(&precompiles, &u64_to_address(CUSTOM_C_ADDRESS)),
+        "precondition: the precompile is installed"
+    );
+
+    let changed = PrecompileProvider::<Ctx>::set_spec(&mut precompiles, SeismicSpecId::MERCURY);
+
+    assert!(!changed, "an unchanged spec must report no change");
+    assert!(
+        PrecompileProvider::<Ctx>::contains(&precompiles, &u64_to_address(CUSTOM_C_ADDRESS)),
+        "executing a transaction must not wipe injected precompiles"
+    );
+}
+
+/// Sanity check that the fixtures above are not accidentally part of the stock set.
+#[test]
+fn custom_addresses_are_not_builtin() {
+    let mercury = seismic_revm::precompiles::mercury::<Ctx>().0;
+    for address in [CUSTOM_A_ADDRESS, CUSTOM_B_ADDRESS, CUSTOM_C_ADDRESS] {
+        assert!(
+            Precompiles::get(mercury, &u64_to_address(address)).is_none(),
+            "test fixture address {address:#x} must not collide with a real precompile"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #230

## What was wrong

Custom precompiles installed on a `SeismicPrecompiles` were silently discarded by three defects. Together they make anvil's precompile injection a no-op — `inject_precompiles` in seismic-foundry loops over a `PrecompileFactory`'s set and calls `apply_precompile` once per entry.

| | Defect | Effect |
|---|---|---|
| 1 | `apply_precompile` memoized the merged set in a process-wide `OnceLock` whose initializer captured the `p` argument | The first precompile ever applied wins; every later call re-applies it instead of its own |
| 2 | `set_spec` rebuilt the provider unconditionally, and it runs before every transaction | The first transaction wipes whatever was installed |
| 3 | `mercury_with_extra` cached its result in a `OnceBox` whose initializer captured the `extra` argument | Whichever call runs first decides the contents process-wide — extras get dropped, or plain `mercury()` starts serving another caller's extras to every EVM |

Full analysis, including the odyssey-mode ordering that costs a user their entire factory, is in #230.

## The change

- **`apply_precompile`** — drop the static; build the merged set per call. Documented as a setup-time API since the merged set is leaked to satisfy the `&'static` bound `EthPrecompiles` requires.
- **`set_spec`** — track the spec on `SeismicPrecompiles` and early-return when unchanged, mirroring [`EthPrecompiles::set_spec`](https://github.com/SeismicSystems/seismic-revm/blob/seismic/crates/handler/src/precompile_provider.rs#L79). Besides preserving injected precompiles, this stops rebuilding the precompile set and re-warming the journal on every transaction.
- **`mercury_with_extra`** — keep the process-wide cache for the argument-less `None` path (the hot one, reached by `mercury()` before every transaction) and memoize the `Some(extra)` path per distinct `extra`. Memoizing rather than leaking per call keeps allocations bounded by the number of distinct extra sets.

The `None` path — every ordinary transaction — is byte-for-byte what it was: same `OnceBox`, same contents, one cached set per process. Only the argument-carrying paths change behavior.

`set_spec` now returns `false` for an unchanged spec. That is the same contract `EthPrecompiles` already has, and `load_accounts` still warms the journal on the first transaction via its `empty_warmed_precompiles` branch.

## Tests

Seven tests across three binaries. The ordering-dependent scenarios need separate binaries because the caches are process-wide and `cargo test` shares one process per test target.

- `tests/precompile_extension.rs` — a loop of two injections installs both; the builtin Ethereum and Seismic precompiles survive an injection; `set_spec` on an unchanged spec preserves injected precompiles and reports no change.
- `tests/mercury_extra_isolation.rs` — after `mercury_with_extra(Some(..))`, a plain `mercury()` must not inherit those extras.
- `tests/mercury_extra_after_plain.rs` — after a plain `mercury()`, extras must still be honored; repeated calls with the same extra reuse one set.

## Verification

Both runs are on a fork of this repo, using this repo's own `Seismic CI` workflow (rustfmt, build, warnings, `cargo test --workspace`, strict clippy on `seismic-revm`, semantic tests with `ssolc`).

**With this change — all 6 jobs green:** https://github.com/Dusk1e/seismic-revm/actions/runs/31433495732

**Same tests on unmodified `seismic`, without the fix** — to show they catch the bug rather than passing vacuously: https://github.com/Dusk1e/seismic-revm/actions/runs/31433973030

| Test | Without the fix |
| --- | --- |
| `apply_precompile_installs_every_precompile` | **FAILED** — defect 1 |
| `set_spec_preserves_injected_precompiles` | **FAILED** — defect 2 |
| `plain_mercury_does_not_inherit_another_callers_extras` | **FAILED** — defect 3, extras-first ordering |
| `extras_are_honored_after_the_plain_set_was_built` | **FAILED** — defect 3, plain-first ordering |
| `apply_precompile_keeps_the_builtin_set` | passes — regression guard, not expected to fail |
| `repeated_calls_with_the_same_extra_are_memoized` | passes — the old shared cache is trivially "memoized"; this guards the new one |
| `custom_addresses_are_not_builtin` | passes — fixture sanity check |

On that proof branch the workflow's test step is narrowed to these three targets with `--no-fail-fast`, so every target reports instead of `cargo test` stopping at the first failing one. That branch carries the tests only — `precompiles.rs` is untouched `seismic`.
