### PR TITLE
fix(seismic): prepend the chunk counter in RootRng::derive_bytes

### DIFF
--- a/crates/seismic/src/precompiles/rng/domain_sep_rng.rs
+++ b/crates/seismic/src/precompiles/rng/domain_sep_rng.rs
@@ -107,9 +107,16 @@ impl RootRng {
                 let chunk_len = remaining.min(MAX_HKDF_OUTPUT);
                 let mut chunk = vec![0u8; chunk_len];
 
-                let mut chunk_info = Vec::with_capacity(info.len() + 4 /* counter */);
-                chunk_info.extend_from_slice(&info);
+                // The counter is prepended, not appended. `pers` is caller-controlled
+                // and is the tail of `info`, so appending the counter would make a
+                // chunked derivation with personalization `P` produce the same HKDF
+                // info as a single-shot derivation with `P || counter` — i.e. the
+                // caller could obtain a chunked call's first 8160 bytes from a
+                // separate short call. Prepending keeps the two disjoint, because
+                // `info` always starts with the fixed-length domain data.
+                let mut chunk_info = Vec::with_capacity(4 /* counter */ + info.len());
                 chunk_info.extend_from_slice(&chunk_idx.to_le_bytes());
+                chunk_info.extend_from_slice(&info);
 
                 // SAFETY: chunk_len <= MAX_HKDF_OUTPUT
                 #[allow(clippy::expect_used)]

--- a/crates/seismic/src/precompiles/rng/test.rs
+++ b/crates/seismic/src/precompiles/rng/test.rs
@@ -134,3 +134,75 @@ fn test_large_output() {
         "large output should be deterministic"
     );
 }
+
+/// The HKDF-SHA256 single-expand limit; above this, `derive_bytes` chunks.
+const MAX_HKDF_OUTPUT: usize = 255 * 32;
+
+/// A chunked derivation must not be reproducible through a short derivation.
+///
+/// `pers` is caller-controlled and forms the tail of the HKDF `info`. If the
+/// chunk counter were appended, a chunked call with personalization `P` would
+/// share its info with a single-shot call using `P || counter`, handing the
+/// caller the chunked call's first 8160 bytes for a fraction of the gas.
+#[test]
+fn test_chunked_output_does_not_collide_with_short_call() {
+    let root_rng = RootRng::test_default();
+    let pers = b"collide";
+
+    let mut pers_with_counter = pers.to_vec();
+    pers_with_counter.extend_from_slice(&0u32.to_le_bytes());
+
+    let chunked = root_rng.derive_bytes(pers, MAX_HKDF_OUTPUT + 1);
+    let short = root_rng.derive_bytes(&pers_with_counter, 32);
+
+    assert_ne!(
+        &chunked[..32],
+        &short[..],
+        "a chunked derivation must not be reproducible by a short call whose \
+         pers carries the chunk counter"
+    );
+}
+
+/// Every chunk boundary must be domain-separated, not just the first.
+#[test]
+fn test_each_chunk_is_domain_separated() {
+    let root_rng = RootRng::test_default();
+    let pers = b"chunks";
+
+    let out = root_rng.derive_bytes(pers, MAX_HKDF_OUTPUT * 2 + 64);
+    assert_eq!(out.len(), MAX_HKDF_OUTPUT * 2 + 64);
+
+    let chunk0 = &out[..MAX_HKDF_OUTPUT];
+    let chunk1 = &out[MAX_HKDF_OUTPUT..MAX_HKDF_OUTPUT * 2];
+    assert_ne!(chunk0, chunk1, "consecutive chunks must differ");
+
+    for idx in 0..3u32 {
+        let mut spoof = pers.to_vec();
+        spoof.extend_from_slice(&idx.to_le_bytes());
+        let short = root_rng.derive_bytes(&spoof, 32);
+        assert_ne!(
+            &out[..32],
+            &short[..],
+            "chunk 0 must not be reproducible via pers || {idx}"
+        );
+    }
+}
+
+/// Requesting exactly the single-expand limit must not take the chunked path,
+/// and asking for one more byte must change the output rather than extend it.
+#[test]
+fn test_chunk_boundary_changes_derivation() {
+    let root_rng = RootRng::test_default();
+    let pers = b"boundary";
+
+    let at_limit = root_rng.derive_bytes(pers, MAX_HKDF_OUTPUT);
+    let over_limit = root_rng.derive_bytes(pers, MAX_HKDF_OUTPUT + 1);
+
+    assert_eq!(at_limit.len(), MAX_HKDF_OUTPUT);
+    assert_eq!(over_limit.len(), MAX_HKDF_OUTPUT + 1);
+    assert_ne!(
+        &at_limit[..32],
+        &over_limit[..32],
+        "crossing the chunk boundary must re-derive, not extend"
+    );
+}


### PR DESCRIPTION
Fixes #234

## What was wrong

`RootRng::derive_bytes` builds its HKDF `info` as `domain_data || b"pers" || pers`, then chunks outputs above the HKDF-SHA256 single-expand limit (255·32 = 8160 bytes) by **appending** a counter to that same string:

```rust
let mut chunk_info = Vec::with_capacity(info.len() + 4 /* counter */);
chunk_info.extend_from_slice(&info);
chunk_info.extend_from_slice(&chunk_idx.to_le_bytes());
```

`pers` is caller-controlled and is the tail of `info`, with the counter appended directly after it. The two constructions therefore produce identical strings:

```
chunked,     pers = P,     chunk i   ->  D || "pers" || P || i
single-shot, pers = P || i           ->  D || "pers" || P || i
```

Same HKDF info, same bytes. A caller could obtain the first 8160 bytes of a chunked derivation from a separate short call whose personalization carried the counter — defeating the separation this RNG exists to provide.

Nothing absorbs the ambiguity: `derive_rng_output` assembles `domain_data` as `b"block"‖32 ‖ b"acc"‖32 ‖ b"tx"‖32 ‖ b"gas"‖8` — a fixed 117 bytes — and there is no length prefix anywhere.

## The change

Prepend the counter rather than appending it:

```diff
-let mut chunk_info = Vec::with_capacity(info.len() + 4 /* counter */);
-chunk_info.extend_from_slice(&info);
-chunk_info.extend_from_slice(&chunk_idx.to_le_bytes());
+let mut chunk_info = Vec::with_capacity(4 /* counter */ + info.len());
+chunk_info.extend_from_slice(&chunk_idx.to_le_bytes());
+chunk_info.extend_from_slice(&info);
```

`info` always begins with the fixed-length domain data, so a chunk's info (counter first) is unreachable from a single-shot call (domain data first) no matter what the caller supplies as `pers`.

## Why this is safe to land

The single-expand path (`len <= 8160`) is untouched, so **every RNG output reachable today is bit-for-bit unchanged**. Only the chunked path derives differently, and nothing requests it: both official clients cap the request at 32 bytes —

- `seismic-viem`: `if (BigInt(numBytes) > 32n) throw new Error('Invalid length: must be less than or equal to 32')`
- `seismic-web3`: `raise ValueError(f"num_bytes must be 1-32, got {params.num_bytes}")`

So this closes the hole before anything depends on the current chunked derivation.

## Tests

Three tests added to `precompiles/rng/test.rs`. The existing `test_large_output` already covers the chunked path for length and determinism, but not for separation — which is how this slipped through.

| Test | Without the fix |
| --- | --- |
| `test_chunked_output_does_not_collide_with_short_call` | **FAILED** — `assertion left != right failed`, i.e. the two derivations were equal |
| `test_each_chunk_is_domain_separated` | **FAILED** — `chunk 0 must not be reproducible via pers \|\| 0` |
| `test_chunk_boundary_changes_derivation` | passes — guard that crossing the boundary re-derives rather than extends |

## Verification

Both runs use this repo's own `Seismic CI` workflow on a fork (rustfmt, build, warnings, `cargo test --workspace`, strict clippy on `seismic-revm`, semantic tests with `ssolc`).

- **With this change — all 6 jobs green:** https://github.com/Dusk1e/seismic-revm/actions/runs/31485811457
- **Same tests on unmodified `seismic` — the `test` job fails:** https://github.com/Dusk1e/seismic-revm/actions/runs/31485814741

The second run carries the tests only, so the failures above are against untouched `domain_sep_rng.rs`.
