### PR TITLE
feat(seismic): expose signed_read via the 0x6A tx-context precompile

### DIFF
--- a/crates/seismic/src/precompiles.rs
+++ b/crates/seismic/src/precompiles.rs
@@ -23,7 +23,7 @@ pub mod hkdf_derive_sym_key;
 pub mod rng;
 pub mod secp256k1_sign;
 pub mod stateful_precompile;
-pub mod tx_type;
+pub mod tx_context;
 pub use stateful_precompile::StatefulPrecompiles;
 
 use crate::{api::exec::SeismicContextTr, SeismicSpecId};
@@ -104,7 +104,7 @@ pub fn mercury_with_extra<CTX: SeismicContextTr>(
     //TODO: check how expensive is the below instead of a single init! issue with generics
     let mut stateful_precompiles = StatefulPrecompiles::new();
     stateful_precompiles.extend(rng::precompile::rng_precompile_iter::<CTX>().map(|p| (p.0, p.1)));
-    stateful_precompiles.extend([tx_type::tx_type_precompile::<CTX>().into()]);
+    stateful_precompiles.extend([tx_context::tx_context_precompile::<CTX>().into()]);
     (regular_precompiles, stateful_precompiles)
 }
 
@@ -362,8 +362,8 @@ mod tests {
     }
 
     #[test]
-    fn test_precompile_addresses_unique_and_txinfo_registered() {
-        use crate::precompiles::tx_type::TX_TYPE_ADDRESS;
+    fn test_precompile_addresses_unique_and_tx_context_registered() {
+        use crate::precompiles::tx_context::TX_CONTEXT_ADDRESS;
         use revm::precompile::u64_to_address;
         use std::collections::HashSet;
 
@@ -372,7 +372,7 @@ mod tests {
 
         // tx-info (0x6A) is registered as a stateful precompile.
         assert!(
-            stateful.contains(&u64_to_address(TX_TYPE_ADDRESS)),
+            stateful.contains(&u64_to_address(TX_CONTEXT_ADDRESS)),
             "0x6A tx-type precompile must be registered"
         );
 

--- a/crates/seismic/src/precompiles/tx_context.rs
+++ b/crates/seismic/src/precompiles/tx_context.rs
@@ -20,6 +20,8 @@ pub const TX_CONTEXT_ADDRESS: u64 = 106; // Hex address `0x6A`.
 // Selector for the signed-read flag. An empty input keeps returning the tx type (backward compat).
 pub const SIGNED_READ_SELECTOR: u8 = 0x01;
 
+pub const SEISMIC_TX_TYPE: u8 = 74;
+
 // Flat cost for a single transaction-context read. NOTE: this is a consensus parameter — changing
 // it after activation is itself a hardfork.
 pub const TX_CONTEXT_GAS_COST: u64 = 20;
@@ -40,7 +42,9 @@ fn tx_context<CTX: SeismicContextTr>(
     // stays extensible (and so nodes without a given selector fail closed rather than return 0).
     let value: u64 = match input.as_ref() {
         [] => evmctx.tx().tx_type() as u64,
-        [SIGNED_READ_SELECTOR] => evmctx.tx().signed_read() as u64,
+        [SIGNED_READ_SELECTOR] => {
+            (evmctx.tx().signed_read() && evmctx.tx().tx_type() == SEISMIC_TX_TYPE) as u64
+        }
         _ => {
             return Err(PrecompileError::Other(
                 "tx-context precompile: unknown selector".to_string(),
@@ -117,6 +121,26 @@ mod tests {
             assert!(
                 out.bytes[..31].iter().all(|b| *b == 0),
                 "upper bytes must be zero"
+            );
+        }
+    }
+
+    #[test]
+    fn signed_read_requires_seismic_type() {
+        for ty in [0u8, 1, 2, 255] {
+            let mut ctx = Context::seismic_with_random_rng_key().modify_tx_chained(|tx| {
+                tx.base.tx_type = ty;
+                tx.signed_read = true;
+            });
+            let out = tx_context_precompile::<SeismicContext<EmptyDB>>().1(
+                &mut ctx,
+                &Bytes::from_static(&[SIGNED_READ_SELECTOR]),
+                1000,
+            )
+            .unwrap();
+            assert_eq!(
+                out.bytes[31], 0,
+                "signed_read must be 0 for non-Seismic type {ty}"
             );
         }
     }

--- a/crates/seismic/src/precompiles/tx_context.rs
+++ b/crates/seismic/src/precompiles/tx_context.rs
@@ -15,25 +15,25 @@ use crate::{
 //   (empty)  -> EIP-2718 tx type (74 = Seismic)
 //   [0x01]   -> signed_read flag (1 = authenticated signed read, 0 otherwise)
 // Any other input is rejected, keeping the selector space open for future fields.
-pub const TX_TYPE_ADDRESS: u64 = 106; // Hex address `0x6A`.
+pub const TX_CONTEXT_ADDRESS: u64 = 106; // Hex address `0x6A`.
 
 // Selector for the signed-read flag. An empty input keeps returning the tx type (backward compat).
 pub const SIGNED_READ_SELECTOR: u8 = 0x01;
 
 // Flat cost for a single transaction-context read. NOTE: this is a consensus parameter — changing
 // it after activation is itself a hardfork.
-pub const TX_TYPE_GAS_COST: u64 = 20;
+pub const TX_CONTEXT_GAS_COST: u64 = 20;
 
-pub fn tx_type_precompile<CTX: SeismicContextTr>() -> StatefulPrecompileWithAddress<CTX> {
-    StatefulPrecompileWithAddress(u64_to_address(TX_TYPE_ADDRESS), tx_type::<CTX>)
+pub fn tx_context_precompile<CTX: SeismicContextTr>() -> StatefulPrecompileWithAddress<CTX> {
+    StatefulPrecompileWithAddress(u64_to_address(TX_CONTEXT_ADDRESS), tx_context::<CTX>)
 }
 
-fn tx_type<CTX: SeismicContextTr>(
+fn tx_context<CTX: SeismicContextTr>(
     evmctx: &mut CTX,
     input: &Bytes,
     gas_limit: u64,
 ) -> PrecompileResult {
-    if gas_limit < TX_TYPE_GAS_COST {
+    if gas_limit < TX_CONTEXT_GAS_COST {
         return Err(PrecompileError::OutOfGas);
     }
     // The input selects which context field to read; unknown selectors are rejected so the ABI
@@ -43,14 +43,14 @@ fn tx_type<CTX: SeismicContextTr>(
         [SIGNED_READ_SELECTOR] => evmctx.tx().signed_read() as u64,
         _ => {
             return Err(PrecompileError::Other(
-                "tx-type precompile: unknown selector".to_string(),
+                "tx-context precompile: unknown selector".to_string(),
             ))
         }
     };
 
     let output = U256::from(value).to_be_bytes::<32>();
     Ok(PrecompileOutput::new(
-        TX_TYPE_GAS_COST,
+        TX_CONTEXT_GAS_COST,
         Bytes::copy_from_slice(&output),
     ))
 }
@@ -86,9 +86,9 @@ mod tests {
         for ty in [0u8, 1, 2, 74, 255] {
             let mut ctx = ctx_with_tx_type(ty);
             let out =
-                tx_type_precompile::<SeismicContext<EmptyDB>>().1(&mut ctx, &Bytes::new(), 1000)
+                tx_context_precompile::<SeismicContext<EmptyDB>>().1(&mut ctx, &Bytes::new(), 1000)
                     .unwrap();
-            assert_eq!(out.gas_used, TX_TYPE_GAS_COST);
+            assert_eq!(out.gas_used, TX_CONTEXT_GAS_COST);
             assert_eq!(out.bytes.len(), 32, "must be a 32-byte abi uint256");
             assert_eq!(out.bytes[31], ty, "low byte is the tx type ({ty})");
             assert!(
@@ -102,13 +102,13 @@ mod tests {
     fn signed_read_selector_returns_flag() {
         for sr in [false, true] {
             let mut ctx = ctx_with_signed_read(sr);
-            let out = tx_type_precompile::<SeismicContext<EmptyDB>>().1(
+            let out = tx_context_precompile::<SeismicContext<EmptyDB>>().1(
                 &mut ctx,
                 &Bytes::from_static(&[SIGNED_READ_SELECTOR]),
                 1000,
             )
             .unwrap();
-            assert_eq!(out.gas_used, TX_TYPE_GAS_COST);
+            assert_eq!(out.gas_used, TX_CONTEXT_GAS_COST);
             assert_eq!(out.bytes.len(), 32, "must be a 32-byte abi uint256");
             assert_eq!(
                 out.bytes[31], sr as u8,
@@ -126,7 +126,7 @@ mod tests {
         let mut ctx = ctx_with_tx_type(74);
         // An unknown 1-byte selector and any multi-byte input are both rejected (fail-closed).
         for bad in [vec![0x00u8], vec![0x02], b"arbitrary input".to_vec()] {
-            let res = tx_type_precompile::<SeismicContext<EmptyDB>>().1(
+            let res = tx_context_precompile::<SeismicContext<EmptyDB>>().1(
                 &mut ctx,
                 &Bytes::from(bad),
                 1000,
@@ -142,16 +142,16 @@ mod tests {
     fn tx_type_charges_exactly_base_cost() {
         let mut ctx = ctx_with_tx_type(74);
         // Exact threshold succeeds; one below is OutOfGas.
-        assert!(tx_type_precompile::<SeismicContext<EmptyDB>>().1(
+        assert!(tx_context_precompile::<SeismicContext<EmptyDB>>().1(
             &mut ctx,
             &Bytes::new(),
-            TX_TYPE_GAS_COST
+            TX_CONTEXT_GAS_COST
         )
         .is_ok());
-        let res = tx_type_precompile::<SeismicContext<EmptyDB>>().1(
+        let res = tx_context_precompile::<SeismicContext<EmptyDB>>().1(
             &mut ctx,
             &Bytes::new(),
-            TX_TYPE_GAS_COST - 1,
+            TX_CONTEXT_GAS_COST - 1,
         );
         assert!(matches!(res, Err(PrecompileError::OutOfGas)));
     }

--- a/crates/seismic/src/precompiles/tx_type.rs
+++ b/crates/seismic/src/precompiles/tx_type.rs
@@ -6,12 +6,19 @@ use revm::{
 
 use crate::{
     api::exec::SeismicContextTr, precompiles::stateful_precompile::StatefulPrecompileWithAddress,
+    transaction::abstraction::SeismicTxTr,
 };
 
-// Returns the current transaction's EIP-2718 type byte (74 = Seismic) so a contract can detect a
-// Seismic execution context without a dedicated opcode. Takes no input (non-empty calldata is
-// rejected); output is the type as a 32-byte big-endian word (abi `uint256`).
+// Exposes read-only transaction-context flags so a contract can detect a Seismic execution context
+// without a dedicated opcode. The 1-byte input selects the field; output is a 32-byte big-endian
+// word (abi `uint256`):
+//   (empty)  -> EIP-2718 tx type (74 = Seismic)
+//   [0x01]   -> signed_read flag (1 = authenticated signed read, 0 otherwise)
+// Any other input is rejected, keeping the selector space open for future fields.
 pub const TX_TYPE_ADDRESS: u64 = 106; // Hex address `0x6A`.
+
+// Selector for the signed-read flag. An empty input keeps returning the tx type (backward compat).
+pub const SIGNED_READ_SELECTOR: u8 = 0x01;
 
 // Flat cost for a single transaction-context read. NOTE: this is a consensus parameter — changing
 // it after activation is itself a hardfork.
@@ -29,14 +36,19 @@ fn tx_type<CTX: SeismicContextTr>(
     if gas_limit < TX_TYPE_GAS_COST {
         return Err(PrecompileError::OutOfGas);
     }
-    // Takes no input. Reject non-empty calldata so a future versioned/selector ABI stays open.
-    if !input.is_empty() {
-        return Err(PrecompileError::Other(
-            "tx-type precompile takes no input".to_string(),
-        ));
-    }
+    // The input selects which context field to read; unknown selectors are rejected so the ABI
+    // stays extensible (and so nodes without a given selector fail closed rather than return 0).
+    let value: u64 = match input.as_ref() {
+        [] => evmctx.tx().tx_type() as u64,
+        [SIGNED_READ_SELECTOR] => evmctx.tx().signed_read() as u64,
+        _ => {
+            return Err(PrecompileError::Other(
+                "tx-type precompile: unknown selector".to_string(),
+            ))
+        }
+    };
 
-    let output = U256::from(evmctx.tx().tx_type()).to_be_bytes::<32>();
+    let output = U256::from(value).to_be_bytes::<32>();
     Ok(PrecompileOutput::new(
         TX_TYPE_GAS_COST,
         Bytes::copy_from_slice(&output),
@@ -62,6 +74,13 @@ mod tests {
         })
     }
 
+    fn ctx_with_signed_read(signed_read: bool) -> SeismicContext<EmptyDB> {
+        Context::seismic_with_random_rng_key().modify_tx_chained(|tx| {
+            tx.base.tx_type = 74; // a signed read is always Seismic-typed
+            tx.signed_read = signed_read;
+        })
+    }
+
     #[test]
     fn tx_type_returns_type_as_uint256() {
         for ty in [0u8, 1, 2, 74, 255] {
@@ -80,17 +99,43 @@ mod tests {
     }
 
     #[test]
-    fn tx_type_rejects_nonempty_input() {
+    fn signed_read_selector_returns_flag() {
+        for sr in [false, true] {
+            let mut ctx = ctx_with_signed_read(sr);
+            let out = tx_type_precompile::<SeismicContext<EmptyDB>>().1(
+                &mut ctx,
+                &Bytes::from_static(&[SIGNED_READ_SELECTOR]),
+                1000,
+            )
+            .unwrap();
+            assert_eq!(out.gas_used, TX_TYPE_GAS_COST);
+            assert_eq!(out.bytes.len(), 32, "must be a 32-byte abi uint256");
+            assert_eq!(
+                out.bytes[31], sr as u8,
+                "low byte is the signed_read flag ({sr})"
+            );
+            assert!(
+                out.bytes[..31].iter().all(|b| *b == 0),
+                "upper bytes must be zero"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_selector_rejected() {
         let mut ctx = ctx_with_tx_type(74);
-        let res = tx_type_precompile::<SeismicContext<EmptyDB>>().1(
-            &mut ctx,
-            &Bytes::from_static(b"arbitrary input"),
-            1000,
-        );
-        assert!(
-            matches!(res, Err(PrecompileError::Other(_))),
-            "non-empty input must be rejected"
-        );
+        // An unknown 1-byte selector and any multi-byte input are both rejected (fail-closed).
+        for bad in [vec![0x00u8], vec![0x02], b"arbitrary input".to_vec()] {
+            let res = tx_type_precompile::<SeismicContext<EmptyDB>>().1(
+                &mut ctx,
+                &Bytes::from(bad),
+                1000,
+            );
+            assert!(
+                matches!(res, Err(PrecompileError::Other(_))),
+                "unknown selector must be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/seismic/src/transaction/abstraction.rs
+++ b/crates/seismic/src/transaction/abstraction.rs
@@ -13,6 +13,11 @@ pub trait SeismicTxTr: Transaction {
 
     /// Whether this transaction failed calldata decryption.
     fn decryption_failed(&self) -> bool;
+
+    /// Whether this transaction executes as an authenticated signed read (an RPC read) rather than
+    /// a mined state-changing transaction. Both are `tx_type == 74`; this is the finer distinction,
+    /// set by the node at tx-env construction.
+    fn signed_read(&self) -> bool;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -23,6 +28,9 @@ pub struct SeismicTransaction<T: Transaction> {
     pub tx_hash: B256,
     /// Whether this transaction failed decryption. Used for handling execution and metering.
     pub decryption_failed: bool,
+    /// Whether this tx executes as an authenticated signed read (RPC read) vs a mined write. Set by
+    /// the node at tx-env construction; both a signed read and a mined Seismic write are tx_type 74.
+    pub signed_read: bool,
 }
 
 impl<T: Transaction> SeismicTransaction<T> {
@@ -31,6 +39,7 @@ impl<T: Transaction> SeismicTransaction<T> {
             base,
             tx_hash: B256::ZERO,
             decryption_failed: false,
+            signed_read: false,
         }
     }
 
@@ -41,6 +50,11 @@ impl<T: Transaction> SeismicTransaction<T> {
 
     pub fn with_decryption_failed(mut self, failed: bool) -> Self {
         self.decryption_failed = failed;
+        self
+    }
+
+    pub fn with_signed_read(mut self, signed_read: bool) -> Self {
+        self.signed_read = signed_read;
         self
     }
 }
@@ -70,6 +84,7 @@ impl Default for SeismicTransaction<TxEnv> {
             base: TxEnv::default(),
             tx_hash: B256::ZERO,
             decryption_failed: false,
+            signed_read: false,
         }
     }
 }
@@ -160,6 +175,10 @@ impl<T: Transaction> SeismicTxTr for SeismicTransaction<T> {
 
     fn decryption_failed(&self) -> bool {
         self.decryption_failed
+    }
+
+    fn signed_read(&self) -> bool {
+        self.signed_read
     }
 }
 


### PR DESCRIPTION
Part of SEI-98 (signed-read detection), stacked on the SEI-67 tx-type precompile (`hbai__txtype-precompile`).

Lets a contract tell an authenticated signed read from a mined Seismic write (both are tx type 74):

- `signed_read: bool` on `SeismicTransaction` + `SeismicTxTr::signed_read()` accessor (mirrors `decryption_failed`).
- Extends the `0x6A` precompile with a 1-byte input selector: empty -> tx type (unchanged), `0x01` -> signed_read flag, any other input rejected. Renamed `tx_type` -> `tx_context`.
- Selector returns `signed_read && tx_type == 74`, so `isSignedRead()` implies `isSeismicTx()`.

Tests 127/127, clippy-strict clean. Closes SEI-115.