### PR TITLE
test(database): restore slot2's distinct value in reverts_preserve_old_values

### DIFF
--- a/crates/database/src/states/state.rs
+++ b/crates/database/src/states/state.rs
@@ -455,7 +455,7 @@ mod tests {
         };
         let existing_account_initial_storage = HashMap::<U256, state::FlaggedStorage>::from_iter([
             (slot1, state::FlaggedStorage::from(U256::from(100))), // 0x01 => 100
-            (slot2, state::FlaggedStorage::from(U256::from(100))), // 0x02 => 200
+            (slot2, state::FlaggedStorage::from(U256::from(200))), // 0x02 => 200
         ]);
         let existing_account_changed_info = AccountInfo {
             nonce: 2,


### PR DESCRIPTION
## What's wrong

When `reverts_preserve_old_values` was carried into the fork alongside the `StorageValue` → `FlaggedStorage` change, `slot2`'s initial value was rewritten as `100` instead of `200`, while the `// 0x02 => 200` comment was left in place:

```rust
// upstream (main)
let existing_account_initial_storage = HashMap::<StorageKey, StorageValue>::from_iter([
    (slot1, StorageValue::from(100)), // 0x01 => 100
    (slot2, StorageValue::from(200)), // 0x02 => 200
]);

// seismic
let existing_account_initial_storage = HashMap::<U256, state::FlaggedStorage>::from_iter([
    (slot1, state::FlaggedStorage::from(U256::from(100))), // 0x01 => 100
    (slot2, state::FlaggedStorage::from(U256::from(100))), // 0x02 => 200   <-- 100
]);
```

Both slots now hold the same value. The test builds its transitions *and* its expected bundle by looking slots up in that one map, so once the two values are identical the assertions can no longer tell the slots apart — a revert that recorded the wrong slot's old value still satisfies every `assert_eq!`.

This is a test-only change; nothing in the revert logic itself is wrong (see below).

## The change

```diff
-(slot2, state::FlaggedStorage::from(U256::from(100))), // 0x02 => 200
+(slot2, state::FlaggedStorage::from(U256::from(200))), // 0x02 => 200
```

Restores the upstream value so the assertions are slot-specific again, and makes the code agree with the comment that was kept.

## Measuring that this actually matters

Rather than argue it, I mutated the test's *setup* so the revert record stores `slot1`'s old value for `slot2` — exactly the class of bug this test exists to catch — and ran it both ways:

| Branch | slot2 initial | Mutation | `test` job |
| --- | --- | --- | --- |
| this PR | **200** | none | [**success**](https://github.com/Dusk1e/seismic-revm/actions/runs/31487227491) — all 6 jobs green |
| `proof/setup-current` | 100 (today) | yes | [**success**](https://github.com/Dusk1e/seismic-revm/actions/runs/31487719527) — bug goes **undetected** |
| `proof/setup-fixed` | **200** | yes | [**failure**](https://github.com/Dusk1e/seismic-revm/actions/runs/31487724401) — `reverts_preserve_old_values ... FAILED` |

So the injected bug is invisible to the test as it stands today, and caught the moment `slot2`'s value is restored.

The first row is the other half of the result: with the distinct value back, the unmutated test still passes, which means the revert logic itself is correct — the current test simply wasn't able to demonstrate that.

## Verification

Run on a fork using this repo's own `Seismic CI` workflow (rustfmt, build, warnings, `cargo test --workspace`, strict clippy on `seismic-revm`, semantic tests with `ssolc`): all 6 jobs green, linked above.
