### PR TITLE
chore(deps): bump seismic-crypto to 7dc159d (well-known key rename)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,17 +552,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3412d52bb97c6c6cc27ccc28d4e6e8cf605469101193b50b0bd5813b1f990b5"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arrayvec",
  "derive_more",
  "nybbles",
  "serde",
  "smallvec",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -975,9 +975,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "async-stream"
@@ -1648,33 +1645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version 0.4.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,12 +2056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,16 +2251,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom_or_panic"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
-dependencies = [
- "rand 0.8.5",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,6 +2380,12 @@ checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hkdf"
@@ -2948,18 +2908,6 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
-
-[[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -4287,27 +4235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schnorrkel"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9fcb6c2e176e86ec703e22560d99d65a5ee9056ae45a08e13e84ebf796296f"
-dependencies = [
- "aead",
- "arrayref",
- "arrayvec",
- "cfg-if",
- "curve25519-dalek",
- "getrandom_or_panic",
- "merlin",
- "rand_core 0.6.4",
- "serde",
- "serde_bytes",
- "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4395,13 +4322,13 @@ dependencies = [
 [[package]]
 name = "seismic-crypto"
 version = "0.1.0"
-source = "git+https://github.com/SeismicSystems/enclave.git?rev=e3df924cd4ce95d54c52bb9b15a7c8f81327a20f#e3df924cd4ce95d54c52bb9b15a7c8f81327a20f"
+source = "git+https://github.com/SeismicSystems/enclave.git?rev=7dc159d50f7142466e0ac5c73e15d524d996b5b2#7dc159d50f7142466e0ac5c73e15d524d996b5b2"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "hex-literal",
  "hkdf",
  "rand 0.9.2",
- "schnorrkel",
  "secp256k1 0.30.0",
  "serde",
  "sha2",
@@ -4462,15 +4389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,5 +179,5 @@ inherits = "test"
 opt-level = 3
 
 [patch.crates-io]
-seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "e3df924cd4ce95d54c52bb9b15a7c8f81327a20f" }
+seismic-crypto = { git = "https://github.com/SeismicSystems/enclave.git", rev = "7dc159d50f7142466e0ac5c73e15d524d996b5b2" }
 alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "994f7b3fbc4582c2e06a00d03c7f3fe476b1b7c7" }

--- a/crates/seismic/src/chain/seismic_chain.rs
+++ b/crates/seismic/src/chain/seismic_chain.rs
@@ -143,11 +143,11 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
-    use seismic_crypto::get_unsecure_sample_schnorrkel_keypair;
+    use seismic_crypto::well_known_rng_ikm;
 
     #[test]
     fn test_execution_mode_same_inputs_same_output() {
-        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let ikm = well_known_rng_ikm();
         let chain = SeismicChain::new(ikm);
 
         let tx_hash = B256::from([1u8; 32]);
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn test_execution_mode_different_pers_different_output() {
-        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let ikm = well_known_rng_ikm();
         let chain = SeismicChain::new(ikm);
 
         let tx_hash = B256::from([1u8; 32]);
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_execution_mode_different_tx_hash_different_output() {
-        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let ikm = well_known_rng_ikm();
         let chain = SeismicChain::new(ikm);
 
         let pers = b"test_pers";
@@ -200,7 +200,7 @@ mod tests {
 
     #[test]
     fn test_execution_mode_deterministic_across_chains() {
-        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let ikm = well_known_rng_ikm();
         let chain1 = SeismicChain::new(ikm);
         let chain2 = SeismicChain::new(ikm);
 
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn test_different_parent_block_hash_different_output() {
-        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let ikm = well_known_rng_ikm();
         let mut chain1 = SeismicChain::new(ikm);
         let mut chain2 = SeismicChain::new(ikm);
 
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn test_different_tx_hash_accumulator_different_output() {
-        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let ikm = well_known_rng_ikm();
         let mut chain1 = SeismicChain::new(ikm);
         let mut chain2 = SeismicChain::new(ikm);
 
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn test_advance_tx_accumulator() {
-        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let ikm = well_known_rng_ikm();
         let mut chain = SeismicChain::new(ikm);
 
         assert_eq!(*chain.tx_hash_accumulator(), B256::ZERO);
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn test_accumulator_affects_rng_output() {
-        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let ikm = well_known_rng_ikm();
         let mut chain = SeismicChain::new(ikm);
         chain.set_parent_block_hash(B256::from([0xFF; 32]));
 

--- a/crates/seismic/src/evm.rs
+++ b/crates/seismic/src/evm.rs
@@ -390,11 +390,11 @@ mod tests {
 
     #[test]
     fn test_rng_precompile_expected_output() {
-        use seismic_crypto::get_unsecure_sample_schnorrkel_keypair;
+        use seismic_crypto::well_known_rng_ikm;
 
         let bytes_requested: u32 = 32;
         let personalization = vec![0xAA, 0xBB, 0xCC, 0xDD];
-        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let ikm = well_known_rng_ikm();
 
         // Get EVM output
         let ctx = rng_test_tx(

--- a/crates/seismic/src/precompiles.rs
+++ b/crates/seismic/src/precompiles.rs
@@ -260,11 +260,11 @@ mod tests {
 
     #[test]
     fn test_seismic_precompiles_rng() {
-        use seismic_crypto::get_unsecure_sample_schnorrkel_keypair;
+        use seismic_crypto::well_known_rng_ikm;
 
         let mut precompiles =
             SeismicPrecompiles::<SeismicContext<EmptyDB>>::new_with_spec(SeismicSpecId::MERCURY);
-        let ikm = get_unsecure_sample_schnorrkel_keypair().secret.to_bytes();
+        let ikm = well_known_rng_ikm();
         let mut context = SeismicContext::<EmptyDB>::seismic_with_rng_key(ikm);
         let rng_address = *precompiles
             .stateful_precompiles

--- a/crates/seismic/src/precompiles/rng/domain_sep_rng.rs
+++ b/crates/seismic/src/precompiles/rng/domain_sep_rng.rs
@@ -13,7 +13,6 @@
 //! then derives output. There is no persistent state between calls.
 use hkdf::Hkdf;
 use revm::primitives::B256;
-use seismic_crypto::get_unsecure_sample_schnorrkel_keypair;
 use sha2::Sha256;
 
 /// RNG domain separation salt.
@@ -37,13 +36,6 @@ impl RootRng {
             key_bytes: rng_ikm,
             domain_data: Vec::new(),
         }
-    }
-
-    /// A default RNG for testing that loads a sample key.
-    /// We do not implement the Default trait because
-    /// it might be misleading or error-prone.
-    pub fn test_default() -> Self {
-        Self::new(get_unsecure_sample_schnorrkel_keypair().secret.to_bytes())
     }
 
     /// Append the parent block hash to the domain separation data.

--- a/crates/seismic/src/precompiles/rng/test.rs
+++ b/crates/seismic/src/precompiles/rng/test.rs
@@ -9,6 +9,7 @@ use super::*;
 use domain_sep_rng::RootRng;
 use rand::RngCore;
 use revm::primitives::B256;
+use seismic_crypto::well_known_rng_ikm;
 use std::str::FromStr;
 
 fn hex_to_hash_bytes(input: &str) -> B256 {
@@ -18,7 +19,7 @@ fn hex_to_hash_bytes(input: &str) -> B256 {
 #[test]
 fn test_rng_basic() {
     // First derivation with empty pers
-    let root_rng = RootRng::test_default();
+    let root_rng = RootRng::new(well_known_rng_ikm());
     let bytes1 = root_rng.derive_bytes(&[], 32);
 
     // Same RNG, same pers — should produce the same output (stateless derivation)
@@ -29,7 +30,7 @@ fn test_rng_basic() {
     );
 
     // Create second root RNG using the same keypair — should produce the same output
-    let root_rng2 = RootRng::test_default();
+    let root_rng2 = RootRng::new(well_known_rng_ikm());
     let bytes2 = root_rng2.derive_bytes(&[], 32);
     assert_eq!(
         bytes1, bytes2,
@@ -44,7 +45,7 @@ fn test_rng_basic() {
     );
 
     // Appending a tx hash should change the output
-    let mut root_rng3 = RootRng::test_default();
+    let mut root_rng3 = RootRng::new(well_known_rng_ikm());
     root_rng3.append_tx(&hex_to_hash_bytes(
         "0000000000000000000000000000000000000000000000000000000000000001",
     ));
@@ -52,7 +53,7 @@ fn test_rng_basic() {
     assert_ne!(bytes1, bytes4, "tx hash should change output");
 
     // Different tx hash should produce different output
-    let mut root_rng4 = RootRng::test_default();
+    let mut root_rng4 = RootRng::new(well_known_rng_ikm());
     root_rng4.append_tx(&hex_to_hash_bytes(
         "0000000000000000000000000000000000000000000000000000000000000002",
     ));
@@ -63,7 +64,7 @@ fn test_rng_basic() {
     );
 
     // Same tx hash as root_rng3 should produce the same output
-    let mut root_rng5 = RootRng::test_default();
+    let mut root_rng5 = RootRng::new(well_known_rng_ikm());
     root_rng5.append_tx(&hex_to_hash_bytes(
         "0000000000000000000000000000000000000000000000000000000000000001",
     ));
@@ -71,7 +72,7 @@ fn test_rng_basic() {
     assert_eq!(bytes4, bytes6, "same tx hash should be deterministic");
 
     // Multiple tx hashes should produce different output than single
-    let mut root_rng6 = RootRng::test_default();
+    let mut root_rng6 = RootRng::new(well_known_rng_ikm());
     root_rng6.append_tx(&hex_to_hash_bytes(
         "0000000000000000000000000000000000000000000000000000000000000001",
     ));
@@ -84,12 +85,12 @@ fn test_rng_basic() {
 
 #[test]
 fn test_rng_gas_domain_separation() {
-    let mut root_rng1 = RootRng::test_default();
+    let mut root_rng1 = RootRng::new(well_known_rng_ikm());
     root_rng1.append_tx(&B256::from([1u8; 32]));
     root_rng1.append_gas_left(1000);
     let bytes1 = root_rng1.derive_bytes(&[], 32);
 
-    let mut root_rng2 = RootRng::test_default();
+    let mut root_rng2 = RootRng::new(well_known_rng_ikm());
     root_rng2.append_tx(&B256::from([1u8; 32]));
     root_rng2.append_gas_left(2000);
     let bytes2 = root_rng2.derive_bytes(&[], 32);
@@ -121,7 +122,7 @@ fn test_rng_different_keys_different_output() {
 
 #[test]
 fn test_large_output() {
-    let root_rng = RootRng::test_default();
+    let root_rng = RootRng::new(well_known_rng_ikm());
 
     // Request more than the HKDF single-expand limit (8160 bytes)
     let large_output = root_rng.derive_bytes(b"large", 10000);


### PR DESCRIPTION
Part of SEI-172

seismic-crypto renamed its well-known network key getters for what they are (SeismicSystems/enclave#262): these are the keys every network without a root key actually runs, not test fixtures. The RNG tests here take the rename: well_known_rng_ikm() returns the 64 ikm bytes directly, which every call site already narrowed the schnorrkel keypair down to. The bytes are identical, so the pinned RNG-precompile outputs (consensus-visible) are unchanged.

- schnorrkel is now a dev-dependency of seismic-crypto, so it and its curve25519-dalek subtree leave this crate's dependency graph.
- RootRng::test_default() is deleted. It was public API with no callers outside this crate's own tests, and hid which key the tests pin; the tests construct RootRng::new(well_known_rng_ikm()) directly.